### PR TITLE
 [INLONG-1448][docker-compose] fix bug in docker-compose.yml

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - JDBC_URL=mysql:3306
       - USERNAME=root
       - PASSWORD=inlong
-      - TUBE_MANAGER=tubemq-manager:8089
+      - TUBE_MANAGER=http:\/\/tubemq-manager:8089
       - TUBE_MASTER=tubemq-server:8715
       - ZK_URL=tubemq-server:2181
       - SORT_APP_NAME=inlong_hive


### PR DESCRIPTION
### Title Name: [INLONG-1448][docker-compose] fix bug in docker-compose.yml

Fixes #1448 

### Modifications

change tube-manager address in `docker-compose.yml`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)
