### PR TITLE
[INLONG-787] ci: update checkstyle workflow

### DIFF
--- a/.github/workflows/ci_checkstyle.yml
+++ b/.github/workflows/ci_checkstyle.yml
@@ -32,18 +32,18 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1
-        with:
-          reviewdog_version: latest
+        env:
+          REVIEWDOG_VERSION: latest
+        run: curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /opt ${REVIEWDOG_VERSION}
 
-      - name: Download checkstyle.jar
+      - name: Download checkstyle
         env:
           CHECKSTYLE_VERSION: 8.37
-        run: curl -o checkstyle.jar -L https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/checkstyle-${CHECKSTYLE_VERSION}-all.jar
+        run: curl -o /opt/checkstyle.jar -L https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/checkstyle-${CHECKSTYLE_VERSION}-all.jar
 
       - name: Check code style
         env:
           WORKDIR: ./
           CHECKSTYLE_CONFIG: codestyle/checkstyle.xml
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: java -jar checkstyle.jar "${WORKDIR}" -c "${CHECKSTYLE_CONFIG}" -f xml | reviewdog -name="Checkstyle" -f=checkstyle -reporter=github-check -filter-mode=added
+        run: java -jar /opt/checkstyle.jar "${WORKDIR}" -c "${CHECKSTYLE_CONFIG}" -f xml | /opt/reviewdog -name="Checkstyle" -f=checkstyle -reporter=github-check -filter-mode=added


### PR DESCRIPTION
Fixes Jira Issue ID:

https://issues.apache.org/jira/browse/INLONG-787

### Motivation

The checkstyle workflow starts up failed because [reviewdog/action-setup](https://github.com/reviewdog/action-setup) is not allowed to be used.

This PR sets up reviewdog through [install.sh](https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh) rather than actions.

### Modifications

- update checkstyle workflow
