### PR TITLE
Revert "[INLONG-744] Error log, should use log4j"

### DIFF
--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/MasterStartup.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/MasterStartup.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,7 @@ public class MasterStartup {
         // get configure file path
         ProcessResult result = new ProcessResult();
         if (!CliUtils.getConfigFilePath(args, result)) {
-            logger.error("Master startup failed! {}",result.errInfo);
+            logger.error("Master startup failed! {}", result.errInfo);
             System.exit(1);
         }
         String configFilePath = (String) result.retData1;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/MasterStartup.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/MasterStartup.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,7 @@ public class MasterStartup {
         // get configure file path
         ProcessResult result = new ProcessResult();
         if (!CliUtils.getConfigFilePath(args, result)) {
-            logger.error("Master startup failed! {}", result.errInfo);
+            System.err.println(result.errInfo);
             System.exit(1);
         }
         String configFilePath = (String) result.retData1;


### PR DESCRIPTION
Reverts apache/incubator-inlong#551

Sorry, I must revert this PR

The modification of this PR is a modification of the CLI command, we have defined a principle in the CLI command: we only record the information after the program is started in the log file. If the program fails to start due to a wrong startup parameter, we output it through System.err.println(), and you can also see this CLI directory, all other classes follow this definition.