### PR TITLE
Add Apollo dependency and config for InLong-Manager

### DIFF
--- a/inlong-manager/manager-web/pom.xml
+++ b/inlong-manager/manager-web/pom.xml
@@ -113,6 +113,11 @@
             <artifactId>guava</artifactId>
             <groupId>com.google.guava</groupId>
         </dependency>
+        <dependency>
+            <groupId>com.ctrip.framework.apollo</groupId>
+            <artifactId>apollo-client</artifactId>
+            <version>1.8.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/inlong-manager/manager-web/src/main/resources/application.properties
+++ b/inlong-manager/manager-web/src/main/resources/application.properties
@@ -40,3 +40,10 @@ mybatis.configuration.map-underscore-to-camel-case=true
 pagehelper.helperDialect=mysql
 pagehelper.reasonable=true
 pagehelper.params=count=countSql
+
+# Apollo Config
+app.id=InLong-Manager
+apollo.meta=http://10.176.122.155:8080
+apollo.bootstrap.enabled=false
+
+

--- a/inlong-manager/manager-web/src/main/resources/application.properties
+++ b/inlong-manager/manager-web/src/main/resources/application.properties
@@ -43,7 +43,7 @@ pagehelper.params=count=countSql
 
 # Apollo Config
 app.id=InLong-Manager
-apollo.meta=http://10.176.122.155:8080
+apollo.meta=http://localhost:8080
 apollo.bootstrap.enabled=false
 
 


### PR DESCRIPTION
###  [INLONG-1316][InLong-Manager] Add Apollo dependency and config for InLong-Manager


Fixes #1316  (partially)

### Modifications

Add Apollo dependency and config for InLong-Manager.

The Apollo is disabled by default, and the local configuration files is enabled.

If you want to use Apollo as configuration server, you need to do following things:
1. change `apollo.bootstrap.enabled` to `true`.
2. change `apollo.meta` to your Apollo meta service URL.

Then you can use Apollo as the configuration server, and the local configuration files will be overridden.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


