### PR TITLE
[INLONG-1401] ci: add labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+inlong-agent:
+  - inlong-agent/**/*
+
+inlong-dataproxy:
+  - inlong-dataproxy-sdk/**/*
+  - inlong-dataproxy/**/*
+
+inlong-manager:
+  - inlong-manager/**/*
+
+inlong-sort:
+  - inlong-sort/**/*
+
+inlong-tubemq:
+  - inlong-tubemq/**/*
+
+inlong-website:
+  - inlong-website/**/*

--- a/.github/workflows/ci_labeler.yml
+++ b/.github/workflows/ci_labeler.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: InLong Pull Request Labeler
+
+on: pull_request_target
+
+jobs:
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
### [INLONG-1401][CI] Add labeler workflow

Fixes #1401

### Motivation

Using [labeler](https://github.com/actions/labeler) to automatically label new pull requests based on the paths of files being changed. The label of PR can make people clearly know what it does.

### Modifications

- Add labeler workflow
