### PR TITLE
[INLONG-1415][TubeMQ] Docker image expose zookeeper port for other component usages

### DIFF
--- a/inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile
+++ b/inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile
@@ -34,4 +34,6 @@ WORKDIR /opt/tubemq-server/
 EXPOSE 8715 8080 9001
 # broker port
 EXPOSE 8123 8081
+# zookkeeper port
+EXPOSE 2181
 CMD ["/opt/tubemq-server/bin/tubemq-docker.sh"]

--- a/inlong-tubemq/tubemq-docker/tubemq-all/README.md
+++ b/inlong-tubemq/tubemq-docker/tubemq-all/README.md
@@ -8,7 +8,7 @@ docker pull inlong/tubemq-all:latest
 
 ##### Start Standalone Container
 ```
-docker run -p 8080:8080 -p 8715:8715 -p 8123:8123 --name tubemq -d inlong/tubemq-all:latest
+docker run -p 8080:8080 -p 8715:8715 -p 8123:8123 2181:2181 --name tubemq -d inlong/tubemq-all:latest
 ```
 this command will start zookeeper/master/broker service in one container.
 #### Add Topic


### PR DESCRIPTION
### Title Name: [INLONG-XYZ][component] Title of the pull request

where *XYZ* should be replaced by the actual issue number.

Fixes #1415

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
