### PR TITLE
[INLONG-719] Add helm chart to support Kubernetes for inlong

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-## Docker For InLong
+## Docker and Kubernetes for InLong
 
 Requirements:
 - [Docker](https://docs.docker.com/engine/install/) 19.03.1+
@@ -9,4 +9,6 @@ mvn clean package -DskipTests -Pdocker
 ```
 
 ### Run All Modules
+
 - [docker-compose](docker-compose/README.md)
+- [kubernetes](kubernetes/README.md)

--- a/docker/kubernetes/.helmignore
+++ b/docker/kubernetes/.helmignore
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/docker/kubernetes/Chart.yaml
+++ b/docker/kubernetes/Chart.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v2
+name: inlong
+description: A Helm Chart for Apache InLong
+type: application
+version: 2.0.0
+appVersion: 0.10.0
+home: https://inlong.apache.org
+icon: https://inlong.apache.org/img/first-page-bg.png
+sources:
+  - https://github.com/apache/incubator-inlong
+keywords:
+  - inlong
+  - tubemq
+maintainers:
+  - name: dockerzhang
+    email: dockerzhang@apache.org

--- a/docker/kubernetes/Chart.yaml
+++ b/docker/kubernetes/Chart.yaml
@@ -31,3 +31,7 @@ keywords:
 maintainers:
   - name: dockerzhang
     email: dockerzhang@apache.org
+    url: https://github.com/dockerzhang
+  - name: shink
+    email: jiyuanhao1997@gmail.com
+    url: https://github.com/shink

--- a/docker/kubernetes/README.md
+++ b/docker/kubernetes/README.md
@@ -1,0 +1,32 @@
+## The Helm Chart for Apache InLong
+
+### Prerequisites
+
+- Kubernetes 1.10+
+- Helm 3.0+
+- A dynamic provisioner for the PersistentVolumes(`production environment`)
+
+### Usage
+
+#### Install
+
+```shell
+kubectl create namespace inlong
+helm upgrade inlong --install -n inlong ./
+```
+
+#### Configuration
+
+
+
+#### Uninstall
+
+```shell
+helm uninstall inlong -n inlong
+```
+
+You can delete all `PVC ` if any persistent volume claims used, it will lose all data.
+
+```shell
+kubectl delete pvc -n inlong --all
+```

--- a/docker/kubernetes/templates/NOTES.txt
+++ b/docker/kubernetes/templates/NOTES.txt
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+1. Get the application URL by running these commands:
+{{/*{{- if .Values.ingress.enabled }}*/}}
+{{/*{{- range $host := .Values.ingress.hosts }}*/}}
+{{/*  {{- range .paths }}*/}}
+{{/*  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}*/}}
+{{/*  {{- end }}*/}}
+{{/*{{- end }}*/}}
+{{/*{{- else if contains "NodePort" .Values.service.type }}*/}}
+{{/*  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "inlong.fullname" . }})*/}}
+{{/*  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")*/}}
+{{/*  echo http://$NODE_IP:$NODE_PORT*/}}
+{{/*{{- else if contains "LoadBalancer" .Values.service.type }}*/}}
+{{/*     NOTE: It may take a few minutes for the LoadBalancer IP to be available.*/}}
+{{/*           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "inlong.fullname" . }}'*/}}
+{{/*  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "inlong.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")*/}}
+{{/*  echo http://$SERVICE_IP:{{ .Values.service.port }}*/}}
+{{/*{{- else if contains "ClusterIP" .Values.service.type }}*/}}
+{{/*  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "inlong.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")*/}}
+{{/*  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")*/}}
+{{/*  echo "Visit http://127.0.0.1:8080 to use your application"*/}}
+{{/*  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT*/}}
+{{/*{{- end }}*/}}

--- a/docker/kubernetes/templates/_helpers.tpl
+++ b/docker/kubernetes/templates/_helpers.tpl
@@ -1,0 +1,146 @@
+{{/*
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "inlong.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "inlong.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "inlong.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the common labels.
+*/}}
+{{- define "inlong.commonLabels" -}}
+app: {{ template "inlong.name" . }}
+chart: {{ template "inlong.chart" . }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+cluster: {{ template "inlong.fullname" . }}
+{{- end -}}
+
+{{/*
+Create the template labels.
+*/}}
+{{- define "inlong.template.labels" -}}
+app: {{ template "inlong.name" . }}
+release: {{ .Release.Name }}
+cluster: {{ template "inlong.fullname" . }}
+{{- end -}}
+
+{{/*
+Create the match labels.
+*/}}
+{{- define "inlong.matchLabels" -}}
+app: {{ template "inlong.name" . }}
+release: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Define the manager web hostname
+*/}}
+{{- define "inlong.managerWeb.hostname" -}}
+${HOSTNAME}.{{ template "inlong.fullname" . }}-{{ .Values.managerWeb.component }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+
+{{/*
+Define the dataproxy hostname
+*/}}
+{{- define "inlong.dataproxy.hostname" -}}
+${HOSTNAME}.{{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+
+{{/*
+Define the tubemq manager hostname
+*/}}
+{{- define "inlong.tubemqManager.hostname" -}}
+${HOSTNAME}.{{ template "inlong.fullname" . }}-{{ .Values.tubemqManager.component }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+
+{{/*
+Define the tubemq master hostname
+*/}}
+{{- define "inlong.tubemqMaster.hostname" -}}
+${HOSTNAME}.{{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+
+{{/*
+Define the mysql hostname
+*/}}
+{{- define "inlong.mysql.hostname" -}}
+${HOSTNAME}.{{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+
+{{/*
+Define the zookeeper hostname
+*/}}
+{{- define "inlong.zookeeper.hostname" -}}
+${HOSTNAME}.{{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "inlong.labels" -}}
+helm.sh/chart: {{ include "inlong.chart" . }}
+{{ include "inlong.selectorLabels" . }}
+{{- if .Chart.AppVersion -}}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "inlong.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "inlong.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "inlong.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "inlong.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/docker/kubernetes/templates/agent-service.yaml
+++ b/docker/kubernetes/templates/agent-service.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.agent.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.agent.component }}
+spec:
+  ports:
+    - name: {{ .Values.agent.component}}-port
+      port: {{ .Values.agent.ports.agent }}
+  type: ClusterIP
+  selector:
+    {{- include "inlong.matchLabels" . | nindent 4 }}
+    component: {{ .Values.agent.component }}

--- a/docker/kubernetes/templates/agent-statefulset.yaml
+++ b/docker/kubernetes/templates/agent-statefulset.yaml
@@ -1,0 +1,94 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.agent.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.agent.component }}
+spec:
+  serviceName: {{ template "inlong.fullname" . }}-{{ .Values.agent.component }}
+  replicas: {{ .Values.agent.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.agent.component }}
+  template:
+    metadata:
+      labels:
+        {{- include "inlong.template.labels" . | nindent 8 }}
+        component: {{ .Values.agent.component }}
+    spec:
+      initContainers:
+      - name: wait-website
+        image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
+        command: [ "/bin/bash", "-c" ]
+        args:
+          - >-
+            for ((i=0;i<{{ .Values.website.replicaCount }};i++))
+            do
+              host="{{ template "inlong.fullname" $ }}-{{ .Values.website.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.website.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+              port={{ .Values.website.ports.webPort }}
+              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+              do
+                echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.website.component }}-$i to be ready"
+                sleep 3
+              done
+            done
+      - name: wait-dataproxy
+        image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
+        command: [ "/bin/bash", "-c" ]
+        args:
+          - >-
+            for ((i=0;i<{{ .Values.dataproxy.replicaCount }};i++))
+            do
+              host="{{ template "inlong.fullname" $ }}-{{ .Values.dataproxy.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.dataproxy.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+              port={{ .Values.dataproxy.containerPort }}
+              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+              do
+                echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.dataproxy.component }}-$i to be ready"
+                sleep 3
+              done
+            done
+      containers:
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.agent.component }}
+          image: {{ .Values.images.agent.repository }}:{{ .Values.images.agent.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          env:
+            - name: MANAGER_OPENAPI_IP
+              value: {{ template "inlong.tubemqManager.hostname" . }}
+            - name: MANAGER_OPENAPI_PORT
+              value: {{ .Values.agent.ports.managerOpenApi }}
+            - name: DATAPROXY_IP
+              value: {{ template "inlong.dataproxy.hostname" . }}
+            - name: DATAPROXY_PORT
+              value: {{ .Values.agent.ports.dataProxy }}
+          ports:
+            - name: {{ .Values.agent.component }}-port
+              containerPort: 8008
+          volumeMounts:
+            - name: data
+              mountPath: /data/collect-data
+      volumes:
+        - name: data
+          emptyDir: {}
+      restartPolicy: Always

--- a/docker/kubernetes/templates/broker-configmap.yaml
+++ b/docker/kubernetes/templates/broker-configmap.yaml
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: {{ .Values.tubemqBroker.component }}
+data:
+  ok: |
+    #!/bin/sh
+    /opt/tubemq-server/bin/tubemq.sh broker status
+
+  ready: |
+    #!/bin/sh
+    /opt/tubemq-server/bin/tubemq.sh broker status
+
+  run: |
+    #!/bin/bash
+    set -a
+    # get pod index
+    HOST=$(hostname)
+    if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
+      NAME=${BASH_REMATCH[1]}
+      ORD=${BASH_REMATCH[2]}
+      MY_POD_ID=$((ORD+1))
+    else
+      echo "Failed to extract ordinal from hostname $HOST"
+      exit 1
+    fi
+    # get active master and register broker
+    for ((i=0;i<{{ .Values.tubemqMaster.replicaCount }};i++)); do
+      master="{{ template "inlong.fullname" $ }}-\
+    {{ .Values.tubemqMaster.component }}-$i.{{ template "inlong.fullname" $ }}-\
+    {{ .Values.tubemqMaster.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+      index=$(curl $master:8080/index.htm)
+      if [[ -n "$index" ]]; then
+        # add broker
+        curl -d "type=op_modify&method=admin_add_broker_configure&brokerId=$MY_POD_ID\
+        &brokerIp=$HOST&brokerPort=8123&deletePolicy=delete,168h&numPartitions=3\
+        &unflushThreshold=1000&acceptPublish=true&acceptSubscribe=true&unflushInterval=10000\
+        &createUser=docker&confModAuthToken=abc" http://$master:8080/webapi.htm
+        # online
+        curl -d "type=op_modify&method=admin_online_broker_configure&brokerId=$MY_POD_ID\
+        &modifyUser=docker&confModAuthToken=abc" http://$master:8080/webapi.htm
+      fi
+      # master addresses list
+      MASTER_LIST="$master:8715,"$MASTER_LIST
+    done
+    # generate config file
+    cp /opt/tubemq-server/conf/broker.ini.raw /opt/tubemq-server/conf/broker.ini
+    sed -i "s/REPLACE_BY_POD_ID/$MY_POD_ID/g" /opt/tubemq-server/conf/broker.ini
+    sed -i "s/REPLACE_BY_POD_HOSTNAME/$HOST/g" /opt/tubemq-server/conf/broker.ini
+    sed -i "s/REPLACE_BY_MASTER_LIST/${MASTER_LIST%?}/g" /opt/tubemq-server/conf/broker.ini
+    # start
+    /opt/tubemq-server/bin/tubemq.sh broker start
+    tail -F /opt/tubemq-server/logs/broker.log

--- a/docker/kubernetes/templates/broker-ini-configmap.yaml
+++ b/docker/kubernetes/templates/broker-ini-configmap.yaml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-ini
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: {{ .Values.tubemqBroker.component }}
+data:
+  broker.ini.raw: |
+    [broker]
+    brokerId=REPLACE_BY_POD_ID
+    hostName=REPLACE_BY_POD_HOSTNAME
+    port=8123
+    webPort=8081
+    masterAddressList=REPLACE_BY_MASTER_LIST
+    primaryPath=/data/stage/metadata_REPLACE_BY_POD_ID
+    maxSegmentSize=1073741824
+    maxIndexSegmentSize=22020096
+    transferSize=524288
+    loadMessageStoresInParallel=true
+    consumerRegTimeoutMs=35000
+
+    [zookeeper]
+    zkNodeRoot=/tubemq
+    zkServerAddr={{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}:2181
+    zkSessionTimeoutMs=30000
+    zkConnectionTimeoutMs=30000
+    zkSyncTimeMs=5000
+    zkCommitPeriodMs=5000
+    zkCommitFailRetries=10

--- a/docker/kubernetes/templates/broker-pdb.yaml
+++ b/docker/kubernetes/templates/broker-pdb.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+{{- if .Values.tubemqBroker.pdb.usePolicy }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.tubemqBroker.component }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.tubemqBroker.component }}
+  maxUnavailable: {{ .Values.tubemqBroker.pdb.maxUnavailable }}
+{{- end }}

--- a/docker/kubernetes/templates/broker-service.yaml
+++ b/docker/kubernetes/templates/broker-service.yaml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.tubemqBroker.component }}
+  annotations:
+{{ toYaml .Values.tubemqBroker.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.tubemqBroker.service.type }}
+  ports:
+    - name: web-port
+      port: {{ .Values.tubemqBroker.ports.webPort }}
+    - name: rpc-port
+      port: {{ .Values.tubemqBroker.ports.rpcPort }}
+  selector:
+    {{- include "inlong.matchLabels" . | nindent 4 }}
+    component: {{ .Values.tubemqBroker.component }}

--- a/docker/kubernetes/templates/broker-statefulset.yaml
+++ b/docker/kubernetes/templates/broker-statefulset.yaml
@@ -1,0 +1,157 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.tubemqBroker.component }}
+spec:
+  serviceName: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}
+  replicas: {{ .Values.tubemqBroker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.tubemqBroker.component }}
+  updateStrategy:
+    {{ toYaml .Values.tubemqBroker.updateStrategy | indent 4 }}
+  podManagementPolicy: {{ .Values.tubemqBroker.podManagementPolicy }}
+  template:
+    metadata:
+      labels:
+        {{- include "inlong.template.labels" . | nindent 8 }}
+        component: {{ .Values.tubemqBroker.component }}
+      annotations:
+    {{ toYaml .Values.tubemqBroker.annotations | indent 8 }}
+    spec:
+      {{- if .Values.tubemqBroker.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.tubemqBroker.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tubemqBroker.tolerations }}
+      tolerations:
+      {{ toYaml .Values.tubemqBroker.tolerations | indent 8 }}
+      {{- end }}
+      initContainers:
+        - name: wait-master-ready
+          image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - >-
+              for ((i=0;i<{{ .Values.tubemqMaster.replicaCount }};i++)); do
+              until curl {{ template "inlong.fullname" $ }}-{{ .Values.tubemqMaster.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.tubemqMaster.component }}.{{ .Release.Namespace }}.svc.cluster.local:${1:-8080}/index.htm; do
+              sleep 3; done; done;
+      affinity:
+        {{- if .Values.affinity.anti_affinity }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.tubemqBroker.component }}
+            topologyKey: "kubernetes.io/hostname"
+        {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.tubemqBroker.gracePeriod }}
+      containers:
+        - name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}
+          image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          {{- if .Values.tubemqBroker.resources }}
+          resources:
+          {{ toYaml .Values.tubemqBroker.resources | indent 10 }}
+          {{- end }}
+          command: [ "sh", "-c" ]
+          args:
+            - >
+              /config-scripts/run;
+          ports:
+            - name: web-port
+              containerPort: {{ .Values.tubemqBroker.ports.webPort }}
+            - name: rpc-port
+              containerPort: {{ .Values.tubemqBroker.ports.rpcPort }}
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          {{- if .Values.tubemqBroker.probe.readiness.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - /config-scripts/ready
+            initialDelaySeconds: {{ .Values.tubemqBroker.probe.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.tubemqBroker.probe.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.tubemqBroker.probe.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.tubemqBroker.probe.liveness.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - /config-scripts/ok
+            initialDelaySeconds: {{ .Values.tubemqBroker.probe.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.tubemqBroker.probe.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.tubemqBroker.probe.liveness.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.data.name }}
+              mountPath: /data
+            - name: config
+              mountPath: /config-scripts
+            - name: {{ .Values.tubemqBroker.component }}-ini
+              mountPath: /opt/tubemq-server/conf/{{ .Values.tubemqBroker.component }}.ini.raw
+              subPath: {{ .Values.tubemqBroker.component }}.ini.raw
+              readOnly: false
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}
+            defaultMode: 0755
+        - name: {{ .Values.tubemqBroker.component }}-ini
+          configMap:
+            name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}-ini
+            defaultMode: 0644
+        {{- if not .Values.volumes.persistence }}
+        - name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.data.name }}
+          emptyDir: {}
+        {{- end }}
+  {{- if .Values.volumes.persistence }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.data.name }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.tubemqBroker.volumes.data.size }}
+        {{- if .Values.volumes.storageClassName }}
+        storageClassName: {{ .Values.volumes.storageClassName }}
+        {{- end }}
+  {{- end }}

--- a/docker/kubernetes/templates/dataproxy-service.yaml
+++ b/docker/kubernetes/templates/dataproxy-service.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.dataproxy.component }}
+spec:
+  ports:
+    - name: {{ .Values.dataproxy.component }}-port
+      port: {{ .Values.dataproxy.containerPort }}
+  type: ClusterIP
+  selector:
+    {{- include "inlong.matchLabels" . | nindent 4 }}
+    component: {{ .Values.dataproxy.component }}

--- a/docker/kubernetes/templates/dataproxy-statefulset.yaml
+++ b/docker/kubernetes/templates/dataproxy-statefulset.yaml
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component}}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.dataproxy.component }}
+spec:
+  serviceName: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}
+  replicas: {{ .Values.dataproxy.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.dataproxy.component }}
+  template:
+    metadata:
+      labels:
+        {{- include "inlong.template.labels" . | nindent 8 }}
+        component: {{ .Values.dataproxy.component }}
+    spec:
+      initContainers:
+      - name: wait-manager-web
+        image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
+        command: [ "/bin/bash", "-c" ]
+        args:
+          - >-
+            for ((i=0;i<{{ .Values.managerWeb.replicaCount }};i++))
+            do
+              host="{{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+              port={{ .Values.managerWeb.ports.webPort }}
+              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+              do
+                echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}-$i to be ready"
+                sleep 3
+              done
+            done
+      containers:
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component}}
+          image: {{ .Values.images.dataproxy.repository }}:{{ .Values.images.dataproxy.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          env:
+            - name: MANAGER_OPENAPI_IP
+              value: {{ template "inlong.managerWeb.hostname" . }}
+            - name: MANAGER_OPENAPI_PORT
+              value: {{ .Values.dataproxy.managerOpenApiPort }}
+            - name: TUBMQ_MASTER_LIST
+              value: "{{ template "inlong.tubemqMaster.hostname" . }}:{{ .Values.tubemqMaster.ports.rpcPort}}"
+          ports:
+            - name: {{ .Values.dataproxy.component }}-port
+              containerPort: 46801
+      restartPolicy: Always

--- a/docker/kubernetes/templates/manager-web-service.yaml
+++ b/docker/kubernetes/templates/manager-web-service.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.managerWeb.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.managerWeb.component }}
+spec:
+  type: {{ .Values.managerWeb.service.type }}
+  ports:
+    - name: {{ .Values.managerWeb.component }}-port
+      port: {{ .Values.managerWeb.ports.webPort }}
+      nodePort: {{ .Values.managerWeb.ports.webNodePort }}
+  selector:
+    {{- include "inlong.matchLabels" . | nindent 4 }}
+    component: {{ .Values.managerWeb.component }}

--- a/docker/kubernetes/templates/manager-web-statefulset.yaml
+++ b/docker/kubernetes/templates/manager-web-statefulset.yaml
@@ -1,0 +1,80 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.managerWeb.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.managerWeb.component }}
+spec:
+  serviceName: {{ template "inlong.fullname" . }}-{{ .Values.managerWeb.component }}
+  replicas: {{ .Values.managerWeb.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.managerWeb.component }}
+  template:
+    metadata:
+      labels:
+        {{- include "inlong.template.labels" . | nindent 8 }}
+        component: {{ .Values.managerWeb.component }}
+    spec:
+      initContainers:
+        - name: wait-tubemq-manager
+          image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - >-
+              for ((i=0;i<{{ .Values.tubemqManager.replicaCount }};i++))
+              do
+                host="{{ template "inlong.fullname" $ }}-{{ .Values.tubemqManager.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.tubemqManager.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+                port={{ .Values.tubemqManager.containerPort }}
+                until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+                do
+                  echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.tubemqManager.component }}-$i to be ready"
+                  sleep 3
+                done
+              done
+      containers:
+        - name: {{ template "inlong.name" . }}-{{ .Values.managerWeb.component }}
+          image: {{ .Values.images.managerWeb.repository }}:{{ .Values.images.managerWeb.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          env:
+            - name: ACTIVE_PROFILE
+              value: {{ .Values.managerWeb.activeProfile }}
+            - name: JDBC_URL
+              value: "{{ template "inlong.mysql.hostname" }}:{{ .Values.mysql.ports.server }}"
+            - name: USERNAME
+              value: {{ .Values.managerWeb.username }}
+            - name: PASSWORD
+              value: {{ .Values.managerWeb.password }}
+            - name: TUBE_MANAGER
+              value: "http://{{ template "inlong.tubemqManager.hostname" . }}:{{ .Values.tubemqManager.containerPort }}"
+            - name: TUBE_MASTER
+              value: "{{ template "inlong.tubemqMaster.hostname" . }}:{{ .Values.tubemqMaster.ports.rpcPort }}"
+            - name: ZK_URL
+              value: "{{ template "inlong.zookeeper.hostname" . }}:{{ .Values.zookeeper.ports.client }}"
+            - name: SORT_APP_NAME
+              value: {{ .Values.managerWeb.sortAppName }}
+          ports:
+            - name: {{ .Values.managerWeb.component }}-port
+              containerPort: 8083
+      restartPolicy: Always

--- a/docker/kubernetes/templates/master-configmap.yaml
+++ b/docker/kubernetes/templates/master-configmap.yaml
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: {{ .Values.tubemqMaster.component }}
+data:
+  ok: |
+    #!/bin/sh
+    /opt/tubemq-server/bin/tubemq.sh master status
+
+  ready: |
+    #!/bin/sh
+    curl 127.0.0.1:8080/index.htm
+
+  run: |
+    #!/bin/bash
+    set -a
+    # get pod index
+    HOST=$(hostname)
+    if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
+      NAME=${BASH_REMATCH[1]}
+      ORD=${BASH_REMATCH[2]}
+      MY_POD_ID=$((ORD+1))
+    else
+      echo "Failed to extract ordinal from hostname $HOST"
+      exit 1
+    fi
+    # generate config file
+    cp /opt/tubemq-server/conf/master.ini.raw /opt/tubemq-server/conf/master.ini
+    sed -i "s/REPLACE_BY_POD_ID/$MY_POD_ID/g" /opt/tubemq-server/conf/master.ini
+    sed -i "s/REPLACE_BY_POD_HOSTNAME/$HOST.{{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}.{{ .Release.Name }}.svc.cluster.local/g" /opt/tubemq-server/conf/master.ini
+    # start master
+    /opt/tubemq-server/bin/tubemq.sh master start
+    tail -F /opt/tubemq-server/logs/master.log

--- a/docker/kubernetes/templates/master-ini-configmap.yaml
+++ b/docker/kubernetes/templates/master-ini-configmap.yaml
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-ini
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: {{ .Values.tubemqMaster.component }}
+data:
+  master.ini.raw: |
+    [master]
+    hostName=REPLACE_BY_POD_HOSTNAME
+    port=8715
+    webPort=8080
+    consumerBalancePeriodMs=30000
+    firstBalanceDelayAfterStartMs=60000
+    consumerHeartbeatTimeoutMs=30000
+    producerHeartbeatTimeoutMs=45000
+    brokerHeartbeatTimeoutMs=25000
+    confModAuthToken=abc
+    webResourcePath=resources
+    metaDataPath=/data/meta_data
+    useWebProxy=true
+
+    [zookeeper]
+    zkNodeRoot=/tubemq
+    zkServerAddr={{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}:2181
+    zkSessionTimeoutMs=30000
+    zkConnectionTimeoutMs=30000
+    zkSyncTimeMs=5000
+    zkCommitPeriodMs=5000
+
+    [replication]
+    repGroupName={{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
+    repNodeName={{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-REPLACE_BY_POD_ID
+    repNodePort=9001
+    repHelperHost={{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-0.{{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}.{{ .Release.Name }}.svc.cluster.local:9001

--- a/docker/kubernetes/templates/master-pdb.yaml
+++ b/docker/kubernetes/templates/master-pdb.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+  {{- if .Values.tubemqMaster.pdb.usePolicy }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.tubemqMaster.component }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.tubemqMaster.component }}
+  maxUnavailable: {{ .Values.tubemqMaster.pdb.maxUnavailable }}
+{{- end }}

--- a/docker/kubernetes/templates/master-service.yaml
+++ b/docker/kubernetes/templates/master-service.yaml
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.tubemqMaster.component }}
+  annotations:
+{{ toYaml .Values.tubemqMaster.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.tubemqMaster.service.type }}
+  ports:
+    - name: web-port
+      port: {{ .Values.tubemqMaster.ports.webPort }}
+      nodePort: {{ .Values.tubemqMaster.ports.webNodePort }}
+    - name: help-port
+      port: {{ .Values.tubemqMaster.ports.helpPort }}
+    - name: rpc-port
+      port: {{ .Values.tubemqMaster.ports.rpcPort }}
+  selector:
+    {{- include "inlong.matchLabels" . | nindent 4 }}
+    component: {{ .Values.tubemqMaster.component }}

--- a/docker/kubernetes/templates/master-statefulset.yaml
+++ b/docker/kubernetes/templates/master-statefulset.yaml
@@ -1,0 +1,159 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.tubemqMaster.component }}
+spec:
+  serviceName: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
+  replicas: {{ .Values.tubemqMaster.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.tubemqMaster.component }}
+  updateStrategy:
+{{ toYaml .Values.tubemqMaster.updateStrategy | indent 4 }}
+  podManagementPolicy: {{ .Values.tubemqMaster.podManagementPolicy }}
+  template:
+    metadata:
+      labels:
+        {{- include "inlong.template.labels" . | nindent 8 }}
+        component: {{ .Values.tubemqMaster.component }}
+      annotations:
+{{ toYaml .Values.tubemqMaster.annotations | indent 8 }}
+    spec:
+    {{- if .Values.tubemqMaster.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.tubemqMaster.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tubemqMaster.tolerations }}
+      tolerations:
+{{ toYaml .Values.tubemqMaster.tolerations | indent 8 }}
+    {{- end }}
+      initContainers:
+        - name: wait-zk-ready
+          image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - >-
+              for ((i=0;i<{{ .Values.zookeeper.replicaCount }};i++)); do
+              until echo ruok | nc {{ template "inlong.fullname" $ }}-{{ .Values.zookeeper.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }}.svc.cluster.local ${1:-2181}; do
+              sleep 3; done; done;
+      affinity:
+        {{- if .Values.affinity.anti_affinity}}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "inlong.name" . }}-{{ .Values.tubemqMaster.component }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.tubemqMaster.component }}
+            topologyKey: "kubernetes.io/hostname"
+        {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.tubemqMaster.gracePeriod }}
+      containers:
+      - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
+        image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
+      {{- if .Values.tubemqMaster.resources }}
+        resources:
+{{ toYaml .Values.tubemqMaster.resources | indent 10 }}
+      {{- end }}
+        command: ["sh", "-c"]
+        args:
+        - >
+          /config-scripts/run;
+        ports:
+        - name: web-port
+          containerPort: {{ .Values.tubemqMaster.ports.webPort }}
+        - name: help-port
+          containerPort: {{ .Values.tubemqMaster.ports.helpPort }}
+        - name: rpc-port
+          containerPort: {{ .Values.tubemqMaster.ports.rpcPort }}
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- if .Values.tubemqMaster.probe.readiness.enabled }}
+        readinessProbe:
+          exec:
+            command:
+            - /config-scripts/ready
+          initialDelaySeconds: {{ .Values.tubemqMaster.probe.readiness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.tubemqMaster.probe.readiness.periodSeconds }}
+          failureThreshold: {{ .Values.tubemqMaster.probe.readiness.failureThreshold }}
+        {{- end }}
+        {{- if .Values.tubemqMaster.probe.liveness.enabled }}
+        livenessProbe:
+          exec:
+            command:
+            - /config-scripts/ok
+          initialDelaySeconds: {{ .Values.tubemqMaster.probe.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.tubemqMaster.probe.liveness.periodSeconds }}
+          failureThreshold: {{ .Values.tubemqMaster.probe.liveness.failureThreshold }}
+        {{- end }}
+        volumeMounts:
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.data.name }}
+          mountPath: /data
+        - name: config
+          mountPath: /config-scripts
+        - name: {{ .Values.tubemqMaster.component }}-ini
+          mountPath: /opt/tubemq-server/conf/{{ .Values.tubemqMaster.component }}.ini.raw
+          subPath: {{ .Values.tubemqMaster.component }}.ini.raw
+          readOnly: false
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
+          defaultMode: 0755
+      - name: {{ .Values.tubemqMaster.component }}-ini
+        configMap:
+          name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-ini
+          defaultMode: 0644
+      {{- if not .Values.volumes.persistence }}
+      - name: "{{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.data.name }}"
+        emptyDir: {}
+      {{- end }}
+  {{- if .Values.volumes.persistence }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.data.name }}
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.tubemqMaster.volumes.data.size }}
+    {{- if .Values.volumes.storageClassName }}
+      storageClassName: "{{ .Values.volumes.storageClassName }}"
+    {{- end }}
+  {{- end }}

--- a/docker/kubernetes/templates/mysql-pvc.yaml
+++ b/docker/kubernetes/templates/mysql-pvc.yaml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+{{- if .Values.mysql.persistentVolumeClaim.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.mysql.component }}
+spec:
+  accessModes:
+    {{- range .Values.mysql.persistentVolumeClaim.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storageClassName: {{ .Values.mysql.persistentVolumeClaim.storageClassName | quote }}
+      storage: {{ .Values.mysql.persistentVolumeClaim.storage | quote }}
+{{- end }}

--- a/docker/kubernetes/templates/mysql-secret.yaml
+++ b/docker/kubernetes/templates/mysql-secret.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.mysql.component }}
+type: Opaque
+data:
+  {{- if .Values.mysql.rootPassword }}
+  mysql-root-password: {{ .Values.mysql.rootPassword | b64enc | quote }}
+  {{- else }}
+  mysql-root-password: {{ "inlong" | b64enc | quote }}
+  {{- end }}

--- a/docker/kubernetes/templates/mysql-service.yaml
+++ b/docker/kubernetes/templates/mysql-service.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.mysql.component }}
+spec:
+  ports:
+    - name: {{ .Values.mysql.component }}-server-port
+      port: {{ .Values.mysql.ports.server }}
+  clusterIP: None
+  selector:
+    {{- include "inlong.matchLabels" . | nindent 4 }}
+    component: {{ .Values.mysql.component }}

--- a/docker/kubernetes/templates/mysql-statefulset.yaml
+++ b/docker/kubernetes/templates/mysql-statefulset.yaml
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.mysql.component }}
+spec:
+  serviceName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
+  replicas: {{ .Values.mysql.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.mysql.component }}
+  template:
+    metadata:
+      labels:
+        {{- include "inlong.template.labels" . | nindent 8 }}
+        component: {{ .Values.mysql.component }}
+    spec:
+      containers:
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
+          image: {{ .Values.images.mysql.repository }}:{{ .Values.images.mysql.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
+                  key: mysql-root-password
+          ports:
+            - name: {{ .Values.mysql.component }}-server-port
+              containerPort: 3306
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+            - name: sql
+              mountPath: /docker-entrypoint-initdb.d
+      volumes:
+        - name: data
+          {{- if .Values.mysql.persistentVolumeClaim.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}-pvc
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: sql
+          {{- if .Values.mysql.persistentVolumeClaim.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}-pvc
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      restartPolicy: Always

--- a/docker/kubernetes/templates/tubemq-manager-service.yaml
+++ b/docker/kubernetes/templates/tubemq-manager-service.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqManager.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.tubemqManager.component }}
+spec:
+  ports:
+    - name: {{ .Values.tubemqManager.component }}-port
+      port: {{ .Values.tubemqManager.containerPort }}
+  type: ClusterIP
+  selector:
+    {{- include "inlong.matchLabels" . | nindent 6 }}
+    component: {{ .Values.tubemqManager.component }}

--- a/docker/kubernetes/templates/tubemq-manager-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-manager-statefulset.yaml
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqManager.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.tubemqManager.component }}
+spec:
+  serviceName: {{ template "inlong.fullname" . }}-{{ .Values.tubemqManager.component }}
+  replicas: {{ .Values.tubemqManager.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.tubemqManager.component }}
+  template:
+    metadata:
+      labels:
+        {{- include "inlong.template.labels" . | nindent 8 }}
+        component: {{ .Values.tubemqManager.component }}
+    spec:
+      initContainers:
+        - name: wait-mysql-ready
+          image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - >-
+              for ((i=0;i<{{ .Values.mysql.replicaCount }};i++))
+              do
+                host="{{ template "inlong.fullname" $ }}-{{ .Values.mysql.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.mysql.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+                port={{ .Values.mysql.ports.server }}
+                until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+                do
+                  echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.mysql.component }}-$i to be ready"
+                  sleep 3
+                done
+              done
+        - name: wait-tubemq-master
+          image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - >-
+              for ((i=0;i<{{ .Values.tubemqMaster.replicaCount }};i++))
+              do
+                host="{{ template "inlong.fullname" $ }}-{{ .Values.tubemqMaster.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.tubemqMaster.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+                port={{ .Values.tubemqMaster.ports.rpcPort }}
+                until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+                do
+                  echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.tubemqMaster.component }}-$i to be ready"
+                  sleep 3
+                done
+              done
+      containers:
+        - name: {{ template "inlong.name" . }}-{{ .Values.tubemqManager.component }}
+          image: {{ .Values.images.tubemqManager.repository }}:{{ .Values.images.tubemqManager.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          env:
+            - name: MYSQL_HOST
+              value: {{ template "inlong.mysql.hostname" }}
+            - name: MYSQL_USER
+              value: {{ .Values.tubemqManager.mysqlUser | quote }}
+            - name: MYSQL_PASSWD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
+                  key: mysql-root-password
+            - name: TUBE_MASTER_IP
+              value: {{ include "inlong.tubemqMaster.hostname" . | quote}}
+          ports:
+            - name: {{ .Values.tubemqManager.component }}-port
+              containerPort: 8089
+      restartPolicy: Always

--- a/docker/kubernetes/templates/website-service.yaml
+++ b/docker/kubernetes/templates/website-service.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.website.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.website.component }}
+spec:
+  type: {{ .Values.website.service.type }}
+  ports:
+    - name: {{ .Values.website.component }}-port
+      port: {{ .Values.website.ports.webPort }}
+      nodePort: {{ .Values.website.ports.webNodePort }}
+  selector:
+    {{- include "inlong.matchLabels" . | nindent 4 }}
+    component: {{ .Values.website.component }}

--- a/docker/kubernetes/templates/website-statefulset.yaml
+++ b/docker/kubernetes/templates/website-statefulset.yaml
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.website.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.website.component }}
+spec:
+  serviceName: {{ template "inlong.fullname" . }}-{{ .Values.website.component }}
+  replicas: {{ .Values.tubemqManager.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.website.component }}
+  template:
+    metadata:
+      labels:
+        {{- include "inlong.template.labels" . | nindent 8 }}
+        component: {{ .Values.website.component }}
+    spec:
+      initContainers:
+      - name: wait-manager-web
+        image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
+        command: [ "/bin/bash", "-c" ]
+        args:
+          - >-
+            for ((i=0;i<{{ .Values.managerWeb.replicaCount }};i++))
+            do
+              host="{{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+              port={{ .Values.managerWeb.ports.webPort }}
+              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+              do
+                echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}-$i to be ready"
+                sleep 3
+              done
+            done
+      containers:
+        - name: {{ template "inlong.name" . }}-{{ .Values.website.component }}
+          image: {{ .Values.images.website.repository }}:{{ .Values.images.tubemqManager.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          env:
+            - name: MANAGER_API_ADDRESS
+              value: "{{ template "inlong.tubemqManager.hostname" .}}:{{ .Values.tubemqManager.containerPort }}"
+          ports:
+            - name: {{ .Values.website.component }}-port
+              containerPort: 80
+      restartPolicy: Always

--- a/docker/kubernetes/templates/zookeeper-configmap.yaml
+++ b/docker/kubernetes/templates/zookeeper-configmap.yaml
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: {{ .Values.zookeeper.component }}
+data:
+  ok: |
+    #!/bin/sh
+    zkServer.sh status
+
+  ready: |
+    #!/bin/sh
+    echo ruok | nc 127.0.0.1 ${1:-2181}
+
+  run: |
+    #!/bin/bash
+    set -a
+    HOST=$(hostname)
+    if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
+      NAME=${BASH_REMATCH[1]}
+      ORD=${BASH_REMATCH[2]}
+      MY_POD_ID=$((ORD+1))
+    else
+      echo "Failed to extract ordinal from hostname $HOST"
+      exit 1
+    fi
+    if [ ! -d "/data/zoo_data/" ]; then
+      mkdir /data/zoo_data/ /data/zoo_log/
+    fi
+    export ZOO_MY_ID=$MY_POD_ID
+    export ZOO_DATA_DIR="/data/zoo_data/"
+    export ZOO_DATA_LOG_DIR="/data/zoo_log/"
+    export SERVER_JVMFLAGS="-Xmx1g -Xms1g"
+    /docker-entrypoint.sh zkServer.sh start-foreground

--- a/docker/kubernetes/templates/zookeeper-pdb.yaml
+++ b/docker/kubernetes/templates/zookeeper-pdb.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+{{- if .Values.zookeeper.pdb.usePolicy }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.zookeeper.component }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.zookeeper.component }}
+  maxUnavailable: {{ .Values.zookeeper.pdb.maxUnavailable }}
+{{- end }}

--- a/docker/kubernetes/templates/zookeeper-service.yaml
+++ b/docker/kubernetes/templates/zookeeper-service.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.zookeeper.component }}
+  annotations:
+{{ toYaml .Values.zookeeper.service.annotations | indent 4 }}
+spec:
+  ports:
+    - name: follower
+      port: {{ .Values.zookeeper.ports.follower }}
+    - name: leader-election
+      port: {{ .Values.zookeeper.ports.leaderElection }}
+    - name: client
+      port: {{ .Values.zookeeper.ports.client }}
+  clusterIP: None
+  selector:
+    {{- include "inlong.matchLabels" . | nindent 4 }}
+    component: {{ .Values.zookeeper.component }}

--- a/docker/kubernetes/templates/zookeeper-statefulset.yaml
+++ b/docker/kubernetes/templates/zookeeper-statefulset.yaml
@@ -1,0 +1,141 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inlong.commonLabels" . | nindent 4 }}
+    component: {{ .Values.zookeeper.component }}
+spec:
+  serviceName: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
+  replicas: {{ .Values.zookeeper.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inlong.matchLabels" . | nindent 6 }}
+      component: {{ .Values.zookeeper.component }}
+  updateStrategy:
+{{ toYaml .Values.zookeeper.updateStrategy | indent 4 }}
+  podManagementPolicy: {{ .Values.zookeeper.podManagementPolicy }}
+  template:
+    metadata:
+      labels:
+        {{- include "inlong.template.labels" . | nindent 8 }}
+        component: {{ .Values.zookeeper.component }}
+      annotations:
+{{ toYaml .Values.zookeeper.annotations | indent 8 }}
+    spec:
+    {{- if .Values.zookeeper.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.zookeeper.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.zookeeper.tolerations }}
+      tolerations:
+{{ toYaml .Values.zookeeper.tolerations | indent 8 }}
+    {{- end }}
+      affinity:
+        {{- if .Values.affinity.anti_affinity}}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "inlong.name" . }}-{{ .Values.zookeeper.component }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.zookeeper.component }}
+            topologyKey: "kubernetes.io/hostname"
+        {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}
+      containers:
+      - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
+        image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
+      {{- if .Values.zookeeper.resources }}
+        resources:
+{{ toYaml .Values.zookeeper.resources | indent 10 }}
+      {{- end }}
+        command: ["sh", "-c"]
+        args:
+        - >
+          /config-scripts/run;
+        ports:
+        - name: client
+          containerPort: {{ .Values.zookeeper.ports.client }}
+        - name: follower
+          containerPort: {{ .Values.zookeeper.ports.follower }}
+        - name: leader-election
+          containerPort: {{ .Values.zookeeper.ports.leaderElection }}
+        env:
+        - name: ZOOKEEPER_SERVERS
+          value:
+            {{- $global := . }}
+            {{ range $i, $e := until (.Values.zookeeper.replicaCount | int) }}{{ if ne $i 0 }},{{ end }}{{ template "inlong.fullname" $global }}-{{ $global.Values.zookeeper.component }}-{{ printf "%d" $i }}{{ end }}
+        {{- if .Values.zookeeper.probe.readiness.enabled }}
+        readinessProbe:
+          exec:
+            command:
+            - /config-scripts/ready
+          initialDelaySeconds: {{ .Values.zookeeper.probe.readiness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.zookeeper.probe.readiness.periodSeconds }}
+          failureThreshold: {{ .Values.zookeeper.probe.readiness.failureThreshold }}
+        {{- end }}
+        {{- if .Values.zookeeper.probe.liveness.enabled }}
+        livenessProbe:
+          exec:
+            command:
+            - /config-scripts/ok
+          initialDelaySeconds: {{ .Values.zookeeper.probe.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.zookeeper.probe.liveness.periodSeconds }}
+          failureThreshold: {{ .Values.zookeeper.probe.liveness.failureThreshold }}
+        {{- end }}
+        volumeMounts:
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}
+          mountPath: /data
+        - name: config
+          mountPath: /config-scripts
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
+          defaultMode: 0755
+      {{- if not .Values.volumes.persistence }}
+      - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}
+        emptyDir: {}
+      {{- end }}
+  {{- if .Values.volumes.persistence }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.zookeeper.volumes.data.size }}
+    {{- if .Values.volumes.storageClassName }}
+      storageClassName: "{{ .Values.volumes.storageClassName }}"
+    {{- end }}
+  {{- end }}

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -1,0 +1,237 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+timezone: "Asia/Shanghai"
+
+images:
+  agent:
+    repository: inlong/agent
+    tag: latest
+  website:
+    repository: inlong/website
+    tag: latest
+  dataproxy:
+    repository: inlong/dataproxy
+    tag: latest
+  tubemqManager:
+    repository: inlong/tubemq-manager
+    tag: latest
+  tubemqServer:
+    repository: inlong/tubemq-all
+    tag: latest
+  managerWeb:
+    repository: inlong/manager-web
+    tag: latest
+  mysql:
+    repository: mysql
+    tag: 5.7
+  zookeeper:
+    repository: zookeeper
+    tag: latest
+  initContainer:
+    repository: busybox
+    tag: latest
+  pullPolicy: "IfNotPresent"
+
+volumes:
+  persistence: false
+  storageClassName: "local-storage"
+
+affinity:
+  anti_affinity: false
+
+ingress:
+  enabled: false
+  hosts:
+
+
+agent:
+  component: "agent"
+  replicaCount: 1
+  ports:
+    agent: 8008
+    managerOpenApi: ${managerWeb.containerPort}
+    dataProxy: ${dataproxy.containerPort}
+
+website:
+  component: "website"
+  replicaCount: 1
+  ports:
+    webPort: 80
+    webNodePort: 80
+  service:
+    type: LoadBalancer
+
+dataproxy:
+  component: "dataproxy"
+  replicaCount: 1
+  containerPort: 46801
+  managerOpenApiPort: ${managerWeb.containerPort}
+
+tubemqManager:
+  component: "tubemq-manager"
+  replicaCount: 1
+  containerPort: 8089
+  #  mysqlHost: "mysql"
+  mysqlUser: "root"
+  mysqlPassword: ${mysql.rootPassword}
+#  tubemqMasterIp: "tubemq-server"
+
+managerWeb:
+  component: "manager-web"
+  replicaCount: 1
+  ports:
+    webPort: 8083
+    webNodePort: 8083
+  activeProfile: "prod"
+  username: "root"
+  password: "inlong"
+  sortAppName: "inlong_hive"
+  service:
+    type: LoadBalancer
+
+mysql:
+  component: "mysql"
+  replicaCount: 2
+  rootPassword: "inlong"
+  ports:
+    server: 3306
+  persistentVolumeClaim:
+    enabled: false
+    accessModes:
+      - "ReadWriteOnce"
+    storageClassName: "-"
+    storage: "8Gi"
+
+zookeeper:
+  component: "zookeeper"
+  replicaCount: 2
+  updateStrategy:
+    type: "RollingUpdate"
+  podManagementPolicy: "OrderedReady"
+  ports:
+    client: 2181
+    follower: 2888
+    leaderElection: 3888
+  probe:
+    liveness:
+      enabled: true
+      failureThreshold: 10
+      initialDelaySeconds: 10
+      periodSeconds: 30
+    readiness:
+      enabled: true
+      failureThreshold: 10
+      initialDelaySeconds: 10
+      periodSeconds: 30
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8000"
+  tolerations: [ ]
+  gracePeriod: 30
+  resources:
+    requests:
+      cpu: 1
+      memory: "1Gi"
+  volumes:
+    data:
+      name: data
+      size: "10Gi"
+  service:
+    annotations:
+      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  pdb:
+    usePolicy: true
+    maxUnavailable: 1
+
+tubemqMaster:
+  component: "tubemq-master"
+  replicaCount: 1
+  updateStrategy:
+    type: "RollingUpdate"
+  podManagementPolicy: "OrderedReady"
+  ports:
+    rpcPort: 8715
+    webPort: 8080
+    webNodePort: 8080
+    helpPort: 9001
+  probe:
+    liveness:
+      enabled: true
+      failureThreshold: 10
+      initialDelaySeconds: 10
+      periodSeconds: 30
+    readiness:
+      enabled: true
+      failureThreshold: 10
+      initialDelaySeconds: 10
+      periodSeconds: 30
+  tolerations: [ ]
+  gracePeriod: 30
+  resources:
+    requests:
+      cpu: 1
+      memory: "1Gi"
+  volumes:
+    data:
+      name: data
+      size: "10Gi"
+  service:
+    type: LoadBalancer
+    annotations:
+      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  pdb:
+    usePolicy: true
+    maxUnavailable: 1
+
+tubemqBroker:
+  component: "tubemq-broker"
+  replicaCount: 1
+  updateStrategy:
+    type: "RollingUpdate"
+  podManagementPolicy: "OrderedReady"
+  ports:
+    rpcPort: 8123
+    webPort: 8081
+  probe:
+    liveness:
+      enabled: true
+      failureThreshold: 10
+      initialDelaySeconds: 10
+      periodSeconds: 30
+    readiness:
+      enabled: true
+      failureThreshold: 10
+      initialDelaySeconds: 10
+      periodSeconds: 30
+  tolerations: []
+  gracePeriod: 30
+  resources:
+    requests:
+      cpu: 1
+      memory: "1Gi"
+  volumes:
+    data:
+      name: data
+      size: "10Gi"
+  service:
+    type: LoadBalancer
+    annotations:
+      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  pdb:
+    usePolicy: true
+    maxUnavailable: 1


### PR DESCRIPTION
Fixes #1308

### Motivation

Add a helm chart to support deploying all modules on Kubernetes.

### Modifications

- add the helm chart to `docker/kubernetes`
