### PR TITLE
[INLONG-1571][CI] Add check license header workflow

### DIFF
--- a/.github/workflows/ci_check_license.yml
+++ b/.github/workflows/ci_check_license.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check License Header
-        uses: apache/skywalking-eyes@v0.1.0
+        uses: apache/skywalking-eyes@ed749b83e23f10eae9c379870c3d5ed45ce4e67a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ci_check_license.yml
+++ b/.github/workflows/ci_check_license.yml
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: InLong Check License Header
+
+on:
+  push:
+    branches: [ master, 'INLONG-*' ]
+  pull_request:
+    branches: [ master, 'INLONG-*' ]
+
+jobs:
+  build:
+    name: Check License Header
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check License Header
+        uses: apache/skywalking-eyes@v0.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          log: info
+          config: .licenserc.yaml

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -21,21 +21,67 @@ header:
     copyright-owner: Apache Software Foundation
 
   paths-ignore:
-    - 'licenses'
-    - '**/lib/**'
+    # Exclude license copies
+    - 'licenses/**'
+
+    # Exclude generated content
     - 'LICENSE'
     - 'NOTICE'
-    - '**/.gitignore'
-    - '**/*.json'
+    - 'DISCLAIMER-WIP'
+    - 'codestyle/**'
+
+    # Documents
     - '**/*.md'
+    - '**/*.MD'
+    - '**/*.txt'
     - '**/*.key'
     - '**/*.crt'
     - '**/*.pem'
+    - '**/*.json'
     - '**/*.csv'
+    - '**/*.log'
+    - '**/logs/**'
+    - '**/docs/**'
 
-    # Exclude local files
-    # - '**/target/**'
-    # - '**/build/**'
-    # - '**/node_modules/**'
+    # Web configure files
+    - '**/.env'
+    - '**/.env.production'
+    - '**/.eslintignore'
+    - '**/.eslintrc'
+    - '**/.headerignore'
+    - '**/.prettierrc'
+    - '**/.stylelintrc'
+    - '**/build/**'
+    - '**/node_modules/**'
+
+    # Git files
+    - '**/.gitignore'
+    - '**/.gitmodules'
+    - '**/.git/**'
+
+    # GitHub
+    - '**/.github/**'
+
+    # Intellij IDEA
+    - '**/*.iml'
+    - '**/.idea/**'
+
+    # Build targets
+    - '**/target/**'
+    - '**/out/**'
+    - '**/dist/**'
+
+    # Test case: certificates used in test cases
+    - '**/tubemq-core/src/test/resources/*.keystore'
+
+    # Test case: temporary data for test cases
+    - '**/AgentBaseTestsHelper/**'
+
+    # Referenced 3rd codes
+    - '**/resources/assets/lib/**'
+    - '**/resources/assets/public/**'
+    - '**/tubemq-client-cpp/src/any.h'
+    - '**/tubemq-client-cpp/src/buffer.h'
+    - '**/tubemq-client-cpp/third_party/**'
 
   comment: on-failure

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Apache Software Foundation
+
+  paths-ignore:
+    - 'licenses'
+    - '**/lib/**'
+    - 'LICENSE'
+    - 'NOTICE'
+    - '**/.gitignore'
+    - '**/*.json'
+    - '**/*.md'
+    - '**/*.key'
+    - '**/*.crt'
+    - '**/*.pem'
+    - '**/*.csv'
+
+    # Exclude local files
+    # - '**/target/**'
+    # - '**/build/**'
+    # - '**/node_modules/**'
+
+  comment: on-failure


### PR DESCRIPTION
fix: #1571

### Motivation

We can use [SkyWalking Eyes](https://github.com/marketplace/actions/license-eye) to check license headers. 

### Modifications

- `.github/workflows/ci_check_license.yml`
- `.licenserc.yaml`
