### PR TITLE
[INLONG-1432][InLong-Dataproxy][InLong-Agent] The manager url of agent and dataproxy need to be updated since manager merged openapi and api into one module

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/constants/FetcherConstants.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/constants/FetcherConstants.java
@@ -34,7 +34,7 @@ public class FetcherConstants {
     public static final String DEFAULT_AGENT_TDM_VIP_HTTP_PATH = "/getilmvirtualip";
 
     public static final String AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "agent.manager.vip.http.prefix.path";
-    public static final String DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "/openapi/inlong/manager/agent";
+    public static final String DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "/api/inlong/manager/openapi/agent";
 
     public static final String AGENT_MANAGER_TASK_HTTP_PATH = "agent.manager.vip.http.task.path";
     public static final String DEFAULT_AGENT_MANAGER_TASK_HTTP_PATH = "/file_agent/taskconf";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
@@ -253,7 +253,7 @@ public class ConfigManager {
         private boolean checkWithManager(String host) {
             HttpGet httpGet = null;
             try {
-                String url = "http://" + host + "/openapi/inlong/manager/dataproxy/getConfig";
+                String url = "http://" + host + "/api/inlong/manager/openapi/dataproxy/getConfig";
                 LOG.info("start to request {} to get config info", url);
                 httpGet = new HttpGet(url);
                 httpGet.addHeader(HttpHeaders.CONNECTION, "close");


### PR DESCRIPTION
fixs #1432
The manager url of agent and dataproxy need to be updated since manager merged openapi and api into one module