### PR TITLE
[INLONG-1562][K8S] Fix syntax bugs and configuration bugs in helm chart

### DIFF
--- a/docker/kubernetes/templates/_helpers.tpl
+++ b/docker/kubernetes/templates/_helpers.tpl
@@ -17,6 +17,7 @@
 #
 */}}
 
+{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}

--- a/docker/kubernetes/templates/agent-statefulset.yaml
+++ b/docker/kubernetes/templates/agent-statefulset.yaml
@@ -37,35 +37,39 @@ spec:
         component: {{ .Values.agent.component }}
     spec:
       initContainers:
-      - name: wait-website
+      - name: wait-{{ .Values.website.component }}-ready
         image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
-        command: [ "/bin/bash", "-c" ]
+        command: [ "/bin/sh", "-c" ]
         args:
-          - >-
-            for ((i=0;i<{{ .Values.website.replicaCount }};i++))
+          - |
+            count={{ .Values.website.replicaCount }}
+            for i in $(seq 0 $(expr $count - 1))
             do
-              host="{{ template "inlong.fullname" $ }}-{{ .Values.website.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.website.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+              replica="{{ template "inlong.fullname" . }}-{{ .Values.website.component }}-$i"
+              host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.website.component }}.{{ .Release.Namespace }}.svc.cluster.local"
               port={{ .Values.website.ports.webPort }}
-              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
               do
-                echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.website.component }}-$i to be ready"
+                echo "waiting for $replica to be ready"
                 sleep 3
               done
             done
-      - name: wait-dataproxy
+      - name: wait-{{ .Values.dataproxy.component }}-ready
         image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
-        command: [ "/bin/bash", "-c" ]
+        command: [ "/bin/sh", "-c" ]
         args:
-          - >-
-            for ((i=0;i<{{ .Values.dataproxy.replicaCount }};i++))
+          - |
+            count={{ .Values.dataproxy.replicaCount }}
+            for i in $(seq 0 $(expr $count - 1))
             do
-              host="{{ template "inlong.fullname" $ }}-{{ .Values.dataproxy.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.dataproxy.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+              replica="{{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}-$i"
+              host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}.{{ .Release.Namespace }}.svc.cluster.local"
               port={{ .Values.dataproxy.containerPort }}
-              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
               do
-                echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.dataproxy.component }}-$i to be ready"
+                echo "waiting for $replica to be ready"
                 sleep 3
               done
             done
@@ -75,11 +79,11 @@ spec:
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           env:
             - name: MANAGER_OPENAPI_IP
-              value: {{ template "inlong.tubemqManager.hostname" . }}
+              value: {{ include "inlong.tubemqManager.hostname" . | quote }}
             - name: MANAGER_OPENAPI_PORT
               value: {{ .Values.agent.ports.managerOpenApi }}
             - name: DATAPROXY_IP
-              value: {{ template "inlong.dataproxy.hostname" . }}
+              value: {{ include "inlong.dataproxy.hostname" . | quote }}
             - name: DATAPROXY_PORT
               value: {{ .Values.agent.ports.dataProxy }}
           ports:

--- a/docker/kubernetes/templates/broker-pdb.yaml
+++ b/docker/kubernetes/templates/broker-pdb.yaml
@@ -16,7 +16,7 @@
 #
 
 {{- if .Values.tubemqBroker.pdb.usePolicy }}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}

--- a/docker/kubernetes/templates/broker-statefulset.yaml
+++ b/docker/kubernetes/templates/broker-statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       {{- include "inlong.matchLabels" . | nindent 6 }}
       component: {{ .Values.tubemqBroker.component }}
   updateStrategy:
-    {{ toYaml .Values.tubemqBroker.updateStrategy | indent 4 }}
+{{ toYaml .Values.tubemqBroker.updateStrategy | indent 4 }}
   podManagementPolicy: {{ .Values.tubemqBroker.podManagementPolicy }}
   template:
     metadata:
@@ -39,59 +39,68 @@ spec:
         {{- include "inlong.template.labels" . | nindent 8 }}
         component: {{ .Values.tubemqBroker.component }}
       annotations:
-    {{ toYaml .Values.tubemqBroker.annotations | indent 8 }}
+{{ toYaml .Values.tubemqBroker.annotations | indent 8 }}
     spec:
       {{- if .Values.tubemqBroker.nodeSelector }}
       nodeSelector:
-      {{ toYaml .Values.tubemqBroker.nodeSelector | indent 8 }}
+{{ toYaml .Values.tubemqBroker.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.tubemqBroker.tolerations }}
       tolerations:
-      {{ toYaml .Values.tubemqBroker.tolerations | indent 8 }}
+{{ toYaml .Values.tubemqBroker.tolerations | indent 8 }}
       {{- end }}
       initContainers:
-        - name: wait-master-ready
-          image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
+        - name: wait-{{ .Values.tubemqMaster.component }}-ready
+          image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
-          command: [ "/bin/bash", "-c" ]
+          command: [ "/bin/sh", "-c" ]
           args:
-            - >-
-              for ((i=0;i<{{ .Values.tubemqMaster.replicaCount }};i++)); do
-              until curl {{ template "inlong.fullname" $ }}-{{ .Values.tubemqMaster.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.tubemqMaster.component }}.{{ .Release.Namespace }}.svc.cluster.local:${1:-8080}/index.htm; do
-              sleep 3; done; done;
+            - |
+              count={{ .Values.tubemqMaster.replicaCount }}
+              for i in $(seq 0 $(expr $count - 1))
+              do
+                replica="{{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-$i"
+                host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+                port={{ .Values.tubemqMaster.ports.webNodePort }}
+                until curl $host:$port/index.htm
+                do
+                  echo "waiting for $replica to be ready"
+                  sleep 3
+                done
+              done
       affinity:
         {{- if .Values.affinity.anti_affinity }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: "app"
-                operator: In
-                values:
-                - "{{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}"
-              - key: "release"
-                operator: In
-                values:
-                - {{ .Release.Name }}
-              - key: "component"
-                operator: In
-                values:
-                - {{ .Values.tubemqBroker.component }}
-            topologyKey: "kubernetes.io/hostname"
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - "{{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}"
+                  - key: "release"
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+                  - key: "component"
+                    operator: In
+                    values:
+                      - {{ .Values.tubemqBroker.component }}
+              topologyKey: "kubernetes.io/hostname"
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.tubemqBroker.gracePeriod }}
       containers:
-        - name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}
           image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- if .Values.tubemqBroker.resources }}
           resources:
-          {{ toYaml .Values.tubemqBroker.resources | indent 10 }}
+{{ toYaml .Values.tubemqBroker.resources | indent 12 }}
           {{- end }}
-          command: [ "sh", "-c" ]
+          command: [ "/bin/sh", "-c" ]
           args:
             - >
-              /config-scripts/run;
+              /config-scripts/run
           ports:
             - name: web-port
               containerPort: {{ .Values.tubemqBroker.ports.webPort }}
@@ -121,7 +130,7 @@ spec:
             failureThreshold: {{ .Values.tubemqBroker.probe.liveness.failureThreshold }}
           {{- end }}
           volumeMounts:
-            - name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.data.name }}
+            - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.data.name }}
               mountPath: /data
             - name: config
               mountPath: /config-scripts
@@ -132,26 +141,26 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}
+            name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}
             defaultMode: 0755
         - name: {{ .Values.tubemqBroker.component }}-ini
           configMap:
-            name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}-ini
+            name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-ini
             defaultMode: 0644
         {{- if not .Values.volumes.persistence }}
-        - name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.data.name }}
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.data.name }}
           emptyDir: {}
         {{- end }}
   {{- if .Values.volumes.persistence }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ template "inlong.name" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.data.name }}
+        name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.data.name }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
         resources:
           requests:
             storage: {{ .Values.tubemqBroker.volumes.data.size }}
         {{- if .Values.volumes.storageClassName }}
-        storageClassName: {{ .Values.volumes.storageClassName }}
+        storageClassName: "{{ .Values.volumes.storageClassName }}"
         {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/dataproxy-statefulset.yaml
+++ b/docker/kubernetes/templates/dataproxy-statefulset.yaml
@@ -37,19 +37,21 @@ spec:
         component: {{ .Values.dataproxy.component }}
     spec:
       initContainers:
-      - name: wait-manager-web
+      - name: wait-{{ .Values.managerWeb.component }}-ready
         image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
-        command: [ "/bin/bash", "-c" ]
+        command: [ "/bin/sh", "-c" ]
         args:
-          - >-
-            for ((i=0;i<{{ .Values.managerWeb.replicaCount }};i++))
+          - |
+            count={{ .Values.managerWeb.replicaCount }}
+            for i in $(seq 0 $(expr $count - 1))
             do
-              host="{{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}.{{ .Release.Namespace }}.svc.cluster.local"
-              port={{ .Values.managerWeb.ports.webPort }}
-              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+              replica="{{ template "inlong.fullname" . }}-{{ .Values.managerWeb.component }}-$i"
+              host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.managerWeb.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+              port={{ .Values.managerWeb.ports.webNodePort }}
+              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
               do
-                echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}-$i to be ready"
+                echo "waiting for $replica to be ready"
                 sleep 3
               done
             done
@@ -59,11 +61,11 @@ spec:
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           env:
             - name: MANAGER_OPENAPI_IP
-              value: {{ template "inlong.managerWeb.hostname" . }}
+              value: {{ include "inlong.managerWeb.hostname" . | quote }}
             - name: MANAGER_OPENAPI_PORT
               value: {{ .Values.dataproxy.managerOpenApiPort }}
             - name: TUBMQ_MASTER_LIST
-              value: "{{ template "inlong.tubemqMaster.hostname" . }}:{{ .Values.tubemqMaster.ports.rpcPort}}"
+              value: "{{ template "inlong.tubemqMaster.hostname" . }}:{{ .Values.tubemqMaster.ports.rpcPort }}"
           ports:
             - name: {{ .Values.dataproxy.component }}-port
               containerPort: 46801

--- a/docker/kubernetes/templates/manager-web-statefulset.yaml
+++ b/docker/kubernetes/templates/manager-web-statefulset.yaml
@@ -37,31 +37,33 @@ spec:
         component: {{ .Values.managerWeb.component }}
     spec:
       initContainers:
-        - name: wait-tubemq-manager
+        - name: wait-{{ .Values.tubemqManager.component }}-ready
           image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
-          command: [ "/bin/bash", "-c" ]
+          command: [ "/bin/sh", "-c" ]
           args:
-            - >-
-              for ((i=0;i<{{ .Values.tubemqManager.replicaCount }};i++))
+            - |
+              count={{ .Values.tubemqManager.replicaCount }}
+              for i in $(seq 0 $(expr $count - 1))
               do
-                host="{{ template "inlong.fullname" $ }}-{{ .Values.tubemqManager.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.tubemqManager.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+                replica="{{ template "inlong.fullname" . }}-{{ .Values.tubemqManager.component }}-$i"
+                host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.tubemqManager.component }}.{{ .Release.Namespace }}.svc.cluster.local"
                 port={{ .Values.tubemqManager.containerPort }}
-                until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+                until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
                 do
-                  echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.tubemqManager.component }}-$i to be ready"
+                  echo "waiting for $replica to be ready"
                   sleep 3
                 done
               done
       containers:
-        - name: {{ template "inlong.name" . }}-{{ .Values.managerWeb.component }}
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.managerWeb.component }}
           image: {{ .Values.images.managerWeb.repository }}:{{ .Values.images.managerWeb.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           env:
             - name: ACTIVE_PROFILE
               value: {{ .Values.managerWeb.activeProfile }}
             - name: JDBC_URL
-              value: "{{ template "inlong.mysql.hostname" }}:{{ .Values.mysql.ports.server }}"
+              value: "{{ template "inlong.mysql.hostname" . }}:{{ .Values.mysql.ports.server }}"
             - name: USERNAME
               value: {{ .Values.managerWeb.username }}
             - name: PASSWORD

--- a/docker/kubernetes/templates/master-pdb.yaml
+++ b/docker/kubernetes/templates/master-pdb.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-  {{- if .Values.tubemqMaster.pdb.usePolicy }}
+{{- if .Values.tubemqMaster.pdb.usePolicy }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/docker/kubernetes/templates/master-statefulset.yaml
+++ b/docker/kubernetes/templates/master-statefulset.yaml
@@ -41,119 +41,128 @@ spec:
       annotations:
 {{ toYaml .Values.tubemqMaster.annotations | indent 8 }}
     spec:
-    {{- if .Values.tubemqMaster.nodeSelector }}
+      {{- if .Values.tubemqMaster.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.tubemqMaster.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.tubemqMaster.tolerations }}
+      {{- end }}
+      {{- if .Values.tubemqMaster.tolerations }}
       tolerations:
 {{ toYaml .Values.tubemqMaster.tolerations | indent 8 }}
-    {{- end }}
+      {{- end }}
       initContainers:
-        - name: wait-zk-ready
-          image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
+        - name: wait-{{ .Values.zookeeper.component }}-ready
+          image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
-          command: ["/bin/bash", "-c"]
+          command: [ "/bin/sh", "-c" ]
           args:
-            - >-
-              for ((i=0;i<{{ .Values.zookeeper.replicaCount }};i++)); do
-              until echo ruok | nc {{ template "inlong.fullname" $ }}-{{ .Values.zookeeper.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }}.svc.cluster.local ${1:-2181}; do
-              sleep 3; done; done;
+            - |
+              count={{ .Values.zookeeper.replicaCount }}
+              for i in $(seq 0 $(expr $count - 1))
+              do
+                replica="{{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-$i"
+                host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+                port={{ .Values.zookeeper.ports.client }}
+                until [ $(echo ruok | nc $host $port ) = 'imok' ]
+                do
+                  echo "waiting for $replica to be ready"
+                  sleep 3
+                done
+              done
       affinity:
-        {{- if .Values.affinity.anti_affinity}}
+        {{- if .Values.affinity.anti_affinity }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: "app"
-                operator: In
-                values:
-                - "{{ template "inlong.name" . }}-{{ .Values.tubemqMaster.component }}"
-              - key: "release"
-                operator: In
-                values:
-                - {{ .Release.Name }}
-              - key: "component"
-                operator: In
-                values:
-                - {{ .Values.tubemqMaster.component }}
-            topologyKey: "kubernetes.io/hostname"
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - "{{ template "inlong.name" . }}-{{ .Values.tubemqMaster.component }}"
+                  - key: "release"
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+                  - key: "component"
+                    operator: In
+                    values:
+                      - {{ .Values.tubemqMaster.component }}
+              topologyKey: "kubernetes.io/hostname"
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.tubemqMaster.gracePeriod }}
       containers:
-      - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
-        image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
-        imagePullPolicy: {{ .Values.images.pullPolicy }}
-      {{- if .Values.tubemqMaster.resources }}
-        resources:
-{{ toYaml .Values.tubemqMaster.resources | indent 10 }}
-      {{- end }}
-        command: ["sh", "-c"]
-        args:
-        - >
-          /config-scripts/run;
-        ports:
-        - name: web-port
-          containerPort: {{ .Values.tubemqMaster.ports.webPort }}
-        - name: help-port
-          containerPort: {{ .Values.tubemqMaster.ports.helpPort }}
-        - name: rpc-port
-          containerPort: {{ .Values.tubemqMaster.ports.rpcPort }}
-        env:
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        {{- if .Values.tubemqMaster.probe.readiness.enabled }}
-        readinessProbe:
-          exec:
-            command:
-            - /config-scripts/ready
-          initialDelaySeconds: {{ .Values.tubemqMaster.probe.readiness.initialDelaySeconds }}
-          periodSeconds: {{ .Values.tubemqMaster.probe.readiness.periodSeconds }}
-          failureThreshold: {{ .Values.tubemqMaster.probe.readiness.failureThreshold }}
-        {{- end }}
-        {{- if .Values.tubemqMaster.probe.liveness.enabled }}
-        livenessProbe:
-          exec:
-            command:
-            - /config-scripts/ok
-          initialDelaySeconds: {{ .Values.tubemqMaster.probe.liveness.initialDelaySeconds }}
-          periodSeconds: {{ .Values.tubemqMaster.probe.liveness.periodSeconds }}
-          failureThreshold: {{ .Values.tubemqMaster.probe.liveness.failureThreshold }}
-        {{- end }}
-        volumeMounts:
-        - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.data.name }}
-          mountPath: /data
-        - name: config
-          mountPath: /config-scripts
-        - name: {{ .Values.tubemqMaster.component }}-ini
-          mountPath: /opt/tubemq-server/conf/{{ .Values.tubemqMaster.component }}.ini.raw
-          subPath: {{ .Values.tubemqMaster.component }}.ini.raw
-          readOnly: false
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
+          image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          {{- if .Values.tubemqMaster.resources }}
+          resources:
+{{ toYaml .Values.tubemqMaster.resources | indent 12 }}
+          {{- end }}
+          command: [ "/bin/sh", "-c" ]
+          args:
+            - >
+              /config-scripts/run
+          ports:
+            - name: web-port
+              containerPort: {{ .Values.tubemqMaster.ports.webPort }}
+            - name: help-port
+              containerPort: {{ .Values.tubemqMaster.ports.helpPort }}
+            - name: rpc-port
+              containerPort: {{ .Values.tubemqMaster.ports.rpcPort }}
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          {{- if .Values.tubemqMaster.probe.readiness.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - /config-scripts/ready
+            initialDelaySeconds: {{ .Values.tubemqMaster.probe.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.tubemqMaster.probe.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.tubemqMaster.probe.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.tubemqMaster.probe.liveness.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - /config-scripts/ok
+            initialDelaySeconds: {{ .Values.tubemqMaster.probe.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.tubemqMaster.probe.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.tubemqMaster.probe.liveness.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.data.name }}
+              mountPath: /data
+            - name: config
+              mountPath: /config-scripts
+            - name: {{ .Values.tubemqMaster.component }}-ini
+              mountPath: /opt/tubemq-server/conf/{{ .Values.tubemqMaster.component }}.ini.raw
+              subPath: {{ .Values.tubemqMaster.component }}.ini.raw
+              readOnly: false
       volumes:
-      - name: config
-        configMap:
-          name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
-          defaultMode: 0755
-      - name: {{ .Values.tubemqMaster.component }}-ini
-        configMap:
-          name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-ini
-          defaultMode: 0644
-      {{- if not .Values.volumes.persistence }}
-      - name: "{{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.data.name }}"
-        emptyDir: {}
-      {{- end }}
+        - name: config
+          configMap:
+            name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}
+            defaultMode: 0755
+        - name: {{ .Values.tubemqMaster.component }}-ini
+          configMap:
+            name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-ini
+            defaultMode: 0644
+        {{- if not .Values.volumes.persistence }}
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.data.name }}
+          emptyDir: {}
+        {{- end }}
   {{- if .Values.volumes.persistence }}
   volumeClaimTemplates:
-  - metadata:
-      name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.data.name }}
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: {{ .Values.tubemqMaster.volumes.data.size }}
-    {{- if .Values.volumes.storageClassName }}
-      storageClassName: "{{ .Values.volumes.storageClassName }}"
-    {{- end }}
+    - metadata:
+        name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.data.name }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.tubemqMaster.volumes.data.size }}
+        {{- if .Values.volumes.storageClassName }}
+        storageClassName: "{{ .Values.volumes.storageClassName }}"
+        {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/mysql-statefulset.yaml
+++ b/docker/kubernetes/templates/mysql-statefulset.yaml
@@ -58,14 +58,14 @@ spec:
         - name: data
           {{- if .Values.mysql.persistentVolumeClaim.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}-pvc
+            claimName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
           {{- else }}
           emptyDir: {}
           {{- end }}
         - name: sql
           {{- if .Values.mysql.persistentVolumeClaim.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}-pvc
+            claimName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/docker/kubernetes/templates/tubemq-manager-service.yaml
+++ b/docker/kubernetes/templates/tubemq-manager-service.yaml
@@ -29,5 +29,5 @@ spec:
       port: {{ .Values.tubemqManager.containerPort }}
   type: ClusterIP
   selector:
-    {{- include "inlong.matchLabels" . | nindent 6 }}
+    {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.tubemqManager.component }}

--- a/docker/kubernetes/templates/tubemq-manager-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-manager-statefulset.yaml
@@ -37,45 +37,49 @@ spec:
         component: {{ .Values.tubemqManager.component }}
     spec:
       initContainers:
-        - name: wait-mysql-ready
+        - name: wait-{{ .Values.mysql.component }}-ready
           image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
-          command: ["/bin/bash", "-c"]
+          command: [ "/bin/sh", "-c" ]
           args:
-            - >-
-              for ((i=0;i<{{ .Values.mysql.replicaCount }};i++))
+            - |
+              count={{ .Values.mysql.replicaCount }}
+              for i in $(seq 0 $(expr $count - 1))
               do
-                host="{{ template "inlong.fullname" $ }}-{{ .Values.mysql.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.mysql.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+                replica="{{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}-$i"
+                host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}.{{ .Release.Namespace }}.svc.cluster.local"
                 port={{ .Values.mysql.ports.server }}
-                until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+                until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
                 do
-                  echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.mysql.component }}-$i to be ready"
+                  echo "waiting for $replica to be ready"
                   sleep 3
                 done
               done
-        - name: wait-tubemq-master
+        - name: wait-{{ .Values.tubemqMaster.component }}-ready
           image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
-          command: ["/bin/bash", "-c"]
+          command: [ "/bin/sh", "-c" ]
           args:
-            - >-
-              for ((i=0;i<{{ .Values.tubemqMaster.replicaCount }};i++))
+            - |
+              count={{ .Values.tubemqMaster.replicaCount }}
+              for i in $(seq 0 $(expr $count - 1))
               do
-                host="{{ template "inlong.fullname" $ }}-{{ .Values.tubemqMaster.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.tubemqMaster.component }}.{{ .Release.Namespace }}.svc.cluster.local"
-                port={{ .Values.tubemqMaster.ports.rpcPort }}
-                until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+                replica="{{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-$i"
+                host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+                port={{ .Values.tubemqMaster.ports.webNodePort }}
+                until curl $host:$port/index.htm
                 do
-                  echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.tubemqMaster.component }}-$i to be ready"
+                  echo "waiting for $replica to be ready"
                   sleep 3
                 done
               done
       containers:
-        - name: {{ template "inlong.name" . }}-{{ .Values.tubemqManager.component }}
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqManager.component }}
           image: {{ .Values.images.tubemqManager.repository }}:{{ .Values.images.tubemqManager.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           env:
             - name: MYSQL_HOST
-              value: {{ template "inlong.mysql.hostname" }}
+              value: {{ include "inlong.mysql.hostname" . | quote }}
             - name: MYSQL_USER
               value: {{ .Values.tubemqManager.mysqlUser | quote }}
             - name: MYSQL_PASSWD
@@ -84,7 +88,7 @@ spec:
                   name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
                   key: mysql-root-password
             - name: TUBE_MASTER_IP
-              value: {{ include "inlong.tubemqMaster.hostname" . | quote}}
+              value: {{ include "inlong.tubemqMaster.hostname" . | quote }}
           ports:
             - name: {{ .Values.tubemqManager.component }}-port
               containerPort: 8089

--- a/docker/kubernetes/templates/website-statefulset.yaml
+++ b/docker/kubernetes/templates/website-statefulset.yaml
@@ -37,24 +37,26 @@ spec:
         component: {{ .Values.website.component }}
     spec:
       initContainers:
-      - name: wait-manager-web
+      - name: wait-{{ .Values.managerWeb.component }}-ready
         image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
-        command: [ "/bin/bash", "-c" ]
+        command: [ "/bin/sh", "-c" ]
         args:
-          - >-
-            for ((i=0;i<{{ .Values.managerWeb.replicaCount }};i++))
+          - |
+            count={{ .Values.managerWeb.replicaCount }}
+            for i in $(seq 0 $(expr $count - 1))
             do
-              host="{{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}-$i.{{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}.{{ .Release.Namespace }}.svc.cluster.local"
-              port={{ .Values.managerWeb.ports.webPort }}
-              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0]
+              replica="{{ template "inlong.fullname" . }}-{{ .Values.managerWeb.component }}-$i"
+              host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.managerWeb.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+              port={{ .Values.managerWeb.ports.webNodePort }}
+              until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
               do
-                echo "waiting for {{ template "inlong.fullname" $ }}-{{ .Values.managerWeb.component }}-$i to be ready"
+                echo "waiting for $replica to be ready"
                 sleep 3
               done
             done
       containers:
-        - name: {{ template "inlong.name" . }}-{{ .Values.website.component }}
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.website.component }}
           image: {{ .Values.images.website.repository }}:{{ .Values.images.tubemqManager.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           env:

--- a/docker/kubernetes/templates/zookeeper-statefulset.yaml
+++ b/docker/kubernetes/templates/zookeeper-statefulset.yaml
@@ -41,101 +41,102 @@ spec:
       annotations:
 {{ toYaml .Values.zookeeper.annotations | indent 8 }}
     spec:
-    {{- if .Values.zookeeper.nodeSelector }}
+      {{- if .Values.zookeeper.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.zookeeper.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.zookeeper.tolerations }}
+      {{- end }}
+      {{- if .Values.zookeeper.tolerations }}
       tolerations:
 {{ toYaml .Values.zookeeper.tolerations | indent 8 }}
-    {{- end }}
+      {{- end }}
       affinity:
-        {{- if .Values.affinity.anti_affinity}}
+        {{- if .Values.affinity.anti_affinity }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: "app"
-                operator: In
-                values:
-                - "{{ template "inlong.name" . }}-{{ .Values.zookeeper.component }}"
-              - key: "release"
-                operator: In
-                values:
-                - {{ .Release.Name }}
-              - key: "component"
-                operator: In
-                values:
-                - {{ .Values.zookeeper.component }}
-            topologyKey: "kubernetes.io/hostname"
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - "{{ template "inlong.name" . }}-{{ .Values.zookeeper.component }}"
+                  - key: "release"
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+                  - key: "component"
+                    operator: In
+                    values:
+                      - {{ .Values.zookeeper.component }}
+              topologyKey: "kubernetes.io/hostname"
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}
       containers:
-      - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
-        image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
-        imagePullPolicy: {{ .Values.images.pullPolicy }}
-      {{- if .Values.zookeeper.resources }}
-        resources:
-{{ toYaml .Values.zookeeper.resources | indent 10 }}
-      {{- end }}
-        command: ["sh", "-c"]
-        args:
-        - >
-          /config-scripts/run;
-        ports:
-        - name: client
-          containerPort: {{ .Values.zookeeper.ports.client }}
-        - name: follower
-          containerPort: {{ .Values.zookeeper.ports.follower }}
-        - name: leader-election
-          containerPort: {{ .Values.zookeeper.ports.leaderElection }}
-        env:
-        - name: ZOOKEEPER_SERVERS
-          value:
-            {{- $global := . }}
-            {{ range $i, $e := until (.Values.zookeeper.replicaCount | int) }}{{ if ne $i 0 }},{{ end }}{{ template "inlong.fullname" $global }}-{{ $global.Values.zookeeper.component }}-{{ printf "%d" $i }}{{ end }}
-        {{- if .Values.zookeeper.probe.readiness.enabled }}
-        readinessProbe:
-          exec:
-            command:
-            - /config-scripts/ready
-          initialDelaySeconds: {{ .Values.zookeeper.probe.readiness.initialDelaySeconds }}
-          periodSeconds: {{ .Values.zookeeper.probe.readiness.periodSeconds }}
-          failureThreshold: {{ .Values.zookeeper.probe.readiness.failureThreshold }}
-        {{- end }}
-        {{- if .Values.zookeeper.probe.liveness.enabled }}
-        livenessProbe:
-          exec:
-            command:
-            - /config-scripts/ok
-          initialDelaySeconds: {{ .Values.zookeeper.probe.liveness.initialDelaySeconds }}
-          periodSeconds: {{ .Values.zookeeper.probe.liveness.periodSeconds }}
-          failureThreshold: {{ .Values.zookeeper.probe.liveness.failureThreshold }}
-        {{- end }}
-        volumeMounts:
-        - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}
-          mountPath: /data
-        - name: config
-          mountPath: /config-scripts
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
+          image: {{ .Values.images.tubemqServer.repository }}:{{ .Values.images.tubemqServer.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          {{- if .Values.zookeeper.resources }}
+          resources:
+{{ toYaml .Values.zookeeper.resources | indent 12 }}
+          {{- end }}
+          command: [ "/bin/sh", "-c" ]
+          args:
+            - >
+              /config-scripts/run
+          ports:
+            - name: client
+              containerPort: {{ .Values.zookeeper.ports.client }}
+            - name: follower
+              containerPort: {{ .Values.zookeeper.ports.follower }}
+            - name: leader-election
+              containerPort: {{ .Values.zookeeper.ports.leaderElection }}
+          env:
+            - name: ZOOKEEPER_SERVERS
+              value:
+                {{- $global := . }}
+                {{ range $i, $e := until (.Values.zookeeper.replicaCount | int) }}{{ if ne $i 0 }},{{ end }}{{ template "inlong.fullname" $global }}-{{ $global.Values.zookeeper.component }}-{{ printf "%d" $i }}{{ end }}
+          {{- if .Values.zookeeper.probe.readiness.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - /config-scripts/ready
+            initialDelaySeconds: {{ .Values.zookeeper.probe.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.zookeeper.probe.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.zookeeper.probe.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.zookeeper.probe.liveness.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - /config-scripts/ok
+            initialDelaySeconds: {{ .Values.zookeeper.probe.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.zookeeper.probe.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.zookeeper.probe.liveness.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}
+              mountPath: /data
+            - name: config
+              mountPath: /config-scripts
       volumes:
-      - name: config
-        configMap:
-          name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
-          defaultMode: 0755
-      {{- if not .Values.volumes.persistence }}
-      - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}
-        emptyDir: {}
-      {{- end }}
+        - name: config
+          configMap:
+            name:
+              {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
+            defaultMode: 0755
+        {{- if not .Values.volumes.persistence }}
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}
+          emptyDir: {}
+        {{- end }}
   {{- if .Values.volumes.persistence }}
   volumeClaimTemplates:
-  - metadata:
-      name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: {{ .Values.zookeeper.volumes.data.size }}
-    {{- if .Values.volumes.storageClassName }}
-      storageClassName: "{{ .Values.volumes.storageClassName }}"
-    {{- end }}
+    - metadata:
+        name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.zookeeper.volumes.data.size }}
+        {{- if .Values.volumes.storageClassName }}
+        storageClassName: "{{ .Values.volumes.storageClassName }}"
+        {{- end }}
   {{- end }}

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -58,7 +58,6 @@ ingress:
   enabled: false
   hosts:
 
-
 agent:
   component: "agent"
   replicaCount: 1
@@ -86,10 +85,8 @@ tubemqManager:
   component: "tubemq-manager"
   replicaCount: 1
   containerPort: 8089
-  #  mysqlHost: "mysql"
   mysqlUser: "root"
   mysqlPassword: ${mysql.rootPassword}
-#  tubemqMasterIp: "tubemq-server"
 
 managerWeb:
   component: "manager-web"
@@ -106,7 +103,7 @@ managerWeb:
 
 mysql:
   component: "mysql"
-  replicaCount: 2
+  replicaCount: 1
   rootPassword: "inlong"
   ports:
     server: 3306
@@ -119,7 +116,7 @@ mysql:
 
 zookeeper:
   component: "zookeeper"
-  replicaCount: 2
+  replicaCount: 1
   updateStrategy:
     type: "RollingUpdate"
   podManagementPolicy: "OrderedReady"
@@ -141,7 +138,7 @@ zookeeper:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8000"
-  tolerations: [ ]
+  tolerations: []
   gracePeriod: 30
   resources:
     requests:
@@ -180,7 +177,7 @@ tubemqMaster:
       failureThreshold: 10
       initialDelaySeconds: 10
       periodSeconds: 30
-  tolerations: [ ]
+  tolerations: []
   gracePeriod: 30
   resources:
     requests:


### PR DESCRIPTION
fix: #1562

### Motivation

There are some syntax bugs and configuration bugs in helm chart.

For example:

https://github.com/apache/incubator-inlong/blob/51523c7d66845fc6c8183cc27cb1ce068bebcdf5/docker/kubernetes/templates/tubemq-manager-statefulset.yaml#L78

It should be `{{ template "inlong.mysql.hostname" . }}`

Besides, the `busybox` image don't support `/bin/bash`, so it should uses `/bin/sh`.

Etc., etc. I will fix it right away.

### Modifications

- `docker/kubernetes/template/*.yaml`
- `docker/kubernetes/template/_helpers.tpl`
- `docker/kubernetes/values.yaml`
- `docker/kubernetes/values.yaml`: `CRLF` -> `LF`

### Documentation

I will complete the documentation in another PR.
