### PR TITLE
[INLONG-1470]Java.util.ConcurrentModificationException error when rebalance

### DIFF
--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/balance/DefaultLoadBalancer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/balance/DefaultLoadBalancer.java
@@ -198,7 +198,7 @@ public class DefaultLoadBalancer implements LoadBalancer {
                 }
             }
             //　random allocate
-            if (partMap.size() > 0) {
+            if (!partMap.isEmpty()) {
                 onlineOfflineGroupSet.add(group);
                 if (!newConsumerList2.isEmpty()) {
                     this.randomAssign(partMap, newConsumerList2,
@@ -206,11 +206,15 @@ public class DefaultLoadBalancer implements LoadBalancer {
                 }
             }
         }
-        List<String> groupsNeedToBalance = null;
-        if (onlineOfflineGroupSet.size() == 0) {
-            groupsNeedToBalance = groupSet;
+        List<String> groupsNeedToBalance = new ArrayList<>();
+        if (onlineOfflineGroupSet.isEmpty()) {
+            for (String group : groupSet) {
+                if (group == null) {
+                    continue;
+                }
+                groupsNeedToBalance.add(group);
+            }
         } else {
-            groupsNeedToBalance = new ArrayList<>();
             for (String group : groupSet) {
                 if (group == null) {
                     continue;
@@ -220,12 +224,12 @@ public class DefaultLoadBalancer implements LoadBalancer {
                 }
             }
         }
-        if (bandGroupSet.size() > 0) {
+        if (!bandGroupSet.isEmpty()) {
             for (String group : bandGroupSet) {
                 groupsNeedToBalance.remove(group);
             }
         }
-        if (groupsNeedToBalance.size() > 0) {
+        if (!groupsNeedToBalance.isEmpty()) {
             finalSubInfoMap =
                     balance(finalSubInfoMap, consumerHolder, brokerRunManager,
                             groupsNeedToBalance, clusterState, rejGroupClientINfoMap);
@@ -348,9 +352,9 @@ public class DefaultLoadBalancer implements LoadBalancer {
                 }
             }
             // load balance partition between consumer
-            if (partitionToMove.size() > 0) {
+            if (!partitionToMove.isEmpty()) {
                 for (String consumerId : serverToTake.keySet()) {
-                    if (partitionToMove.size() <= 0) {
+                    if (partitionToMove.isEmpty()) {
                         break;
                     }
                     assign(partitionToMove.poll(), clusterState, consumerId);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/ConsumerInfoHolder.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/ConsumerInfoHolder.java
@@ -427,11 +427,13 @@ public class ConsumerInfoHolder {
             rwLock.readLock().lock();
             ConsumerInfo consumerInfo = null;
             String groupName = consumerIndexMap.get(consumerId);
-            ConsumerBandInfo consumeBandInfo = groupInfoMap.get(groupName);
-            if (consumeBandInfo != null) {
-                consumerInfo = consumeBandInfo.getConsumerInfo(consumerId);
+            if (groupName != null) {
+                ConsumerBandInfo consumeBandInfo = groupInfoMap.get(groupName);
+                if (consumeBandInfo != null) {
+                    consumerInfo = consumeBandInfo.getConsumerInfo(consumerId);
+                }
             }
-            return new Tuple2<String, ConsumerInfo>(groupName, consumerInfo);
+            return new Tuple2<>(groupName, consumerInfo);
         } finally {
             rwLock.readLock().unlock();
         }


### PR DESCRIPTION
Fixes #1470 

Optimization items:
1. Modify the usage mode of the subGroups object to be read-only processing;
2. Adjust the log printing to output the set of consumer groups affected by each abnormality;
3. Modify the consumption information acquisition of the consumer group, and add the check that the result is null;
4. When optimizing the processing of consumer events, the list is changed from judging the size to judging whether it is empty
