### PR TITLE
[INLONG-1405][Platform] modify the notifications for issue status, to avoid too many issue mails

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,5 +48,5 @@ notifications:
   issues:       commits@inlong.apache.org
   pullrequests_status: commits@inlong.apache.org
   pullrequests_comment: commits@inlong.apache.org
-  issues_status: dev@inlong.apache.org
+  issues_status: commits@inlong.apache.org
   issues_comment: commits@inlong.apache.org


### PR DESCRIPTION
### Title Name: [INLONG-XYZ][component] Title of the pull request

where *XYZ* should be replaced by the actual issue number.

Fixes #1405 

### Motivation

modify the notifications for issue status, to avoid too many issue mails. we will use a special issue account in the future.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
