### PR TITLE
[INLONG-1587][Sort] Fix compile error

### DIFF
--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -220,6 +220,10 @@
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-slf4j-impl</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hbase</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -276,6 +280,10 @@
                         <groupId>org.apache.parquet</groupId>
                         <artifactId>parquet-hadoop-bundle</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hbase</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -303,6 +311,10 @@
                     <exclusion>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-slf4j-impl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hbase</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
Fixes #1587 

### Motivation

When compile under JDK11, it will build failed. And the latest Intellij IDEA internal is jdk11.

```
[ERROR] Failed to execute goal on project sort-core: Could not resolve dependencies for project org.apache.inlong:sort-core:jar:0.11.0-incubating-SNAPSHOT: Could not find artifact jdk.tools:jdk.tools:jar:1.7 at specified path /work/JAVA_WORK/jdk/jdk/../lib/tools.jar -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
```
### Modifications

Exclude hbase dependency.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
