### PR TITLE
[INLONG-615] Fail to compile INLONG locally - Unknown host download.oracle.com

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <repository>
             <id>berkeleydb-je</id>
             <name>berkeleydb-je</name>
-            <url>https://download.oracle.com/maven/</url>
+            <url>https://maven.oracle.com/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
 Since Oracle modified the maven  address of BDB, adjust "https://download.oracle.com/maven/" to "https://maven.oracle.com/"

Thanks @tisonkun 