### PR TITLE
[INLONG-1475][inlong-tubemq] Tube manager compile ch.qos.logback with error

### DIFF
--- a/inlong-tubemq/tubemq-manager/pom.xml
+++ b/inlong-tubemq/tubemq-manager/pom.xml
@@ -112,6 +112,22 @@
         </dependency>
 
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-access</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.15</version>


### PR DESCRIPTION
### Title Name: [INLONG-1475][inlong-tubemq] Tube manager compile ch.qos.logback with error

Fixes #1475

### Motivation

Tube manager compile ch.qos.logback with error

### Modifications

add some vital dependency

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation
  - Does this pull request introduce a new feature? (no)
