### PR TITLE
[INLONG-1468][dataproxy] The update interval of dataproxy is quite long and may cause produce error when config is not updated

### DIFF
--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -20,3 +20,5 @@
 cluster_id=1
 # manager open api address
 manager_hosts=ip:port
+# check interval of local config (millisecond)
+configCheckInterval=10000

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
@@ -311,8 +311,8 @@ public class ConfigManager {
                 count += 1;
                 try {
                     checkLocalFile();
-                    if (count % 30 == 0) {
-
+                    // wait for 30 seconds to update remote config
+                    if (count % 3 == 0) {
                         checkRemoteConfig();
                         count = 0;
                     }


### PR DESCRIPTION
### Title Name: [INLONG-1468][dataproxy] The update interval of dataproxy is quite long and may cause produce error when config is not updated

Fixes #1468

### Motivation

The update interval of dataproxy is quite long and may cause produce error when config is not updated

### Modifications

The update process of dataproxy should be quicker and configurable

### Verifying this change

### Documentation
  - Does this pull request introduce a new feature? (no)

