### PR TITLE
[INLONG-1593][checkstyle] Add EmptyLineSeparator java code checkstyle rule

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -429,12 +429,23 @@
             <property name="tokens" value="BLOCK_COMMENT_BEGIN"/>
         </module>
 
-
         <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
         <module name="SuppressionXpathFilter">
             <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
                       default="checkstyle-xpath-suppressions.xml" />
             <property name="optional" value="true"/>
+        </module>
+
+        <module name="EmptyLineSeparator">
+            <!-- Checks for empty line separator between tokens. The only
+                 excluded token is VARIABLE_DEF, allowing class fields to
+                 be declared on consecutive lines.
+            -->
+            <property name="allowMultipleEmptyLines" value="false"/>
+            <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+            <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF,
+                                           INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF,
+                                           CTOR_DEF"/>
         </module>
     </module>
 </module>

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/common/AgentThreadFactory.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/common/AgentThreadFactory.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.common;
 
-
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constants/AgentConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constants/AgentConstants.java
@@ -97,7 +97,6 @@ public class AgentConstants {
     public static final String JOB_THREAD_RUNNING_CORE = "job.thread.running.core";
     public static final int DEFAULT_JOB_THREAD_RUNNING_CORE = 4;
 
-
     public static final String JOB_MONITOR_INTERVAL = "job.monitor.interval";
     public static final int DEFAULT_JOB_MONITOR_INTERVAL = 5;
 

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constants/CommonConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constants/CommonConstants.java
@@ -29,7 +29,6 @@ public class CommonConstants {
 
     public static final String PROXY_TID = "proxy.tid";
 
-
     public static final String PROXY_LOCAL_HOST = "proxy.localHost";
     public static final String DEFAULT_PROXY_LOCALHOST = AgentUtils.getLocalIp();
 
@@ -122,15 +121,12 @@ public class CommonConstants {
     public static final String PULSAR_PRODUCER_BLOCK_QUEUE = "pulsar.producer.block.queue";
     public static final boolean DEFAULT_PULSAR_PRODUCER_BLOCK_QUEUE = true;
 
-
     public static final String FILE_MAX_NUM = "file.max.num";
     public static final int DEFAULT_FILE_MAX_NUM = 4096;
 
     public static final String TRIGGER_ID_PREFIX = "trigger_";
 
-
     public static final String COMMAND_STORE_INSTANCE_NAME = "commandStore";
-
 
     public static final String AGENT_OS_NAME = "os.name";
     public static final String AGENT_NIX_OS = "nix";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constants/JobConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constants/JobConstants.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.constants;
 
-
 /**
  * Basic config for a single job
  */
@@ -28,7 +27,6 @@ public class JobConstants extends CommonConstants {
     public static final String JOB_INSTANCE_ID = "job.instance.id";
     public static final String JOB_IP = "job.ip";
     public static final String JOB_RETRY = "job.retry";
-
 
     public static final String JOB_SOURCE = "job.source";
     public static final String JOB_SINK = "job.sink";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/BerkeleyDbImp.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/BerkeleyDbImp.java
@@ -141,13 +141,11 @@ public class BerkeleyDbImp implements Db {
         return primaryIndex.get(key);
     }
 
-
     @Override
     public CommandEntity getCommand(String commandId) {
         requireNonNull(commandId);
         return commandPrimaryIndex.get(commandId);
     }
-
 
     @Override
     public CommandEntity putCommand(CommandEntity entity) {

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/CommandDb.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/CommandDb.java
@@ -49,7 +49,6 @@ public class CommandDb {
         return db.searchCommands(false);
     }
 
-
     /**
      * save normal command result for trigger
      * @param profile

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/CommandEntity.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/CommandEntity.java
@@ -25,7 +25,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-
 @Entity(version = 1)
 @Data
 @AllArgsConstructor
@@ -38,7 +37,6 @@ public class CommandEntity {
     private boolean isAcked;
     private String taskId;
     private String deliveryTime;
-
 
     public static String generateCommanid(String taskId, int opType) {
         return taskId + opType;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/Db.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/Db.java
@@ -26,7 +26,6 @@ import javax.management.openmbean.KeyAlreadyExistsException;
  */
 public interface Db extends Closeable {
 
-
     abstract KeyValueEntity get(String key);
 
     /**

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/JobProfileDb.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/JobProfileDb.java
@@ -150,7 +150,6 @@ public class JobProfileDb {
         return null;
     }
 
-
     /**
      * get job reading specific file
      * @param fileName

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/LocalProfile.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/LocalProfile.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.db;
 
 import java.nio.file.Files;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/TriggerProfileDb.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/TriggerProfileDb.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.db;
 
-
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.inlong.agent.conf.TriggerProfile;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/ProxyMessage.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/ProxyMessage.java
@@ -32,7 +32,6 @@ public class ProxyMessage implements Message {
     private final String bid;
     private final String tid;
 
-
     public ProxyMessage(byte[] body, Map<String, String> header) {
         this.body = body;
         this.header = header;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/AgentDynamicMBean.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/AgentDynamicMBean.java
@@ -67,7 +67,6 @@ public class AgentDynamicMBean implements DynamicMBean {
         }
     }
 
-
     private MBeanInfo metricsMetaToInfo() {
         // overwrite name, desc from MetricsMeta if not null.
         String name = this.module == null ? metricsMeta.getName() : this.module;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/MetricsRegister.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/MetricsRegister.java
@@ -81,7 +81,6 @@ public class MetricsRegister {
         }
     }
 
-
     /**
      * handle class level annotation
      */
@@ -94,7 +93,6 @@ public class MetricsRegister {
         }
         return null;
     }
-
 
     private static boolean initFieldByType(Object source, Field field) {
         try {

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/gauge/Gauge.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/gauge/Gauge.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.metrics.gauge;
 
-
 import org.apache.inlong.agent.metrics.MutableMetric;
 
 public interface Gauge<T> extends MutableMetric {

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/Channel.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/Channel.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
  */
 public interface Channel extends Stage {
 
-
     /**
      * write message
      *

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/Sink.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/Sink.java
@@ -29,7 +29,6 @@ public interface Sink extends Stage {
      */
     void write(Message message);
 
-
     /**
      * set source file name where the message is generated
      * @param sourceFileName

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/state/AbstractStateWrapper.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/state/AbstractStateWrapper.java
@@ -40,7 +40,6 @@ public abstract class AbstractStateWrapper implements Runnable {
      */
     public abstract void addCallbacks();
 
-
     public AbstractStateWrapper addCallback(State begin, State end, StateCallback callback) {
         callBacks.put(new ImmutablePair<>(begin, end), callback);
         return this;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/state/StateTransferException.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/state/StateTransferException.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.state;
 
-
 public class StateTransferException extends RuntimeException {
 
     public StateTransferException(State begin, State end) {

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -67,7 +67,6 @@ public class AgentUtils {
     public static final String HOUR_LOW_CASE = "h";
     public static final String MINUTE = "m";
 
-
     /**
      * get md5 of file.
      * @param file - file name
@@ -227,7 +226,6 @@ public class AgentUtils {
         return DateTimeFormatter.ofPattern(formatter).withLocale(Locale.getDefault()).format(zoned);
     }
 
-
     public static String formatCurrentTimeWithoutOffset(String formatter) {
         ZonedDateTime zoned = ZonedDateTime.now().plusDays(0).plusHours(0).plusMinutes(0);
         return DateTimeFormatter.ofPattern(formatter).withLocale(Locale.getDefault()).format(zoned);
@@ -303,7 +301,6 @@ public class AgentUtils {
         return mValueAttrs.getRight();
     }
 
-
     /**
      * get m value in additionStr
      * @param addictiveAttr
@@ -355,9 +352,5 @@ public class AgentUtils {
         }
         return System.currentTimeMillis();
     }
-
-
-
-
 
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/ByteUtil.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/ByteUtil.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.utils;
 
 import java.util.ArrayList;

--- a/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/common/TestAgentUtils.java
+++ b/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/common/TestAgentUtils.java
@@ -69,7 +69,6 @@ public class TestAgentUtils {
         LOGGER.info("agent time is {}", time);
     }
 
-
     @Test
     public void testParseAddictiveStr() {
         String addStr = "m=10&__addcol1__worldid=&t=1";

--- a/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/db/TestBerkeleyDBImp.java
+++ b/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/db/TestBerkeleyDBImp.java
@@ -24,7 +24,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-
 public class TestBerkeleyDBImp {
 
     private static BerkeleyDbImp db;
@@ -77,7 +76,6 @@ public class TestBerkeleyDBImp {
 
     }
 
-
     @Test
     public void testCommandDb() {
         CommandEntity commandEntity = new CommandEntity("1", 0, false, "1", "");
@@ -122,7 +120,6 @@ public class TestBerkeleyDBImp {
         Assert.assertEquals("searchKey1", entityResult1.getKey());
         Assert.assertNull(entityResult);
     }
-
 
     @Test
     public void testFileNameSearch() {

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.core;
 
-
 import static org.apache.inlong.agent.constants.AgentConstants.AGENT_CONF_PARENT;
 import static org.apache.inlong.agent.constants.AgentConstants.DEFAULT_AGENT_CONF_PARENT;
 import static org.apache.inlong.agent.constants.JobConstants.JOB_TRIGGER;
@@ -57,8 +56,6 @@ public class AgentManager extends AbstractDaemon {
 
     // jetty for config operations via http.
     private ConfigJetty configJetty;
-
-
 
     private final ProfileFetcher fetcher;
     private final AgentConfiguration conf;

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/Job.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/Job.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.core.job;
 
-
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.inlong.agent.conf.JobProfile;

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.core.job;
 
-
 import static org.apache.inlong.agent.constants.AgentConstants.DEFAULT_JOB_DB_CACHE_CHECK_INTERVAL;
 import static org.apache.inlong.agent.constants.AgentConstants.DEFAULT_JOB_DB_CACHE_TIME;
 import static org.apache.inlong.agent.constants.AgentConstants.JOB_DB_CACHE_CHECK_INTERVAL;

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobMetrics.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobMetrics.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.core.job;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/Task.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/Task.java
@@ -22,7 +22,6 @@ import org.apache.inlong.agent.plugin.Channel;
 import org.apache.inlong.agent.plugin.Reader;
 import org.apache.inlong.agent.plugin.Sink;
 
-
 /**
  * task meta definition which contains reader -> channel -> sink and job config information
  */

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskPositionManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskPositionManager.java
@@ -105,7 +105,6 @@ public class TaskPositionManager extends AbstractDaemon {
         };
     }
 
-
     private void flushJobProfile(String jobId, JobProfile jobProfile) {
         jobTaskPositionMap.get(jobId).forEach(
             (fileName, position) -> jobProfile.setLong(fileName + POSITION_SUFFIX, position)
@@ -136,7 +135,6 @@ public class TaskPositionManager extends AbstractDaemon {
         Long beforePosition = filePosition.getOrDefault(sourceFilePath, 1L);
         filePosition.put(sourceFilePath, beforePosition + size);
     }
-
 
     public ConcurrentHashMap<String, Long> getTaskPositionMap(String jobId) {
         return jobTaskPositionMap.get(jobId);

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskWrapper.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskWrapper.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.core.task;
 
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
@@ -176,7 +175,6 @@ public class TaskWrapper extends AbstractStateWrapper {
 
         });
     }
-
 
     @Override
     public void run() {

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/trigger/TriggerManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/trigger/TriggerManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.core.trigger;
 
-
 import static org.apache.inlong.agent.constants.AgentConstants.DEFAULT_TRIGGER_MAX_RUNNING_NUM;
 import static org.apache.inlong.agent.constants.AgentConstants.TRIGGER_MAX_RUNNING_NUM;
 import static org.apache.inlong.agent.constants.JobConstants.JOB_ID;
@@ -90,7 +89,6 @@ public class TriggerManager extends AbstractDaemon {
         return true;
     }
 
-
     public Trigger getTrigger(String triggerId) {
         return triggerMap.get(triggerId);
     }
@@ -106,9 +104,6 @@ public class TriggerManager extends AbstractDaemon {
         addTrigger(triggerProfile);
         return true;
     }
-
-
-
 
     private Runnable jobFetchThread() {
         return () -> {
@@ -152,7 +147,6 @@ public class TriggerManager extends AbstractDaemon {
     private void deleteJob(String jobInstanceId) {
         manager.getJobManager().deleteJob(jobInstanceId);
     }
-
 
     private Runnable jobCheckThread() {
         return () -> {
@@ -210,8 +204,6 @@ public class TriggerManager extends AbstractDaemon {
         return false;
     }
 
-
-
     /**
      * init all triggers when daemon started.
      */
@@ -236,13 +228,10 @@ public class TriggerManager extends AbstractDaemon {
         submitWorker(jobCheckThread());
     }
 
-
-
     @Override
     public void stop() {
         // stop all triggers
         stopTriggers();
     }
-
 
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/channel/MemoryChannel.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/channel/MemoryChannel.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.plugin.channel;
 
-
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.inlong.agent.conf.JobProfile;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.plugin.fetcher;
-
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.inlong.agent.constants.AgentConstants.AGENT_HOME;
@@ -105,8 +103,6 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     private final HttpManager httpManager;
     private String localIp;
 
-
-
     private CommandDb commandDb;
 
     private boolean requiredKeys(AgentConfiguration conf) {
@@ -140,8 +136,6 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
         }
     }
 
-
-
     /**
      * for manager to get job profiles
      * @return -  job profile list
@@ -165,7 +159,6 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
         }
         localFileCache.writeToCache(String.join(",", managerIpList));
     }
-
 
     /**
      * request manager to get commands, make sure it not throwing exceptions
@@ -312,14 +305,12 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
         commandDb.saveNormalCmds(triggerProfile, success);
     }
 
-
     /**
      * check agent ip from manager
      */
     private void fetchLocalIp() {
         localIp = AgentConfiguration.getAgentConf().get(AGENT_LOCAL_IP, DEFAULT_LOCAL_IP);
     }
-
 
     /**
      * confirm local ips from manager
@@ -335,7 +326,6 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
         }
         return resultData.get(AGENT_MANAGER_RETURN_PARAM_IP).getAsString();
     }
-
 
     /**
      * fetch manager list, make sure it not throwing exceptions
@@ -360,7 +350,6 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
             fetchTdmList(false, retryTime + 1);
         }
     }
-
 
     /**
      * thread for profile fetcher.

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerResultFormatter.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerResultFormatter.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.plugin.fetcher;
 
 import static org.apache.inlong.agent.plugin.fetcher.constants.FetcherConstants.AGENT_MANAGER_VIP_HTTP_HOST;
@@ -88,8 +87,6 @@ public class ManagerResultFormatter {
         return newHostList.subList(0, num);
     }
 
-
-
     public static TriggerProfile convertToTriggerProfile(DataConfig dataConfigs) {
         if (!dataConfigs.isValid()) {
             throw new IllegalArgumentException("input dataConfig" + dataConfigs + "is invalid please check");
@@ -136,6 +133,5 @@ public class ManagerResultFormatter {
         proxy.setManager(manager);
         return proxy;
     }
-
 
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/constants/CommandConstants.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/constants/CommandConstants.java
@@ -53,5 +53,4 @@ public class CommandConstants {
     public static final String FIELD_SPLITTER = "field_splitter";
     public static final String MD5 = "md5";
 
-
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/constants/FetcherConstants.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/constants/FetcherConstants.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.plugin.fetcher.constants;
 
 public class FetcherConstants {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/CmdConfig.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/CmdConfig.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.plugin.fetcher.dtos;
 
 import lombok.Data;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/CommandInfoDto.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/CommandInfoDto.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.plugin.fetcher.dtos;
 
 import lombok.Data;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/ConfirmAgentIpRequest.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/ConfirmAgentIpRequest.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.plugin.fetcher.dtos;
 
 import java.util.List;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/DataConfig.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/DataConfig.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.plugin.fetcher.dtos;
 
 import lombok.Data;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/ManagerReturnDto.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/ManagerReturnDto.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.plugin.fetcher.dtos;
 
 import lombok.Data;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/TaskRequsetDto.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/TaskRequsetDto.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.plugin.fetcher.dtos;
 
 import java.util.ArrayList;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/TaskResult.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/dtos/TaskResult.java
@@ -23,7 +23,6 @@ import lombok.Data;
 import org.apache.inlong.agent.conf.TriggerProfile;
 import org.apache.inlong.agent.plugin.fetcher.ManagerResultFormatter;
 
-
 @Data
 public class TaskResult {
     private List<CmdConfig> cmdConfigs;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/enums/ManagerOpEnum.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/enums/ManagerOpEnum.java
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.agent.plugin.fetcher.enums;
-
 
 import static java.util.Objects.requireNonNull;
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
@@ -60,7 +60,6 @@ import org.apache.inlong.agent.utils.AgentUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class ProxySink implements Sink {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxySink.class);
@@ -81,7 +80,6 @@ public class ProxySink implements Sink {
     // key is tid, value is a batch of messages belong to the same tid
     private ConcurrentHashMap<String, PackProxyMessage> cache;
     private long dataTime;
-
 
     @Override
     public void write(Message message) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/DataBaseSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/DataBaseSource.java
@@ -50,7 +50,6 @@ public class DataBaseSource implements Source {
         return null;
     }
 
-
     /**
      * Use SQL or binlog to read data.
      *

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/TextFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/TextFileSource.java
@@ -59,8 +59,6 @@ public class TextFileSource implements Source {
         return result;
     }
 
-
-
     private void addValidator(String filterPattern, TextFileReader textFileReader) {
         textFileReader.addPatternValidator(filterPattern);
     }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/SqlReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/SqlReader.java
@@ -70,7 +70,6 @@ public class SqlReader implements Reader {
             String.valueOf(CharUtils.LF)};
     private static final String[] EMPTY_CHARS = new String[]{StringUtils.EMPTY, StringUtils.EMPTY};
 
-
     private final String sql;
     // use statement for mysql due to compatibility
     private Statement statement;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/TextFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/TextFileReader.java
@@ -84,7 +84,6 @@ public class TextFileReader implements Reader {
         return null;
     }
 
-
     private boolean validateMessage(String message) {
         if (validators.isEmpty()) {
             return true;
@@ -127,7 +126,6 @@ public class TextFileReader implements Reader {
         }
         validators.add(new PatternValidator(pattern));
     }
-
 
     @Override
     public void init(JobProfile jobConf) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/DirectoryTrigger.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/DirectoryTrigger.java
@@ -44,7 +44,6 @@ import org.apache.inlong.agent.plugin.utils.PluginUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Watch directory, if new valid files are created, create
  * jobs correspondingly.

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/HttpManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/HttpManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.agent.plugin.utils;
 
-
 import static org.apache.inlong.agent.plugin.fetcher.constants.FetcherConstants.AGENT_HTTP_APPLICATION_JSON;
 import static org.apache.inlong.agent.plugin.fetcher.constants.FetcherConstants.AGENT_HTTP_SUCCESS_CODE;
 import static org.apache.inlong.agent.plugin.fetcher.constants.FetcherConstants.AGENT_MANAGER_REQUEST_TIMEOUT;
@@ -36,7 +35,6 @@ import org.apache.http.util.EntityUtils;
 import org.apache.inlong.agent.conf.AgentConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 public class HttpManager {
 
@@ -60,7 +58,6 @@ public class HttpManager {
         httpClientBuilder.setDefaultRequestConfig(requestConfig);
         return httpClientBuilder.build();
     }
-
 
     public HttpManager(AgentConfiguration conf) {
         httpClient = constructHttpClient(conf.getInt(AGENT_MANAGER_REQUEST_TIMEOUT,
@@ -86,7 +83,6 @@ public class HttpManager {
         }
         return null;
     }
-
 
     public String doSendGet(String url) {
         try {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/PluginUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/PluginUtils.java
@@ -52,9 +52,7 @@ import org.slf4j.LoggerFactory;
 @Slf4j
 public class PluginUtils {
 
-
     private static final Logger LOGGER = LoggerFactory.getLogger(PluginUtils.class);
-
 
     /**
      * convert string compress type to enum compress type
@@ -79,7 +77,6 @@ public class PluginUtils {
         Gson gson = gsonBuilder.create();
         return gson.toJson(obj);
     }
-
 
     public static Collection<File> findSuitFiles(JobProfile jobConf) {
         String dirPattern = jobConf.get(JOB_DIR_FILTER_PATTERN);
@@ -141,7 +138,6 @@ public class PluginUtils {
         }
         return allIps;
     }
-
 
     private static void addIp(List<String> allIps, NetworkInterface ni) {
         Enumeration<InetAddress> ias = ni.getInetAddresses();

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/TestFileAgent.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/TestFileAgent.java
@@ -173,5 +173,4 @@ public class TestFileAgent {
         Assert.assertEquals(1, jobConf.getInt("job.id"));
     }
 
-
 }

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sinks/MockSink.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sinks/MockSink.java
@@ -66,5 +66,4 @@ public class MockSink implements Sink {
         LOGGER.info("destroy mockSink, sink line number is : {}", number.get());
     }
 
-
 }

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/trigger/TestWatchDirTrigger.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/trigger/TestWatchDirTrigger.java
@@ -56,7 +56,6 @@ public class TestWatchDirTrigger {
         helper.teardownAgentHome();
     }
 
-
     @Test
     public void testWatchEntity() throws Exception {
         PathPattern a1 = new PathPattern(helper.getParentPath().toString());

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/utils/TestUtils.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/utils/TestUtils.java
@@ -56,7 +56,6 @@ public class TestUtils {
             + "  }";
     }
 
-
     public static void createHugeFiles(String fileName, String rootDir, String record) throws Exception {
         final Path hugeFile = Paths.get(rootDir, fileName);
         FileWriter writer = new FileWriter(hugeFile.toFile());
@@ -66,8 +65,6 @@ public class TestUtils {
         writer.flush();
         writer.close();
     }
-
-
 
     public static void createMultipleLineFiles(String fileName, String rootDir,
         String record, int lineNum) throws Exception {

--- a/inlong-common/src/main/java/org/apache/inlong/commons/msg/DataInputBuffer.java
+++ b/inlong-common/src/main/java/org/apache/inlong/commons/msg/DataInputBuffer.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.commons.msg;
 
-
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 

--- a/inlong-common/src/main/java/org/apache/inlong/commons/msg/DataOutputBuffer.java
+++ b/inlong-common/src/main/java/org/apache/inlong/commons/msg/DataOutputBuffer.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.commons.msg;
 
-
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.DataOutputStream;

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/DefaultMessageSender.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/DefaultMessageSender.java
@@ -50,7 +50,6 @@ public class DefaultMessageSender implements MessageSender {
     private boolean isSupportLF = false;
     private int cpsSize = ConfigConstants.COMPRESS_SIZE;
 
-
     private static final ConcurrentHashMap<String, DefaultMessageSender> cacheSender =
             new ConcurrentHashMap<>();
 
@@ -189,14 +188,12 @@ public class DefaultMessageSender implements MessageSender {
         return ConfigConstants.PROXY_SDK_VERSION;
     }
 
-
     @Deprecated
     public SendResult sendMessage(byte[] body, String attributes, String msgUUID,
                                   long timeout, TimeUnit timeUnit) {
         return sender.syncSendMessage(new EncodeObject(body, attributes,
                 idGenerator.getNextId()), msgUUID, timeout, timeUnit);
     }
-
 
     public SendResult sendMessage(byte[] body, String bid, String tid, long dt, String msgUUID,
                                   long timeout, TimeUnit timeUnit) {
@@ -226,8 +223,6 @@ public class DefaultMessageSender implements MessageSender {
 
         return null;
     }
-
-
 
     public SendResult sendMessage(byte[] body, String bid, String tid, long dt, String msgUUID,
                                   long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap) {
@@ -261,9 +256,7 @@ public class DefaultMessageSender implements MessageSender {
         }
         return null;
 
-
     }
-
 
     public SendResult sendMessage(List<byte[]> bodyList, String bid, String tid, long dt, String msgUUID,
                                   long timeout, TimeUnit timeUnit) {
@@ -292,7 +285,6 @@ public class DefaultMessageSender implements MessageSender {
         }
         return null;
     }
-
 
     public SendResult sendMessage(List<byte[]> bodyList, String bid, String tid, long dt, String msgUUID,
                                   long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap) {
@@ -325,15 +317,12 @@ public class DefaultMessageSender implements MessageSender {
         return null;
     }
 
-
-
     @Deprecated
     public void asyncSendMessage(SendMessageCallback callback, byte[] body, String attributes, String msgUUID,
                                  long timeout, TimeUnit timeUnit) throws ProxysdkException {
         sender.asyncSendMessage(new EncodeObject(body, attributes, idGenerator.getNextId()),
                 callback, msgUUID, timeout, timeUnit);
     }
-
 
     public void asyncSendMessage(SendMessageCallback callback, byte[] body,
                                  String bid, String tid, long dt, String msgUUID,
@@ -364,7 +353,6 @@ public class DefaultMessageSender implements MessageSender {
         }
 
     }
-
 
     public void asyncSendMessage(SendMessageCallback callback,
                                  byte[] body, String bid, String tid, long dt, String msgUUID,
@@ -399,7 +387,6 @@ public class DefaultMessageSender implements MessageSender {
         }
     }
 
-
     public void asyncSendMessage(SendMessageCallback callback, List<byte[]> bodyList,
                                  String bid, String tid, long dt, String msgUUID,
                                  long timeout, TimeUnit timeUnit) throws ProxysdkException {
@@ -430,7 +417,6 @@ public class DefaultMessageSender implements MessageSender {
             }
         }
     }
-
 
     public void asyncSendMessage(SendMessageCallback callback,
                                  List<byte[]> bodyList, String bid, String tid, long dt, String msgUUID,
@@ -480,8 +466,6 @@ public class DefaultMessageSender implements MessageSender {
         }
     }
 
-
-
     public void asyncsendMessageData(FileCallback callback, List<byte[]> bodyList, String bid,
                                      String tid, long dt, int sid, boolean isSupportLF, String msgUUID,
                                      long timeout, TimeUnit timeUnit,
@@ -519,23 +503,17 @@ public class DefaultMessageSender implements MessageSender {
         }
     }
 
-
-
-
     public void asyncsendMessageProxy(FileCallback callback, byte[] body, String bid, String tid,
                                     long dt, int sid, String ip, String msgUUID,
                                     long timeout, TimeUnit timeUnit) throws ProxysdkException {
         asyncSendMetric(callback, body, bid, tid, dt, sid, ip, msgUUID, timeout, timeUnit, "minute");
     }
 
-
     public void asyncsendMessageFile(FileCallback callback, byte[] body, String bid,
                                      String tid, long dt, int sid, String msgUUID,
                                      long timeout, TimeUnit timeUnit) throws ProxysdkException {
         asyncSendMetric(callback, body, bid, tid, dt, sid, "", msgUUID, timeout, timeUnit, "file");
     }
-
-
 
     public String sendMessageData(List<byte[]> bodyList, String bid,
                                   String tid, long dt, int sid, boolean isSupportLF, String msgUUID,
@@ -573,14 +551,10 @@ public class DefaultMessageSender implements MessageSender {
         return null;
     }
 
-
-
-
     public String sendMessageProxy(byte[] body, String bid, String tid, long dt, int sid, String ip, String msgUUID,
                                  long timeout, TimeUnit timeUnit) {
         return sendMetric(body, bid, tid, dt, sid, ip, msgUUID, timeout, timeUnit, "minute");
     }
-
 
     public String sendMessageFile(byte[] body, String bid, String tid, long dt, int sid, String msgUUID,
                                   long timeout, TimeUnit timeUnit) {

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/FileCallback.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/FileCallback.java
@@ -22,7 +22,6 @@ package org.apache.inlong.dataproxy;
  * Created by jesseyzhou on 2018/6/5.
  */
 
-
 public abstract class FileCallback implements SendMessageCallback {
     /* Invoked when a message is confirmed by TDBus. */
     public void onMessageAck(String result) {

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/ProxyClientConfig.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/ProxyClientConfig.java
@@ -401,7 +401,6 @@ public class ProxyClientConfig {
         this.metricIntervalInMs = metricIntervalInMs;
     }
 
-
     public String getMetricBid() {
         return metricBid;
     }

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/codec/EncodeObject.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/codec/EncodeObject.java
@@ -54,7 +54,6 @@ public class EncodeObject {
     private String msgUUID = null;
     private EncryptConfigEntry encryptEntry = null;
 
-
     private boolean isException = false;
     private ErrorCode exceptionError = null;
 

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/codec/ErrorCode.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/codec/ErrorCode.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 public enum ErrorCode {
 
-
     ATTR_ERROR(1),
 
     DT_ERROR(2),

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/codec/ProtocolDecoder.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/codec/ProtocolDecoder.java
@@ -37,7 +37,6 @@ public class ProtocolDecoder extends FrameDecoder {
                             ChannelBuffer buffer) throws Exception {
         //        if(!channel.isConnected()||channel.isReadable()){return null;}
 
-
         buffer.markReaderIndex();
         // totallen
         int totalLen = buffer.readInt();
@@ -99,7 +98,6 @@ public class ProtocolDecoder extends FrameDecoder {
                 byte[] attrContent = new byte[attrLen];
                 buffer.readBytes(attrContent);
             }
-
 
             buffer.readShort();
 

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/codec/ProtocolEncoder.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/codec/ProtocolEncoder.java
@@ -402,7 +402,6 @@ public class ProtocolEncoder extends OneToOneEncoder {
         return buf;
     }
 
-
     private byte[] processCompress(byte[] body) {
         try {
             ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/config/EncryptConfigEntry.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/config/EncryptConfigEntry.java
@@ -39,7 +39,6 @@ public class EncryptConfigEntry implements java.io.Serializable {
     private String rsaEncryptedKey;
     private AtomicLong lastUpdateTime = new AtomicLong(0);
 
-
     public EncryptConfigEntry(final String userName, final String version, final String pubKey) {
         this.userName = userName;
         this.version = version;
@@ -86,7 +85,6 @@ public class EncryptConfigEntry implements java.io.Serializable {
         }
         return rsaEncryptedKey;
     }
-
 
     public EncryptInfo getRsaEncryptInfo() {
         EncryptInfo encryptInfo = null;

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/config/EncryptInfo.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/config/EncryptInfo.java
@@ -18,7 +18,6 @@
 
 package org.apache.inlong.dataproxy.config;
 
-
 public class EncryptInfo {
     private String version;
     private byte[] desKey;

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/config/HostInfo.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/config/HostInfo.java
@@ -18,7 +18,6 @@
 
 package org.apache.inlong.dataproxy.config;
 
-
 public class HostInfo implements Comparable<HostInfo>, java.io.Serializable {
     private final String referenceName;
     private final String hostName;

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/config/ProxyConfigEntry.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/config/ProxyConfigEntry.java
@@ -96,7 +96,6 @@ public class ProxyConfigEntry implements java.io.Serializable {
                 + ", switch=" + switchStat + "]";
     }
 
-
     public String getClusterId() {
         return clusterId;
     }

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/config/ProxyConfigManager.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/config/ProxyConfigManager.java
@@ -74,7 +74,6 @@ import org.apache.inlong.dataproxy.network.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class ProxyConfigManager extends Thread {
 
     private static final Logger logger = LoggerFactory.getLogger(ProxyConfigManager.class);
@@ -376,7 +375,6 @@ public class ProxyConfigManager extends Thread {
         return encryptEntry;
     }
 
-
     private void updateEncryptConfigEntry() {
         if (Utils.isBlank(this.clientConfig.getUserName())) {
             return;
@@ -588,7 +586,6 @@ public class ProxyConfigManager extends Thread {
         return proxyEntry;
     }
 
-
     private Map<String, HostInfo> getHostInfoMap(JsonObject localProxyAddrJson)
         throws Exception {
         Map<String, HostInfo> hostMap = new HashMap<String, HostInfo>();
@@ -658,7 +655,6 @@ public class ProxyConfigManager extends Thread {
         }
         return isInterVisit;
     }
-
 
     public ProxyConfigEntry requestProxyList(String url) {
         ArrayList<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/demo/MyMessageCallBack.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/demo/MyMessageCallBack.java
@@ -44,7 +44,6 @@ public class MyMessageCallBack extends FileCallback {
         logger.info("onMessageAck return result = {}", result);
     }
 
-
     public void onMessageAck(SendResult result) {
         if (result == SendResult.OK) {
             logger.info("onMessageAck return Ok");

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/http/InternalHttpSender.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/http/InternalHttpSender.java
@@ -186,9 +186,7 @@ public class InternalHttpSender {
                 httpClient = constructHttpClient(timeout, timeUnit);
             }
 
-
             String url = "http://" + hostInfo.getHostName() + ":" + DEFAULT_PORT + "/manager/message";
-
 
             httpPost = new HttpPost(url);
             httpPost.setHeader(HttpHeaders.CONNECTION, "close");

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/network/ClientMgr.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/network/ClientMgr.java
@@ -50,7 +50,6 @@ public class ClientMgr {
     private static final Logger logger = LoggerFactory
             .getLogger(ClientMgr.class);
 
-
     private final Map<HostInfo, NettyClient> clientMapData = new ConcurrentHashMap<HostInfo, NettyClient>();
 
     private final ConcurrentHashMap<HostInfo, NettyClient> clientMapHB = new ConcurrentHashMap<HostInfo, NettyClient>();
@@ -65,7 +64,6 @@ public class ClientMgr {
     //    private final Map<HostInfo, Integer> channelLoadMap = new ConcurrentHashMap<HostInfo, Integer>();
     private final Map<HostInfo, int[]> channelLoadMapData = new ConcurrentHashMap<HostInfo, int[]>();
     private final Map<HostInfo, int[]> channelLoadMapHB = new ConcurrentHashMap<HostInfo, int[]>();
-
 
     private ClientBootstrap bootstrap;
     private int currentIndex = 0;
@@ -440,7 +438,6 @@ public class ClientMgr {
         }
     }
 
-
     private void loadDataInfo(Map<HostInfo, Integer> loadData) {
         for (Map.Entry<HostInfo, int[]> entry : channelLoadMapData.entrySet()) {
             HostInfo key = entry.getKey();
@@ -508,7 +505,6 @@ public class ClientMgr {
                 }
             });
 
-
             logger.info("show info: last compute result!");
             for (Map.Entry<HostInfo, Integer> item : listData) {
 //                System.out.println("listData:"+listData.get(i));
@@ -545,7 +541,6 @@ public class ClientMgr {
                     clientMapHB.remove(hbHost);
                 }
             }
-
 
             if (!isLoadSwitch) {
                 logger.info("Choose other HBClient because there is no load balancing! ");
@@ -619,7 +614,6 @@ public class ClientMgr {
 
     private void fillUpWorkClientWithLastBadClient() {
 
-
         int currentRealSize = aliveConnections - clientMapData.size();
 
         List<HostInfo> pendingBadList = new ArrayList<>();
@@ -668,7 +662,6 @@ public class ClientMgr {
         }
     }
 
-
     private void removeBadHBClients(List<HostInfo> badHostLists, List<HostInfo> normalHostLists) {
         for (HostInfo hostInfo : clientMapHB.keySet()) {
             if (hostInfo == null) {
@@ -712,7 +705,6 @@ public class ClientMgr {
             }
         }
     }
-
 
     public void replaceBadConnectionHB() {
         try {
@@ -772,16 +764,13 @@ public class ClientMgr {
                 }
             }
 
-
             if (clientMapData.size() < aliveConnections) {
                 fillUpWorkClientWithHBClient();
             }
 
-
             if (clientMapData.size() < aliveConnections) {
                 fillUpWorkClientWithLastBadClient();
             }
-
 
             for (HostInfo hostInfo : badHostLists) {
                 AtomicLong tmpValue = new AtomicLong(0);
@@ -799,7 +788,6 @@ public class ClientMgr {
             logger.info(
                     "replace bad connection ,client map size {},client list size {}",
                     clientMapData.size(), clientList.size());
-
 
         } catch (Exception e) {
             logger.error("replaceBadConnection exception {}, {}", e.toString(), e.getStackTrace());
@@ -866,7 +854,6 @@ public class ClientMgr {
         return resultHosts;
     }
 
-
     private class SendHBThread extends Thread {
 
         private boolean bShutDown = false;
@@ -903,6 +890,5 @@ public class ClientMgr {
             }
         }
     }
-
 
 }

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/network/HttpProxySender.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/network/HttpProxySender.java
@@ -47,7 +47,6 @@ public class HttpProxySender extends Thread {
     private final ProxyClientConfig proxyClientConfig;
     private ProxyConfigManager proxyConfigManager;
 
-
     private boolean bShutDown = false;
 
     private final InternalHttpSender internalHttpSender;
@@ -121,7 +120,6 @@ public class HttpProxySender extends Thread {
             }
         }
     }
-
 
     /**
      * send by http

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/network/Sender.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/network/Sender.java
@@ -264,7 +264,6 @@ public class Sender {
         return message;
     }
 
-
     private SendResult syncSendMessageIndexInternal(NettyClient client,
         EncodeObject encodeObject, String msgUUID, long timeout,
         TimeUnit timeUnit) throws ExecutionException, InterruptedException, TimeoutException {
@@ -492,7 +491,6 @@ public class Sender {
         return !needEqual;
     }
 
-
     /* Following methods used by asynchronously message sending. */
     public void asyncSendMessage(EncodeObject encodeObject,
                                  SendMessageCallback callback, String msgUUID,
@@ -690,6 +688,5 @@ public class Sender {
     public void setClusterId(String clusterId) {
         this.clusterId = clusterId;
     }
-
 
 }

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/network/Utils.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/network/Utils.java
@@ -33,7 +33,6 @@ import org.apache.commons.codec.digest.HmacUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class Utils {
     private static final Logger logger = LoggerFactory.getLogger(Utils.class);
     private static String userIp;
@@ -166,12 +165,10 @@ public class Utils {
         return result;
     }
 
-
     public static String getAuthorizenInfo(final String secretId, final String secretKey, long timestamp, int nonce) {
         String signature = generateSignature(secretId, timestamp, nonce, secretKey);
         return "manager " + secretId + " " + timestamp + " " + nonce + " " + signature;
     }
-
 
     public static String convertSetToString(Set<String> list, Character ch) {
         if (list == null || list.isEmpty()) {

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/threads/MetricWorkerThread.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/threads/MetricWorkerThread.java
@@ -43,15 +43,11 @@ public class MetricWorkerThread extends Thread implements Closeable {
 
     private final SequentialID idGenerator = new SequentialID(Utils.getLocalIp());
 
-
     private final ConcurrentHashMap<String, MessageRecord> metricValueCache = new ConcurrentHashMap<>();
-
 
     private final ConcurrentHashMap<String, MetricTimeNumSummary> metricPackTimeMap = new ConcurrentHashMap<>();
 
-
     private final ConcurrentHashMap<String, MetricTimeNumSummary> metricDtMap = new ConcurrentHashMap<>();
-
 
     private static final String DEFAULT_KEY_ITEM = "";
     private static final String DEFAULT_KEY_SPLITTER = "#";
@@ -144,7 +140,6 @@ public class MetricWorkerThread extends Thread implements Closeable {
             String dtKeyName = getKeyStringByConfig(messageRecord.getBid(), messageRecord.getTid(),
                     messageRecord.getLocalIp(), messageRecord.getDt());
 
-
             MetricTimeNumSummary packTimeSummary = getMetricSummary(packTimeKeyName,
                     new MetricTimeNumSummary(messageRecord.getPackTime()), metricPackTimeMap);
 
@@ -169,7 +164,6 @@ public class MetricWorkerThread extends Thread implements Closeable {
                     messageRecord.getLocalIp(), messageRecord.getPackTime());
             String dtKeyName = getKeyStringByConfig(messageRecord.getBid(), messageRecord.getTid(),
                     messageRecord.getLocalIp(), messageRecord.getDt());
-
 
             MetricTimeNumSummary packTimeSummary = getMetricSummary(packTimeKeyName,
                     new MetricTimeNumSummary(messageRecord.getMessageTime()), metricPackTimeMap);

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/utils/EncryptUtil.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/utils/EncryptUtil.java
@@ -48,7 +48,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class EncryptUtil {
     private static final Logger logger =
             LoggerFactory.getLogger(EncryptUtil.class);
@@ -58,7 +57,6 @@ public class EncryptUtil {
     public static final int MAX_DECRYPT_BLOCK = 128;
 
     public static final String DES = "DES";
-
 
     /**
      * load key
@@ -270,7 +268,6 @@ public class EncryptUtil {
 
     }
 
-
     /**
      * key encrypt
      *
@@ -373,8 +370,6 @@ public class EncryptUtil {
         }
     }
 
-
-
     /**
      * generate des key
      *
@@ -394,7 +389,6 @@ public class EncryptUtil {
         SecretKey secretKey = kg.generateKey();
         return secretKey.getEncoded();
     }
-
 
     /**
      * des encrypt
@@ -425,7 +419,6 @@ public class EncryptUtil {
             return null;
         }
     }
-
 
     /**
      * des decrypt
@@ -458,7 +451,6 @@ public class EncryptUtil {
             return null;
         }
     }
-
 
     public static void main(String[] args) {
         String plainText = "TDB-30001 Create Tdw Table Error26880 FAILED: "

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/utils/ProxyUtils.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/utils/ProxyUtils.java
@@ -89,8 +89,6 @@ public class ProxyUtils {
         return true;
     }
 
-
-
     public static long covertZeroDt(long dt) {
         if (dt == 0) {
             return System.currentTimeMillis();

--- a/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/utils/ServiceDiscoveryUtils.java
+++ b/inlong-dataproxy-sdk/src/main/java/org/apache/inlong/dataproxy/utils/ServiceDiscoveryUtils.java
@@ -252,7 +252,6 @@ public class ServiceDiscoveryUtils {
         return newestIp;
     }
 
-
     public static void updateManagerInfo2Local(String storeString, String path) {
         if (StringUtils.isBlank(storeString)) {
             log.warn("ServiceDiscovery updateTdmInfo2Local error, configMap is empty or managerIpList is blank.");

--- a/inlong-dataproxy-sdk/src/test/java/org/apache/inlong/dataproxy/TestMetricWorkerThread.java
+++ b/inlong-dataproxy-sdk/src/test/java/org/apache/inlong/dataproxy/TestMetricWorkerThread.java
@@ -26,7 +26,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-
 public class TestMetricWorkerThread {
 
     private static MetricWorkerThread workerThread;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/channel/FailoverChannelSelector.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/channel/FailoverChannelSelector.java
@@ -51,7 +51,6 @@ public class FailoverChannelSelector extends AbstractChannelSelector {
     private final List<Channel> agentFileMetricChannels = new ArrayList<Channel>();
     private final List<Channel> slaMetricChannels = new ArrayList<Channel>();
 
-
     @Override
     public List<Channel> getRequiredChannels(Event event) {
         List<Channel> retChannels = new ArrayList<Channel>();
@@ -60,7 +59,6 @@ public class FailoverChannelSelector extends AbstractChannelSelector {
         } else if (event.getHeaders().containsKey(ConfigConstants.FILE_CHECK_DATA)) {
             retChannels.add(agentFileMetricChannels.get(0));
         } else if (event.getHeaders().containsKey(ConfigConstants.SLA_METRIC_DATA)) {
-
 
             retChannels.add(slaMetricChannels.get(0));
         } else {
@@ -117,7 +115,6 @@ public class FailoverChannelSelector extends AbstractChannelSelector {
         List<String> transferList = splitChannelName(transfer);
         List<String> fileMetricList = splitChannelName(fileMertic);
         List<String> slaMetricList = splitChannelName(slaMetric);
-
 
         for (Map.Entry<String, Channel> entry : getChannelNameMap().entrySet()) {
             String channelName = entry.getKey();

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
@@ -96,7 +96,6 @@ public class ConfigManager {
         return instance;
     }
 
-
     public Map<String, String> getWeightProperties() {
         return weightHolder.getHolder();
     }
@@ -239,9 +238,7 @@ public class ConfigManager {
 
         private void checkLocalFile() {
 
-
             for (ConfigHolder holder : CONFIG_HOLDER_LIST) {
-
 
                 boolean isChanged = holder.checkAndUpdateHolder();
                 if (isChanged) {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/BidPropertiesHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/BidPropertiesHolder.java
@@ -32,7 +32,6 @@ public class BidPropertiesHolder extends PropertiesConfigHolder {
     private static final Logger LOG = LoggerFactory.getLogger(BidPropertiesHolder.class);
     private static final String BID_VALUE_SPLITTER = "#";
 
-
     private Map<String, String> bidMappingProperties =
             new HashMap<String, String>();
     private Map<String, Map<String, String>> tidMappingProperties =

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/PropertiesConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/PropertiesConfigHolder.java
@@ -100,10 +100,8 @@ public class PropertiesConfigHolder extends ConfigHolder {
                 FileUtils.copyFile(sourceFile, targetFile);
             }
 
-
             List<String> lines = getStringListFromHolder(tmpHolder);
             FileUtils.writeLines(tmpNewFile, lines);
-
 
             FileUtils.copyFile(tmpNewFile, sourceFile);
             tmpNewFile.delete();

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/http/StatusCode.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/http/StatusCode.java
@@ -19,7 +19,6 @@ package org.apache.inlong.dataproxy.http;
 
 public class StatusCode {
 
-
     public static final int SUCCESS = 1;
 
     public static final int ILLEGAL_ARGUMENT = -100;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/MetaSink.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/MetaSink.java
@@ -214,7 +214,6 @@ public class MetaSink extends AbstractSink implements Configurable {
         tubeClientConfig.setHeartbeatPeriodMs(15000L);
         tubeClientConfig.setRpcTimeoutMs(20000L);
 
-
         return tubeClientConfig;
     }
 
@@ -282,7 +281,6 @@ public class MetaSink extends AbstractSink implements Configurable {
         logger.debug("closed meta producer");
     }
 
-
     private void initTopicSet(Set<String> topicSet) throws Exception {
         List<String> sortedList = new ArrayList(topicSet);
         Collections.sort(sortedList);
@@ -321,7 +319,6 @@ public class MetaSink extends AbstractSink implements Configurable {
         logger.info(getName() + " producer is ready for topics : " + producerMap.keySet());
     }
 
-
     @Override
     public void start() {
         try {
@@ -359,9 +356,6 @@ public class MetaSink extends AbstractSink implements Configurable {
         }
 
     }
-
-
-
 
     class SinkTask implements Runnable {
         private void sendMessage(Event event, String topic, AtomicBoolean flag, EventStat es)
@@ -525,7 +519,6 @@ public class MetaSink extends AbstractSink implements Configurable {
         }
     }
 
-
     public class MyCallback implements MessageSentCallback {
         private EventStat myEventStat;
 
@@ -567,7 +560,6 @@ public class MetaSink extends AbstractSink implements Configurable {
         }
     }
 
-
     /**
      * resend event
      *
@@ -598,7 +590,6 @@ public class MetaSink extends AbstractSink implements Configurable {
                     + resendQueue.size(), throwable);
         }
     }
-
 
     @Override
     public Status process() throws EventDeliveryException {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/DefaultServiceDecoder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/DefaultServiceDecoder.java
@@ -64,14 +64,12 @@ public class DefaultServiceDecoder implements ServiceDecoder {
     private static final int BIN_HB_ATTRLEN_SIZE = 2;
     private static final int BIN_HB_FORMAT_SIZE = 17;
 
-
     private static final Logger LOG = LoggerFactory
             .getLogger(DefaultServiceDecoder.class);
 
     private static final Splitter.MapSplitter mapSplitter = Splitter
             .on(AttributeConstants.SEPARATOR).trimResults()
             .withKeyValueSeparator(AttributeConstants.KEY_VALUE_SEPARATOR);
-
 
     /**
      * extract bin heart beat data, message type is 8
@@ -264,7 +262,6 @@ public class DefaultServiceDecoder implements ServiceDecoder {
         int msgCount = cb.readUnsignedShort();
         long uniq = cb.readUnsignedInt();
 
-
         dataTime = dataTime * 1000;
         Map<String, String> commonAttrMap = new HashMap<String, String>();
         cb.skipBytes(BIN_MSG_BODYLEN_SIZE + bodyLen + BIN_MSG_ATTRLEN_SIZE);
@@ -341,7 +338,6 @@ public class DefaultServiceDecoder implements ServiceDecoder {
 
         return resultMap;
     }
-
 
     /**
      * extract bin data, message type less than 7
@@ -449,7 +445,6 @@ public class DefaultServiceDecoder implements ServiceDecoder {
         return resultMap;
     }
 
-
     private byte[] processUnCompress(byte[] input, String compressType) {
         byte[] result = null;
         try {
@@ -462,7 +457,6 @@ public class DefaultServiceDecoder implements ServiceDecoder {
         }
         return result;
     }
-
 
     /**
      * BEFORE                                                                   AFTER

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
@@ -103,7 +103,6 @@ public class ServerMessageHandler extends SimpleChannelHandler {
     private final ChannelBuffer heartbeatBuffer;
     private final String protocolType;
 
-
     public ServerMessageHandler(ChannelProcessor processor, ServiceDecoder serProcessor,
                                 ChannelGroup allChannels,
                                 String topic, String attr, Boolean filterEmptyMsg, Integer maxMsgLength,
@@ -175,7 +174,6 @@ public class ServerMessageHandler extends SimpleChannelHandler {
                 .putShort(dataLen + (BIN_MSG_FORMAT_SIZE - BIN_MSG_ATTRLEN_SIZE - BIN_MSG_MAGIC_SIZE),
                         (short) (strAttr.length() + attrLen));
 
-
         System.arraycopy(strAttr.getBytes(StandardCharsets.UTF_8), 0, dataBuf.array(),
                 dataLen + (BIN_MSG_FORMAT_SIZE - BIN_MSG_MAGIC_SIZE) + attrLen,
                 strAttr.length());
@@ -199,7 +197,6 @@ public class ServerMessageHandler extends SimpleChannelHandler {
             return false;
         }
     }
-
 
     @Override
     public void channelOpen(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception {
@@ -234,12 +231,10 @@ public class ServerMessageHandler extends SimpleChannelHandler {
                 }
             }
 
-
             String value = configManager.getTopicProperties().get(bid);
             if (StringUtils.isNotEmpty(value)) {
                 topicInfo.set(value.trim());
             }
-
 
             Map<String, String> mxValue = configManager.getMxPropertiesMaps().get(bid);
             if (mxValue != null && mxValue.size() != 0) {
@@ -271,7 +266,6 @@ public class ServerMessageHandler extends SimpleChannelHandler {
                     attrMap.put(AttributeConstants.INTERFACE_ID, tid);
                     message.setBid(bid);
                     message.setTid(tid);
-
 
                     String value = configManager.getTopicProperties().get(bid);
                     if (StringUtils.isNotEmpty(value)) {
@@ -370,7 +364,6 @@ public class ServerMessageHandler extends SimpleChannelHandler {
                     }
                 }
 
-
                 long pkgTimeInMillis = tdMsg.getCreatetime();
                 String pkgTimeStr = dateFormator.get().format(pkgTimeInMillis);
 
@@ -381,7 +374,6 @@ public class ServerMessageHandler extends SimpleChannelHandler {
                         pkgTimeStr = dateFormator.get().format(System.currentTimeMillis());
                     }
                 }
-
 
                 if (commonAttrMap.get(AttributeConstants.DATA_TIME) != null) {
                     headers.put(AttributeConstants.DATA_TIME, commonAttrMap.get(AttributeConstants.DATA_TIME));
@@ -397,13 +389,11 @@ public class ServerMessageHandler extends SimpleChannelHandler {
                 String proxyMetricMsgCnt = commonAttrMap.get(AttributeConstants.MESSAGE_COUNT);
                 headers.put(ConfigConstants.MSG_COUNTER_KEY, proxyMetricMsgCnt);
 
-
                 byte[] data = tdMsg.buildArray();
                 headers.put(ConfigConstants.TOTAL_LEN, String.valueOf(data.length));
 
                 String sequenceId = commonAttrMap.get(AttributeConstants.SEQUENCE_ID);
                 if (StringUtils.isNotEmpty(sequenceId)) {
-
 
                     StringBuilder sidBuilder = new StringBuilder();
                     sidBuilder.append(topicEntry.getKey()).append(SEPARATOR).append(tidEntry.getKey())
@@ -623,7 +613,6 @@ public class ServerMessageHandler extends SimpleChannelHandler {
                     processor.processEvent(event);
                 } catch (Throwable ex) {
                     logger.error("Error writing to controller,data will discard.", ex);
-
 
                     throw new ChannelException(
                             "Process Controller Event error can't write event to channel.");

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/SimpleTcpSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/SimpleTcpSource.java
@@ -67,7 +67,6 @@ public class SimpleTcpSource extends AbstractSource implements Configurable, Eve
     private static long propsLastModified;
     private static final String CONNECTIONS = "connections";
 
-
     protected int maxConnections = Integer.MAX_VALUE;
     private ServerBootstrap serverBootstrap = null;
     protected ChannelGroup allChannels;
@@ -156,7 +155,6 @@ public class SimpleTcpSource extends AbstractSource implements Configurable, Eve
         return arrayList;
     }
 
-
     private class CheckBlackListThread extends Thread {
         private boolean shutdown = false;
 
@@ -233,7 +231,6 @@ public class SimpleTcpSource extends AbstractSource implements Configurable, Eve
             fac = (ChannelPipelineFactory) ctor.newInstance(getChannelProcessor(), allChannels,
                     "tcp", serviceDecoder, messageHandlerName,
                     maxMsgLength, topic, attr, filterEmptyMsg, maxConnections, isCompressed, this.getName());
-
 
         } catch (Exception e) {
             logger.error("Simple Tcp Source start error, fail to construct ChannelPipelineFactory with name {}, ex {}",
@@ -342,7 +339,6 @@ public class SimpleTcpSource extends AbstractSource implements Configurable, Eve
         Preconditions.checkArgument(!attr.isEmpty(), "attr is empty");
 
         filterEmptyMsg = context.getBoolean(ConfigConstants.FILTER_EMPTY_MSG, false);
-
 
         msgFactoryName =
                 context.getString(ConfigConstants.MSG_FACTORY_NAME,

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/user/PasswordChangeRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/user/PasswordChangeRequest.java
@@ -20,7 +20,6 @@ package org.apache.inlong.manager.common.pojo.user;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class PasswordChangeRequest {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/CommonDBServerServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/CommonDBServerServiceImpl.java
@@ -48,7 +48,6 @@ public class CommonDBServerServiceImpl implements CommonDBServerService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CommonDBServerServiceImpl.class);
 
-
     @Autowired
     private CommonDbServerEntityMapper commonDbServerMapper;
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/WorkflowApproverServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/WorkflowApproverServiceImpl.java
@@ -163,5 +163,4 @@ public class WorkflowApproverServiceImpl implements WorkflowApproverService {
                 || StringUtils.equals(filterKey2ValueMap.get(filterKey), config.getFilterValue());
     }
 
-
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdpart/hive/builder/HiveChangeColumnBuilder.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdpart/hive/builder/HiveChangeColumnBuilder.java
@@ -48,5 +48,4 @@ public class HiveChangeColumnBuilder extends SqlBuilder<HiveTableQueryBean> {
         return null;
     }
 
-
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdpart/hive/builder/HiveDropTableSqlBuilder.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdpart/hive/builder/HiveDropTableSqlBuilder.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.manager.service.thirdpart.hive.builder;
 
-
 import org.apache.inlong.manager.common.pojo.query.hive.HiveTableQueryBean;
 
 /**

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdpart/mq/CreateTubeConsumeGroupTaskEventListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdpart/mq/CreateTubeConsumeGroupTaskEventListener.java
@@ -60,7 +60,6 @@ public class CreateTubeConsumeGroupTaskEventListener implements TaskEventListene
         return TaskEvent.COMPLETE;
     }
 
-
     @Override
     public ListenerResult listen(WorkflowContext context) throws WorkflowListenerException {
         CreateResourceWorkflowForm form = (CreateResourceWorkflowForm) context.getProcessForm();

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/workflow/WorkflowServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/workflow/WorkflowServiceImpl.java
@@ -211,7 +211,6 @@ public class WorkflowServiceImpl implements WorkflowService {
                 .collect(Collectors.toList());
     }
 
-
     private Consumer<ProcessListView> addCurrentTask(TaskQuery baseTaskQuery) {
         return plv -> {
             baseTaskQuery.setProcessInstId(plv.getId());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/workflow/WorkflowTaskExecuteLog.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/workflow/WorkflowTaskExecuteLog.java
@@ -67,7 +67,6 @@ public class WorkflowTaskExecuteLog {
                 .build();
     }
 
-
     @Data
     @Builder
     @NoArgsConstructor
@@ -107,7 +106,6 @@ public class WorkflowTaskExecuteLog {
                     .build();
         }
     }
-
 
     @Data
     @Builder

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/workflow/newbusiness/CreateResourceWorkflowForm.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/workflow/newbusiness/CreateResourceWorkflowForm.java
@@ -63,7 +63,6 @@ public class CreateResourceWorkflowForm extends BaseWorkflowFormType {
         return businessInfo.getBusinessIdentifier();
     }
 
-
     public String getDataStreamIdentifier() {
         return dataStreamIdentifier;
     }

--- a/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/EventListenerService.java
+++ b/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/EventListenerService.java
@@ -64,5 +64,4 @@ public interface EventListenerService {
      */
     void triggerTaskEvent(Integer taskInstId, TaskEvent taskEvent);
 
-
 }

--- a/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/ProcessService.java
+++ b/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/ProcessService.java
@@ -45,5 +45,4 @@ public interface ProcessService {
      */
     WorkflowContext cancel(Integer processInstId, String operator, String remark);
 
-
 }

--- a/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/WorkflowContextBuilder.java
+++ b/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/WorkflowContextBuilder.java
@@ -47,7 +47,6 @@ public interface WorkflowContextBuilder {
      */
     WorkflowContext buildContextForProcess(Integer processInstId);
 
-
     /**
      * Build context information based on task ID
      *

--- a/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/WorkflowEngine.java
+++ b/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/WorkflowEngine.java
@@ -36,7 +36,6 @@ public interface WorkflowEngine {
      */
     ProcessService processService();
 
-
     /**
      * Obtain task processing services
      *

--- a/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/WorkflowProcessorExecutor.java
+++ b/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/WorkflowProcessorExecutor.java
@@ -43,4 +43,3 @@ public interface WorkflowProcessorExecutor {
 
 }
 
-

--- a/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/impl/EventListenerServiceImpl.java
+++ b/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/impl/EventListenerServiceImpl.java
@@ -46,7 +46,6 @@ public class EventListenerServiceImpl implements EventListenerService {
 
     private WorkflowEventListenerManager workflowEventListenerManager;
 
-
     public EventListenerServiceImpl(
             WorkflowDataAccessor workflowDataAccessor,
             WorkflowContextBuilder workflowContextBuilder,

--- a/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/processor/UserTaskProcessor.java
+++ b/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/core/processor/UserTaskProcessor.java
@@ -199,7 +199,6 @@ public class UserTaskProcessor extends AbstractTaskProcessor<UserTask> {
         return JsonUtils.toJson(extMap);
     }
 
-
     private TaskState toTaskState(Action action) {
         switch (action) {
             case APPROVE:

--- a/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/model/TaskState.java
+++ b/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/model/TaskState.java
@@ -73,7 +73,6 @@ public enum TaskState {
     SKIPPED,
     ;
 
-
     /**
      * Completed
      */

--- a/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/model/definition/ProcessForm.java
+++ b/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/model/definition/ProcessForm.java
@@ -49,5 +49,4 @@ public interface ProcessForm extends Form {
         return null;
     }
 
-
 }

--- a/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/model/definition/TaskForm.java
+++ b/inlong-manager/manager-workflow-engine/src/main/java/org/apache/inlong/manager/workflow/model/definition/TaskForm.java
@@ -22,5 +22,4 @@ package org.apache.inlong.manager.workflow.model.definition;
  */
 public interface TaskForm extends Form {
 
-
 }

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/source/TubeSourceInfo.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/source/TubeSourceInfo.java
@@ -65,7 +65,6 @@ public class TubeSourceInfo extends SourceInfo {
         return masterAddress;
     }
 
-
     @JsonProperty("consumer_group")
     @Nullable
     public String getConsumerGroup() {

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/util/ZooKeeperUtils.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/util/ZooKeeperUtils.java
@@ -211,7 +211,6 @@ public class ZooKeeperUtils {
         return zkClient.create().withMode(createMode).forPath(nodePath, data);
     }
 
-
     /**
      * Secure {@link ACLProvider} implementation.
      */

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/SourceEvent.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/SourceEvent.java
@@ -79,4 +79,3 @@ public class SourceEvent implements Serializable {
     }
 }
 
-

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/pulsar/MultiTopicPulsarSourceFunction.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/pulsar/MultiTopicPulsarSourceFunction.java
@@ -187,7 +187,6 @@ public class MultiTopicPulsarSourceFunction extends RichParallelSourceFunction<S
             queueEvent(SourceEventType.ADDED, dataFlowInfo);
         }
 
-
         @Override
         public void updateDataFlow(DataFlowInfo dataFlowInfo) throws Exception {
             queueEvent(SourceEventType.UPDATE, dataFlowInfo);

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/flink/tubemq/TubeSubscriptionDescriptionTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/flink/tubemq/TubeSubscriptionDescriptionTest.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.sort.flink.tubemq;
 
 import static org.junit.Assert.assertEquals;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/common/PeerInfo.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/common/PeerInfo.java
@@ -17,10 +17,8 @@
 
 package org.apache.inlong.tubemq.client.common;
 
-
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.cluster.Partition;
-
 
 public class PeerInfo {
     private int partitionId = TBaseConstants.META_VALUE_UNDEFINED;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/BaseMessageConsumer.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/BaseMessageConsumer.java
@@ -1175,7 +1175,6 @@ public class BaseMessageConsumer implements MessageConsumer {
         }
     }
 
-
     private ClientMaster.MasterCertificateInfo.Builder genMasterCertificateInfo(boolean force) {
         boolean needAdd = false;
         ClientMaster.MasterCertificateInfo.Builder authInfoBuilder = null;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/ClientSubInfo.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/ClientSubInfo.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 
-
 public class ClientSubInfo {
     private final ConcurrentHashMap<String/* topic */, TopicProcessor> topicCondRegistry =
             new ConcurrentHashMap<>();

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/ConsumeOffsetInfo.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/ConsumeOffsetInfo.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.client.consumer;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 
-
 public class ConsumeOffsetInfo {
     private String partitionKey;
     private long currOffset = TBaseConstants.META_VALUE_UNDEFINED;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/ConsumerResult.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/ConsumerResult.java
@@ -24,7 +24,6 @@ import org.apache.inlong.tubemq.corebase.Message;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.cluster.Partition;
 
-
 public class ConsumerResult {
     private boolean success = false;
     private int errCode = TBaseConstants.META_VALUE_UNDEFINED;
@@ -33,7 +32,6 @@ public class ConsumerResult {
     private PeerInfo peerInfo = new PeerInfo();
     private String confirmContext = "";
     private List<Message> messageList = new ArrayList<>();
-
 
     public ConsumerResult(int errCode, String errMsg) {
         this.success = false;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/ConsumerSamplePrint.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/ConsumerSamplePrint.java
@@ -21,11 +21,9 @@ import org.apache.inlong.tubemq.corebase.utils.AbstractSamplePrint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class ConsumerSamplePrint extends AbstractSamplePrint {
     private static final Logger logger =
             LoggerFactory.getLogger(ConsumerSamplePrint.class);
-
 
     public ConsumerSamplePrint() {
         super();

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/MessageConsumer.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/MessageConsumer.java
@@ -23,7 +23,6 @@ import org.apache.inlong.tubemq.client.config.ConsumerConfig;
 import org.apache.inlong.tubemq.client.exception.TubeClientException;
 import org.apache.inlong.tubemq.corebase.Shutdownable;
 
-
 public interface MessageConsumer extends Shutdownable {
 
     String getClientVersion();

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/MessageFetchManager.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/MessageFetchManager.java
@@ -44,7 +44,6 @@ public class MessageFetchManager {
     private AtomicInteger managerStatus = new AtomicInteger(-1);
     private Thread[] fetchWorkerPool;
 
-
     public MessageFetchManager(final ConsumerConfig consumerConfig,
                                final SimplePushMessageConsumer pushConsumer) {
         this.consumerConfig = consumerConfig;
@@ -86,7 +85,6 @@ public class MessageFetchManager {
         }
         logger.info("Fetch Worker Pool started !");
     }
-
 
     /**
      * Check if the fetch manager is shut down.

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/MessageListener.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/MessageListener.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Executor;
 import org.apache.inlong.tubemq.client.common.PeerInfo;
 import org.apache.inlong.tubemq.corebase.Message;
 
-
 public interface MessageListener {
 
     void receiveMessages(PeerInfo peerInfo, List<Message> messages) throws InterruptedException;
@@ -30,6 +29,5 @@ public interface MessageListener {
     Executor getExecutor();
 
     void stop();
-
 
 }

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/PartitionExt.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/PartitionExt.java
@@ -70,7 +70,6 @@ public class PartitionExt extends Partition {
                 this.limitDlt, this.curDataDlt, this.isRequireSlow) - dltTime;
     }
 
-
     /**
      * Process the consume result.
      *

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/PartitionSelectResult.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/PartitionSelectResult.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.client.consumer;
 
 import org.apache.inlong.tubemq.corebase.cluster.Partition;
 
-
 public class PartitionSelectResult {
     private boolean success;
     private int errCode;
@@ -53,7 +52,6 @@ public class PartitionSelectResult {
         this.usedToken = usedToken;
         this.isLastPackConsumed = isLastPackConsumed;
     }
-
 
     public boolean isSuccess() {
         return success;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/PullMessageConsumer.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/PullMessageConsumer.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.client.consumer;
 import java.util.TreeSet;
 import org.apache.inlong.tubemq.client.exception.TubeClientException;
 
-
 public interface PullMessageConsumer extends MessageConsumer {
 
     boolean isPartitionsReady(long maxWaitTime);

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/PushMessageConsumer.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/PushMessageConsumer.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.client.consumer;
 import java.util.TreeSet;
 import org.apache.inlong.tubemq.client.exception.TubeClientException;
 
-
 public interface PushMessageConsumer extends MessageConsumer {
 
     PushMessageConsumer subscribe(String topic,

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/RmtDataCache.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/RmtDataCache.java
@@ -75,7 +75,6 @@ public class RmtDataCache implements Closeable {
     private AtomicBoolean isClosed = new AtomicBoolean(false);
     private CountDownLatch dataProcessSync = new CountDownLatch(0);
 
-
     /**
      * Construct a remote data cache object.
      *
@@ -920,7 +919,4 @@ public class RmtDataCache implements Closeable {
         }
     }
 }
-
-
-
 

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/SimplePushMessageConsumer.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/SimplePushMessageConsumer.java
@@ -31,7 +31,6 @@ import org.apache.inlong.tubemq.corebase.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * An implementation of PushMessageConsumer.
  */
@@ -43,7 +42,6 @@ public class SimplePushMessageConsumer implements PushMessageConsumer {
     private AtomicLong lastLogPrintTime = new AtomicLong(0);
     private AtomicLong lastFailureCount = new AtomicLong(0);
     private CountDownLatch consumeSync = new CountDownLatch(0);
-
 
     public SimplePushMessageConsumer(final InnerSessionFactory messageSessionFactory,
                                      final ConsumerConfig consumerConfig) throws TubeClientException {
@@ -293,6 +291,5 @@ public class SimplePushMessageConsumer implements PushMessageConsumer {
             }
         }
     }
-
 
 }

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/TopicProcessor.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/consumer/TopicProcessor.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-
 public class TopicProcessor {
     private MessageListener messageListener;
     private TreeSet<String> filterCondStrs;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/exception/TubeClientException.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/exception/TubeClientException.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.client.exception;
 
-
 public class TubeClientException extends Exception {
 
     static final long serialVersionUID = -1L;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/factory/InnerSessionFactory.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/factory/InnerSessionFactory.java
@@ -21,7 +21,6 @@ import org.apache.inlong.tubemq.client.producer.ProducerManager;
 import org.apache.inlong.tubemq.client.producer.qltystats.DefaultBrokerRcvQltyStats;
 import org.apache.inlong.tubemq.corerpc.RpcServiceFactory;
 
-
 public interface InnerSessionFactory extends MessageSessionFactory {
 
     RpcServiceFactory getRpcServiceFactory();

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/factory/MessageSessionFactory.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/factory/MessageSessionFactory.java
@@ -24,7 +24,6 @@ import org.apache.inlong.tubemq.client.exception.TubeClientException;
 import org.apache.inlong.tubemq.client.producer.MessageProducer;
 import org.apache.inlong.tubemq.corebase.Shutdownable;
 
-
 public interface MessageSessionFactory extends Shutdownable {
 
     @Override

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/factory/TubeBaseSessionFactory.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/factory/TubeBaseSessionFactory.java
@@ -39,7 +39,6 @@ import org.apache.inlong.tubemq.corerpc.client.ClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class TubeBaseSessionFactory implements InnerSessionFactory {
 
     private static final Logger logger =
@@ -80,7 +79,6 @@ public class TubeBaseSessionFactory implements InnerSessionFactory {
     public TubeClientConfig getTubeClientConfig() {
         return this.tubeClientConfig;
     }
-
 
     public CopyOnWriteArrayList<Shutdownable> getCurrClients() {
         return this.clientLst;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/factory/TubeMultiSessionFactory.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/factory/TubeMultiSessionFactory.java
@@ -29,7 +29,6 @@ import org.apache.inlong.tubemq.corebase.Shutdownable;
 import org.apache.inlong.tubemq.corerpc.RpcConfig;
 import org.apache.inlong.tubemq.corerpc.netty.NettyClientFactory;
 
-
 public class TubeMultiSessionFactory implements MessageSessionFactory {
 
     private final NettyClientFactory clientFactory = new NettyClientFactory();

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/factory/TubeSingleSessionFactory.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/factory/TubeSingleSessionFactory.java
@@ -30,14 +30,12 @@ import org.apache.inlong.tubemq.corebase.Shutdownable;
 import org.apache.inlong.tubemq.corerpc.RpcConfig;
 import org.apache.inlong.tubemq.corerpc.netty.NettyClientFactory;
 
-
 public class TubeSingleSessionFactory implements MessageSessionFactory {
 
     private static final NettyClientFactory clientFactory = new NettyClientFactory();
     private static final AtomicBoolean isShutDown = new AtomicBoolean(true);
     private static final AtomicLong referenceCounter = new AtomicLong(0);
     private static TubeBaseSessionFactory baseSessionFactory;
-
 
     public TubeSingleSessionFactory(final TubeClientConfig tubeClientConfig) throws TubeClientException {
         if (referenceCounter.incrementAndGet() == 1) {

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/MessageProducer.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/MessageProducer.java
@@ -22,7 +22,6 @@ import org.apache.inlong.tubemq.client.exception.TubeClientException;
 import org.apache.inlong.tubemq.corebase.Message;
 import org.apache.inlong.tubemq.corebase.Shutdownable;
 
-
 public interface MessageProducer extends Shutdownable {
 
     void publish(String topic) throws TubeClientException;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/MessageSentCallback.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/MessageSentCallback.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.client.producer;
 
-
 public interface MessageSentCallback {
 
     void onMessageSent(MessageSentResult result);

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/MessageSentResult.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/MessageSentResult.java
@@ -21,7 +21,6 @@ import org.apache.inlong.tubemq.corebase.Message;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.cluster.Partition;
 
-
 public class MessageSentResult {
     private final boolean success;
     private final int errCode;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/PartitionRouter.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/PartitionRouter.java
@@ -22,7 +22,6 @@ import org.apache.inlong.tubemq.client.exception.TubeClientException;
 import org.apache.inlong.tubemq.corebase.Message;
 import org.apache.inlong.tubemq.corebase.cluster.Partition;
 
-
 public interface PartitionRouter {
 
     Partition getPartition(Message message, List<Partition> partitions) throws TubeClientException;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/ProducerManager.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/ProducerManager.java
@@ -100,7 +100,6 @@ public class ProducerManager {
             new ConcurrentHashMap<>();
     private AtomicBoolean nextWithAuthInfo2M = new AtomicBoolean(false);
 
-
     public ProducerManager(final InnerSessionFactory sessionFactory,
                            final TubeClientConfig tubeClientConfig) throws TubeClientException {
         java.security.Security.setProperty("networkaddress.cache.ttl", "3");

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/RoundRobinPartitionRouter.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/RoundRobinPartitionRouter.java
@@ -25,7 +25,6 @@ import org.apache.inlong.tubemq.client.exception.TubeClientException;
 import org.apache.inlong.tubemq.corebase.Message;
 import org.apache.inlong.tubemq.corebase.cluster.Partition;
 
-
 public class RoundRobinPartitionRouter implements PartitionRouter {
 
     private final AtomicInteger steppedCounter = new AtomicInteger(0);

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/qltystats/BrokerRcvQltyStats.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/qltystats/BrokerRcvQltyStats.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import org.apache.inlong.tubemq.client.exception.TubeClientException;
 import org.apache.inlong.tubemq.corebase.cluster.Partition;
 
-
 public interface BrokerRcvQltyStats {
 
     List<Partition> getAllowedBrokerPartitions(

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/qltystats/BrokerStatsItemSet.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/qltystats/BrokerStatsItemSet.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.client.producer.qltystats;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 
-
 public class BrokerStatsItemSet {
 
     private AtomicLong sendNum = new AtomicLong();

--- a/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/src/main/java/org/apache/flume/sink/tubemq/EventStat.java
+++ b/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/src/main/java/org/apache/flume/sink/tubemq/EventStat.java
@@ -23,8 +23,6 @@ import static org.apache.flume.sink.tubemq.ConfigOptions.TOPIC;
 import java.util.Map;
 import org.apache.flume.Event;
 
-
-
 /**
  * Event with retry time
  */

--- a/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/src/main/java/org/apache/flume/sink/tubemq/TubemqSink.java
+++ b/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/src/main/java/org/apache/flume/sink/tubemq/TubemqSink.java
@@ -317,7 +317,6 @@ public class TubemqSink extends AbstractSink implements Configurable {
         return producerMap.get(topic);
     }
 
-
     class SinkTask implements Runnable {
 
         private void sleepIfOverflow() throws Exception {

--- a/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/src/test/java/org/apache/flume/sink/tubemq/TestTubemqSink.java
+++ b/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/src/test/java/org/apache/flume/sink/tubemq/TestTubemqSink.java
@@ -39,7 +39,6 @@ import org.apache.flume.event.EventBuilder;
 import org.apache.inlong.tubemq.client.config.TubeClientConfig;
 import org.junit.Test;
 
-
 public class TestTubemqSink {
 
     private Context prepareDefaultContext() {
@@ -80,7 +79,6 @@ public class TestTubemqSink {
         Configurables.configure(memoryChannel, context);
         tubeSink.setChannel(memoryChannel);
         tubeSink.start();
-
 
         String msg = "default-topic-test";
         Transaction tx = memoryChannel.getTransaction();

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/Shutdownable.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/Shutdownable.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corebase;
 
-
 public interface Shutdownable {
     void shutdown() throws Throwable;
 }

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TBaseConstants.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TBaseConstants.java
@@ -80,6 +80,4 @@ public class TBaseConstants {
     public static final int META_MAX_MESSAGE_DATA_SIZE_UPPER_LIMIT =
             META_MAX_ALLOWED_MESSAGE_SIZE_MB * META_MB_UNIT_SIZE;
 
-
-
 }

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TErrCodeConstants.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TErrCodeConstants.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corebase;
 
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TokenConstants.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TokenConstants.java
@@ -28,7 +28,6 @@ public class TokenConstants {
     public static final String HYPHEN = "-";
     public static final String BLANK = " ";
 
-
     public static final String TOKEN_MSG_TYPE = "$msgType$";
     public static final String TOKEN_MSG_TIME = "$msgTime$";
 

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/aaaclient/SimpleClientAuthenticateHandler.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/aaaclient/SimpleClientAuthenticateHandler.java
@@ -23,7 +23,6 @@ import org.apache.inlong.tubemq.corebase.TokenConstants;
 import org.apache.inlong.tubemq.corebase.protobuf.generated.ClientMaster;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 
-
 public class SimpleClientAuthenticateHandler implements ClientAuthenticateHandler {
 
     public SimpleClientAuthenticateHandler() {

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/balance/ConsumerEvent.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/balance/ConsumerEvent.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.inlong.tubemq.corebase.cluster.SubscribeInfo;
 
-
 public class ConsumerEvent {
 
     private long rebalanceId;
@@ -29,7 +28,6 @@ public class ConsumerEvent {
     private EventStatus status;
     private List<SubscribeInfo> subscribeInfoList =
             new ArrayList<>();
-
 
     public ConsumerEvent(long rebalanceId,
                          EventType type,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/balance/EventStatus.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/balance/EventStatus.java
@@ -40,7 +40,6 @@ public enum EventStatus {
      * */
     FAILED(-2, "Process failed");
 
-
     private int value;
     private String description;
 

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/BrokerInfo.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/BrokerInfo.java
@@ -43,7 +43,6 @@ public class BrokerInfo implements Comparable<BrokerInfo>, Serializable {
     private String fullInfo;
     private String fullTLSInfo;
 
-
     //create with strBrokerInfo (brokerId:host:port)
     public BrokerInfo(String strBrokerInfo) {
         String[] strBrokers =
@@ -213,7 +212,6 @@ public class BrokerInfo implements Comparable<BrokerInfo>, Serializable {
         }
         return 0;
     }
-
 
     // init the tube broker string info
     private void buildStrInfo() {

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/ConsumerInfo.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/ConsumerInfo.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 
-
 public class ConsumerInfo implements Comparable<ConsumerInfo>, Serializable {
 
     private static final long serialVersionUID = 3095734962491009711L;
@@ -39,7 +38,6 @@ public class ConsumerInfo implements Comparable<ConsumerInfo>, Serializable {
     private int sourceCount = TBaseConstants.META_VALUE_UNDEFINED;
     private boolean overTLS = false;
     private Map<String, Long> requiredPartition;
-
 
     public ConsumerInfo(String consumerId,
                         boolean overTLS,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/MasterInfo.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/MasterInfo.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 
-
 public class MasterInfo {
 
     private final Map<String/* ip:port */, NodeAddrInfo> addrMap4Failover =

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/NodeAddrInfo.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/NodeAddrInfo.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 
-
 public class NodeAddrInfo implements Comparable<NodeAddrInfo>, Serializable {
 
     private static final long serialVersionUID = -1L;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/Partition.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/Partition.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 
-
 public class Partition implements Comparable<Partition>, Serializable {
 
     private static final long serialVersionUID = 7587964123917870096L;
@@ -34,7 +33,6 @@ public class Partition implements Comparable<Partition>, Serializable {
     private String partitionTLSFullStr;
     private int retries = 0;
     private long delayTimeStamp = TBaseConstants.META_VALUE_UNDEFINED;
-
 
     /**
      * create a Partition with broker info , topic and partitionId

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/ProducerInfo.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/ProducerInfo.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import java.util.Set;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 
-
 public class ProducerInfo implements Serializable {
 
     private static final long serialVersionUID = 8324918571047041166L;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/SubscribeInfo.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/SubscribeInfo.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.corebase.cluster;
 
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 
-
 public class SubscribeInfo {
 
     private String consumerId;
@@ -27,7 +26,6 @@ public class SubscribeInfo {
     private Partition partition;
     private boolean overTLS = false;
     private String fullInfo;
-
 
     public SubscribeInfo(String strSubInfo) {
         String strConsumerInfo = strSubInfo.split(TokenConstants.SEGMENT_SEP)[0];

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/TopicInfo.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/cluster/TopicInfo.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 import org.apache.inlong.tubemq.corebase.utils.Tuple2;
 
-
 public class TopicInfo implements Serializable {
 
     private static final long serialVersionUID = -2394664452604382172L;
@@ -33,7 +32,6 @@ public class TopicInfo implements Serializable {
     private int topicStoreNum = 1;
     private boolean acceptPublish;
     private boolean acceptSubscribe;
-
 
     public TopicInfo(final BrokerInfo broker, final String topic,
                      final int partitionNum, final int topicStoreNum,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/daemon/AbstractDaemonService.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/daemon/AbstractDaemonService.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public abstract class AbstractDaemonService implements Service, Runnable {
     private static final Logger logger = LoggerFactory.getLogger(AbstractDaemonService.class);
     private final String name;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/policies/FlowCtrlItem.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/policies/FlowCtrlItem.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.corebase.policies;
 
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 
-
 public class FlowCtrlItem {
 
     private int type = 0;   // 0: current limit, 1: frequency limit, 2: SSD transfer 3: request frequency control
@@ -29,7 +28,6 @@ public class FlowCtrlItem {
     private long dataLtInSZ = TBaseConstants.META_VALUE_UNDEFINED;
     private int freqLtInMs = TBaseConstants.META_VALUE_UNDEFINED;
     private int zeroCnt = TBaseConstants.META_VALUE_UNDEFINED;
-
 
     public FlowCtrlItem(int type, int startTime, int endTime,
                         long dltInM, long dataLtInSZ, int freqLtInMs) {
@@ -131,7 +129,6 @@ public class FlowCtrlItem {
     public int getEndTime() {
         return endTime;
     }
-
 
     public long getDltInM() {
         return dltInM;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/policies/FlowCtrlResult.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/policies/FlowCtrlResult.java
@@ -17,11 +17,9 @@
 
 package org.apache.inlong.tubemq.corebase.policies;
 
-
 public class FlowCtrlResult {
     public long dataLtInSize = Integer.MAX_VALUE;
     public int freqLtInMs = 0;
-
 
     public FlowCtrlResult(long dataLtInSize, int freqLtInMs) {
         this.dataLtInSize = dataLtInSize;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/policies/FlowCtrlRuleHandler.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/policies/FlowCtrlRuleHandler.java
@@ -158,7 +158,6 @@ public class FlowCtrlRuleHandler {
         return null;
     }
 
-
     public int getNormFreqInMs() {
         return this.filterCtrlItem.getFreqLtInMs();
     }
@@ -287,7 +286,6 @@ public class FlowCtrlRuleHandler {
         return qryPriorityId.get();
     }
 
-
     /**
      * @param qryPriorityId
      */
@@ -310,7 +308,6 @@ public class FlowCtrlRuleHandler {
             writeLock.unlock();
         }
     }
-
 
     /**
      * Parse FlowCtrlInfo value

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/policies/SSDCtrlResult.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/policies/SSDCtrlResult.java
@@ -17,11 +17,9 @@
 
 package org.apache.inlong.tubemq.corebase.policies;
 
-
 public class SSDCtrlResult {
     public long dataStartDltInSize = Long.MAX_VALUE;
     public long dataEndDLtInSz = 0;
-
 
     public SSDCtrlResult(long dataStartDltInSize, long dataEndDLtInSz) {
         this.dataStartDltInSize = dataStartDltInSize;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/AbstractSamplePrint.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/AbstractSamplePrint.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.corebase.utils;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-
 public abstract class AbstractSamplePrint {
 
     protected final StringBuilder sBuilder = new StringBuilder(512);
@@ -31,7 +30,6 @@ public abstract class AbstractSamplePrint {
     protected long maxTotalCount = 15;
     protected long maxUncheckDetailCount = 15;
     protected AtomicLong totalUncheckCount = new AtomicLong(10);
-
 
     public AbstractSamplePrint() {
 

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/AddressUtils.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/AddressUtils.java
@@ -28,7 +28,6 @@ import java.util.Enumeration;
 import org.apache.inlong.tubemq.corebase.exception.AddressException;
 import org.jboss.netty.channel.Channel;
 
-
 public class AddressUtils {
 
     private static String localIPAddress = null;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/CheckSum.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/CheckSum.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.corebase.utils;
 
 import java.util.zip.CRC32;
 
-
 public class CheckSum {
     public static final int crc32(byte[] array) {
         return crc32(array, 0, array.length);

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/ConcurrentHashSet.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/ConcurrentHashSet.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corebase.utils;
 
-
 import java.util.AbstractSet;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/DataConverterUtil.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/DataConverterUtil.java
@@ -144,7 +144,6 @@ public class DataConverterUtil {
         return brokerInfoMap;
     }
 
-
     /*********
      * convert string info to  a map of TopicCondition TreeSet
      *
@@ -181,7 +180,6 @@ public class DataConverterUtil {
         }
         return topicConditions;
     }
-
 
     /**
      * convert a list of @link ClientBroker.TransferedMessage with topicName

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/KeyBuilderUtils.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/KeyBuilderUtils.java
@@ -15,15 +15,10 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.corebase.utils;
 
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
-
-
-
-
 
 public class KeyBuilderUtils {
 

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/MixedUtils.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/MixedUtils.java
@@ -25,8 +25,6 @@ import java.util.TreeSet;
 import org.apache.commons.codec.binary.StringUtils;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 
-
-
 public class MixedUtils {
     // java version cache
     private static String javaVersion = "";

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/RegexDef.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/RegexDef.java
@@ -17,8 +17,6 @@
 
 package org.apache.inlong.tubemq.corebase.utils;
 
-
-
 public enum RegexDef {
 
     TMP_FILTER(0, "^[_A-Za-z0-9]+$",
@@ -34,11 +32,9 @@ public enum RegexDef {
             "((?:(?:25[0-5]|2[0-4]\\d|((1\\d{2})|([1-9]?\\d)))\\.){3}(?:25[0-5]|2[0-4]\\d|((1\\d{2})|([1-9]?\\d))))",
             "must matches the IP V4 address regulation");
 
-
     private final int id;
     private final String pattern;
     private final String errMsgTemp;
-
 
     RegexDef(int id, String pattern, String errMsgTemp) {
         this.id = id;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/ServiceStatusHolder.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/ServiceStatusHolder.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class ServiceStatusHolder {
     private static final Logger logger =
             LoggerFactory.getLogger(ServiceStatusHolder.class);
@@ -42,7 +41,6 @@ public class ServiceStatusHolder {
     private static AtomicLong lastWriteStatsTime =
             new AtomicLong(System.currentTimeMillis());
     private static AtomicBoolean isPauseWrite = new AtomicBoolean(false);
-
 
     public static void setStatisParameters(int paraAllowedReadIOExcptCnt,
                                            int paraAllowedWriteIOExcptCnt,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/SettingValidUtils.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/SettingValidUtils.java
@@ -19,9 +19,7 @@ package org.apache.inlong.tubemq.corebase.utils;
 
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 
-
 public class SettingValidUtils {
-
 
     public static int validAndGetMsgSizeInMB(int inMaxMsgSizeInMB) {
         return MixedUtils.mid(inMaxMsgSizeInMB,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/ThreadUtils.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/ThreadUtils.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Thread Utility
  * Copied from <a href="http://hbase.apache.org">Apache HBase Project</a>

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/AbstractServiceInvoker.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/AbstractServiceInvoker.java
@@ -23,7 +23,6 @@ import org.apache.inlong.tubemq.corerpc.client.Callback;
 import org.apache.inlong.tubemq.corerpc.client.ClientFactory;
 import org.apache.inlong.tubemq.corerpc.utils.MixUtils;
 
-
 public abstract class AbstractServiceInvoker implements InvocationHandler {
 
     protected ClientFactory clientFactory;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RemoteConErrStats.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RemoteConErrStats.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.corerpc;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-
 public class RemoteConErrStats {
     private long statisticDuration = 60000;
     private int maxConnAllowedFailCount = 5;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RequestWrapper.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RequestWrapper.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.corerpc;
 import java.io.Serializable;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 
-
 public class RequestWrapper implements Serializable {
 
     private static final long serialVersionUID = -2469749661773014443L;
@@ -32,7 +31,6 @@ public class RequestWrapper implements Serializable {
     private long timeout;
     private int methodId = TBaseConstants.META_VALUE_UNDEFINED;
     private Object requestData;
-
 
     public RequestWrapper(int serviceType, int protocolVersion,
                           int flagId, long timeout) {
@@ -51,7 +49,6 @@ public class RequestWrapper implements Serializable {
         this.flagId = flagId;
         this.timeout = timeout;
     }
-
 
     public int getFlagId() {
         return flagId;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/ResponseWrapper.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/ResponseWrapper.java
@@ -21,9 +21,6 @@ import java.io.Serializable;
 import org.apache.inlong.tubemq.corerpc.exception.StandbyException;
 import org.apache.inlong.tubemq.corerpc.utils.MixUtils;
 
-
-
-
 public class ResponseWrapper implements Serializable {
 
     private static final long serialVersionUID = -3852197088007144687L;
@@ -37,7 +34,6 @@ public class ResponseWrapper implements Serializable {
     private Object responseData;
     private String errMsg;
     private String stackTrace;
-
 
     public ResponseWrapper(int flagId, int serialNo,
                            int serviceType, int locVersion,
@@ -167,6 +163,5 @@ public class ResponseWrapper implements Serializable {
     public void setStackTrace(String stackTrace) {
         this.stackTrace = stackTrace;
     }
-
 
 }

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcConfig.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcConfig.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 
-
 public class RpcConfig {
 
     private final Map<String, Object> params = new HashMap<>();

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcConstants.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcConstants.java
@@ -17,9 +17,7 @@
 
 package org.apache.inlong.tubemq.corerpc;
 
-
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
-
 
 public final class RpcConstants {
 
@@ -46,7 +44,6 @@ public final class RpcConstants {
     public static final String NETTY_WRITE_LOW_MARK = "rpc.netty.write.lowmark";
     public static final String NETTY_TCP_SENDBUF = "rpc.netty.send.buffer";
     public static final String NETTY_TCP_RECEIVEBUF = "rpc.netty.receive.buffer";
-
 
     public static final String TCP_NODELAY = "rpc.tcp.nodelay";
     public static final String TCP_REUSEADDRESS = "rpc.tcp.reuseaddress";

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcDataPack.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcDataPack.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.corerpc;
 import java.nio.ByteBuffer;
 import java.util.List;
 
-
 public class RpcDataPack {
     private int serialNo;
     private List<ByteBuffer> dataLst;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcServiceFactory.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcServiceFactory.java
@@ -40,7 +40,6 @@ import org.apache.inlong.tubemq.corerpc.server.ServiceRpcServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Tube Rpc Service Factory used by all tube service process
  */
@@ -159,7 +158,6 @@ public class RpcServiceFactory {
     public ConcurrentHashMap<Integer, Long> getUnavailableBrokerMap() {
         return brokerUnavailableMap;
     }
-
 
     /**
      * @param remoteAddr
@@ -493,7 +491,6 @@ public class RpcServiceFactory {
         private Class clazzType;
         private NodeAddrInfo addressInfo;
         private RpcConfig config;
-
 
         public ConnectionNode(Class clazzType,
                               NodeAddrInfo nodeAddrInfo,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcServiceFailoverInvoker.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcServiceFailoverInvoker.java
@@ -31,14 +31,12 @@ import org.apache.inlong.tubemq.corerpc.exception.StandbyException;
 import org.apache.inlong.tubemq.corerpc.protocol.RpcProtocol;
 import org.apache.inlong.tubemq.corerpc.utils.MixUtils;
 
-
 public class RpcServiceFailoverInvoker extends AbstractServiceInvoker {
 
     private final AtomicInteger retryCounter = new AtomicInteger(0);
     private MasterInfo masterInfo;
     private Client currentClient;
     private int masterNodeCnt;
-
 
     public RpcServiceFailoverInvoker(ClientFactory clientFactory, Class serviceClass,
                                      RpcConfig conf, MasterInfo masterInfo) {

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcServiceInvoker.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/RpcServiceInvoker.java
@@ -28,7 +28,6 @@ import org.apache.inlong.tubemq.corerpc.exception.OverflowException;
 import org.apache.inlong.tubemq.corerpc.protocol.RpcProtocol;
 import org.apache.inlong.tubemq.corerpc.utils.MixUtils;
 
-
 public class RpcServiceInvoker extends AbstractServiceInvoker {
     private NodeAddrInfo targetAddress;
 

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/benchemark/DefaultSimpleService.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/benchemark/DefaultSimpleService.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corerpc.benchemark;
 
-
 public class DefaultSimpleService implements SimpleService {
 
     @Override

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/benchemark/RcpService4BenchmarkClient.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/benchemark/RcpService4BenchmarkClient.java
@@ -26,7 +26,6 @@ import org.apache.inlong.tubemq.corerpc.RpcConstants;
 import org.apache.inlong.tubemq.corerpc.RpcServiceFactory;
 import org.apache.inlong.tubemq.corerpc.netty.NettyClientFactory;
 
-
 public class RcpService4BenchmarkClient {
 
     private final ExecutorService executorService = Executors.newCachedThreadPool();

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/benchemark/RpcService4BenchmarkServer.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/benchemark/RpcService4BenchmarkServer.java
@@ -21,7 +21,6 @@ import java.util.concurrent.Executors;
 import org.apache.inlong.tubemq.corerpc.RpcConfig;
 import org.apache.inlong.tubemq.corerpc.RpcServiceFactory;
 
-
 public class RpcService4BenchmarkServer {
 
     private final RpcServiceFactory rpcServiceFactory =

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/benchemark/SimpleService.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/benchemark/SimpleService.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corerpc.benchemark;
 
-
 public interface SimpleService {
 
     String echo(String content);

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/client/Client.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/client/Client.java
@@ -22,7 +22,6 @@ import org.apache.inlong.tubemq.corebase.cluster.NodeAddrInfo;
 import org.apache.inlong.tubemq.corerpc.RequestWrapper;
 import org.apache.inlong.tubemq.corerpc.ResponseWrapper;
 
-
 public interface Client {
 
     ResponseWrapper call(RequestWrapper request, Callback callback,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/client/ClientFactory.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/client/ClientFactory.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.corerpc.client;
 import org.apache.inlong.tubemq.corebase.cluster.NodeAddrInfo;
 import org.apache.inlong.tubemq.corerpc.RpcConfig;
 
-
 public interface ClientFactory {
 
     Client getClient(NodeAddrInfo addressInfo, RpcConfig conf) throws Exception;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/codec/PbEnDecoder.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/codec/PbEnDecoder.java
@@ -68,7 +68,6 @@ public class PbEnDecoder {
         return rspDataMessage.toByteArray();
     }
 
-
     /**
      * lizard forgives
      *
@@ -192,7 +191,6 @@ public class PbEnDecoder {
         }
     }
 
-
     public static int getMethIdByName(String methodName) throws Exception {
         Integer methodId = rpcMethodMap.get(methodName);
         if (methodId == null) {
@@ -212,7 +210,6 @@ public class PbEnDecoder {
             return serviceId;
         }
     }
-
 
     /**
      * lizard forgives

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/ClientClosedException.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/ClientClosedException.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corerpc.exception;
 
-
 public class ClientClosedException extends Exception {
     public ClientClosedException() {
     }

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/LocalConnException.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/LocalConnException.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corerpc.exception;
 
-
 public class LocalConnException extends RuntimeException {
 
     private static final long serialVersionUID = 457644321965437488L;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/NetworkException.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/NetworkException.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corerpc.exception;
 
-
 public class NetworkException extends Exception {
 
     private static final long serialVersionUID = 498621339525987435L;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/OverflowException.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/OverflowException.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corerpc.exception;
 
-
 public class OverflowException extends RuntimeException {
 
     private static final long serialVersionUID = 457644321965437488L;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/ServiceStoppingException.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/ServiceStoppingException.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corerpc.exception;
 
-
 public class ServiceStoppingException extends Exception {
 
     private static final long serialVersionUID = 253790701521672986L;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/UnknownProtocolException.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/exception/UnknownProtocolException.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.corerpc.exception;
 
 import java.io.IOException;
 
-
 public class UnknownProtocolException extends IOException {
     private static final long serialVersionUID = 395293249729422L;
 

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/ByteBufferOutputStream.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/ByteBufferOutputStream.java
@@ -24,7 +24,6 @@ import java.util.LinkedList;
 import java.util.List;
 import org.apache.inlong.tubemq.corerpc.RpcConstants;
 
-
 /**
  * Utility to collect data written to an {@link java.io.OutputStream} in {@link java.nio.ByteBuffer}s.
  * Copied from <a href="http://avro.apache.org">Apache Avro Project</a>

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyClient.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyClient.java
@@ -55,7 +55,6 @@ import org.jboss.netty.util.TimerTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * The network Client for tube rpc service
  */
@@ -190,7 +189,6 @@ public class NettyClient implements Client {
         }
         return null;
     }
-
 
     @Override
     public NodeAddrInfo getServerAddressInfo() {

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyClientFactory.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyClientFactory.java
@@ -49,7 +49,6 @@ import org.jboss.netty.util.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Network communication between service processes based on netty
  * see @link MessageSessionFactory Manage network connections
@@ -80,7 +79,6 @@ public class NettyClientFactory implements ClientFactory {
     public NettyClientFactory() {
 
     }
-
 
     /**
      * initial the network by rpc config object
@@ -317,6 +315,5 @@ public class NettyClientFactory implements ClientFactory {
         client.setChannel(future.getChannel(), addressInfo);
         return client;
     }
-
 
 }

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyProtocolDecoder.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyProtocolDecoder.java
@@ -32,7 +32,6 @@ import org.jboss.netty.handler.codec.frame.FrameDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class NettyProtocolDecoder extends FrameDecoder {
     private static final Logger logger =
             LoggerFactory.getLogger(NettyProtocolDecoder.class);
@@ -116,7 +115,6 @@ public class NettyProtocolDecoder extends FrameDecoder {
                     .append(channel.getRemoteAddress().toString()).toString());
         }
     }
-
 
     private void filterIllegalPackageSize(boolean isFrameSize, int inParamValue,
                                           int allowSize, Channel channel) throws UnknownProtocolException {

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyProtocolEncoder.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyProtocolEncoder.java
@@ -27,7 +27,6 @@ import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.oneone.OneToOneEncoder;
 
-
 public class NettyProtocolEncoder extends OneToOneEncoder {
 
     @Override

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyRequestContext.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyRequestContext.java
@@ -35,7 +35,6 @@ import org.jboss.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class NettyRequestContext implements RequestContext {
 
     private static final Logger logger =

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyRpcServer.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/NettyRpcServer.java
@@ -245,7 +245,6 @@ public class NettyRpcServer implements ServiceRpcServer {
 
         private int protocolType = RpcProtocol.RPC_PROTOCOL_TCP;
 
-
         public NettyServerHandler(int protocolType) {
             this.protocolType = protocolType;
         }

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/ReadTimeoutHandler.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/netty/ReadTimeoutHandler.java
@@ -30,7 +30,6 @@ import org.jboss.netty.util.Timeout;
 import org.jboss.netty.util.Timer;
 import org.jboss.netty.util.TimerTask;
 
-
 public class ReadTimeoutHandler extends SimpleChannelUpstreamHandler implements
         LifeCycleAwareChannelHandler, ExternalResourceReleasable {
 

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/protocol/Protocol.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/protocol/Protocol.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.corerpc.protocol;
 import java.util.concurrent.ExecutorService;
 import org.apache.inlong.tubemq.corerpc.server.RequestContext;
 
-
 public interface Protocol {
 
     void registerService(boolean isOverTLS, String serviceName,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/protocol/ProtocolFactory.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/protocol/ProtocolFactory.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.corerpc.protocol;
 import java.util.HashMap;
 import java.util.Map;
 
-
 public class ProtocolFactory {
 
     private static final Map<Integer, Class<? extends Protocol>> protocols =

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/protocol/RpcProtocol.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/protocol/RpcProtocol.java
@@ -34,7 +34,6 @@ import org.apache.inlong.tubemq.corerpc.utils.MixUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class RpcProtocol implements Protocol {
 
     public static final int RPC_PROTOCOL_TCP = 10;
@@ -175,6 +174,5 @@ public class RpcProtocol implements Protocol {
             logger.error("Write response error!", e);
         }
     }
-
 
 }

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/server/RequestContext.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/server/RequestContext.java
@@ -21,7 +21,6 @@ import java.net.SocketAddress;
 import org.apache.inlong.tubemq.corerpc.RequestWrapper;
 import org.apache.inlong.tubemq.corerpc.ResponseWrapper;
 
-
 public interface RequestContext {
 
     RequestWrapper getRequest();

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/server/RpcServer.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/server/RpcServer.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.corerpc.server;
 
-
 public interface RpcServer {
 
     void start(int listenPort) throws Exception;

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/server/ServiceRpcServer.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/server/ServiceRpcServer.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.corerpc.server;
 
 import java.util.concurrent.ExecutorService;
 
-
 public interface ServiceRpcServer extends RpcServer {
 
     void publishService(String serviceName, Object serviceInstance,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/service/BrokerReadService.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/service/BrokerReadService.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.corerpc.service;
 
 import org.apache.inlong.tubemq.corebase.protobuf.generated.ClientBroker;
 
-
 public interface BrokerReadService {
 
     ClientBroker.RegisterResponseB2C consumerRegisterC2B(ClientBroker.RegisterRequestC2B request,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/service/BrokerWriteService.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/service/BrokerWriteService.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.corerpc.service;
 import org.apache.inlong.tubemq.corebase.protobuf.generated.ClientBroker;
 import org.apache.inlong.tubemq.corerpc.client.Callback;
 
-
 public interface BrokerWriteService {
 
     ClientBroker.SendMessageResponseB2P sendMessageP2B(ClientBroker.SendMessageRequestP2B request,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/service/MasterService.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/service/MasterService.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.corerpc.service;
 
 import org.apache.inlong.tubemq.corebase.protobuf.generated.ClientMaster;
 
-
 public interface MasterService {
 
     ClientMaster.RegisterResponseM2P producerRegisterP2M(ClientMaster.RegisterRequestP2M request,

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/utils/MixUtils.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/utils/MixUtils.java
@@ -23,8 +23,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.corerpc.exception.RemoteException;
 import org.apache.inlong.tubemq.corerpc.protocol.RpcProtocol;
 
-
-
 public class MixUtils {
 
     public static String replaceClassNamePrefix(String className,

--- a/inlong-tubemq/tubemq-core/src/test/java/org/apache/inlong/tubemq/corebase/utils/ConcurrentHashSetTest.java
+++ b/inlong-tubemq/tubemq-core/src/test/java/org/apache/inlong/tubemq/corebase/utils/ConcurrentHashSetTest.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.corebase.utils;
 import junit.framework.TestCase;
 import org.junit.Test;
 
-
 public class ConcurrentHashSetTest extends TestCase {
 
     @Test

--- a/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MAMessageProducerExample.java
+++ b/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MAMessageProducerExample.java
@@ -80,8 +80,6 @@ public class MAMessageProducerExample {
             });
     private final AtomicInteger producerIndex = new AtomicInteger(0);
 
-
-
     public MAMessageProducerExample(String masterHostAndPort) throws Exception {
         TubeClientConfig clientConfig = new TubeClientConfig(masterHostAndPort);
         for (int i = 0; i < SESSION_FACTORY_NUM; i++) {
@@ -159,7 +157,6 @@ public class MAMessageProducerExample {
             }
         }
     }
-
 
     public void shutdown() throws Throwable {
         sendExecutorService.shutdownNow();

--- a/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MessageConsumerExample.java
+++ b/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MessageConsumerExample.java
@@ -72,7 +72,6 @@ public final class MessageConsumerExample {
         this.messageConsumer = messageSessionFactory.createPushConsumer(consumerConfig);
     }
 
-
     public static void main(String[] args) {
         final String masterServers = args[0];
         final String topics = args[1];

--- a/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MessagePullConsumerExample.java
+++ b/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MessagePullConsumerExample.java
@@ -34,7 +34,6 @@ import org.apache.inlong.tubemq.corebase.utils.MixedUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * This demo shows how to consume message by pull.
  *
@@ -149,5 +148,4 @@ public final class MessagePullConsumerExample {
         }
     }
 }
-
 

--- a/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MessagePullSetConsumerExample.java
+++ b/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MessagePullSetConsumerExample.java
@@ -38,7 +38,6 @@ import org.apache.inlong.tubemq.corebase.utils.MixedUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * This demo shows how to reset offset on consuming. The main difference from {@link MessagePullConsumerExample}
  * is that we call {@link PullMessageConsumer#completeSubscribe(String, int, boolean, Map)} instead of
@@ -186,5 +185,4 @@ public final class MessagePullSetConsumerExample {
         return messagePullConsumer.getCurConsumedPartitions();
     }
 }
-
 

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/config/AsyncConfiguration.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/config/AsyncConfiguration.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.config;
 
-
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/cluster/ClusterController.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/cluster/ClusterController.java
@@ -162,7 +162,6 @@ public class ClusterController {
         return new TubeMQResult();
     }
 
-
     /**
      * query cluster info
      */

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/cluster/request/DeleteClusterReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/cluster/request/DeleteClusterReq.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.controller.cluster.request;
 
 import lombok.Data;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/cluster/vo/ClusterVo.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/cluster/vo/ClusterVo.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.manager.controller.cluster.vo;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-
 @Data
 @NoArgsConstructor
 public class ClusterVo {

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/GroupController.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/GroupController.java
@@ -104,7 +104,6 @@ public class GroupController {
         return masterService.queryMaster(url);
     }
 
-
     @PostMapping("/offset")
     public @ResponseBody
         TubeMQResult offsetProxy(
@@ -121,7 +120,6 @@ public class GroupController {
         }
     }
 
-
     @PostMapping("/blackGroup")
     public @ResponseBody
         TubeMQResult blackGroupProxy(
@@ -135,7 +133,6 @@ public class GroupController {
                 return TubeMQResult.errorResult(TubeMQErrorConst.NO_SUCH_METHOD);
         }
     }
-
 
     /**
      * query the black list for certain topic
@@ -151,6 +148,5 @@ public class GroupController {
         String url = masterService.getQueryUrl(req);
         return masterService.queryMaster(url);
     }
-
 
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/AllBrokersOffsetRes.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/AllBrokersOffsetRes.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import lombok.Data;
 
-
 @Data
 public class AllBrokersOffsetRes {
 

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/NodeController.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/NodeController.java
@@ -44,7 +44,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping(path = "/v1/node")
 @Slf4j
@@ -74,7 +73,6 @@ public class NodeController {
         return masterService.queryMaster(url);
     }
 
-
     /**
      * query brokers' configuration
      * this method supports batch operation
@@ -87,7 +85,6 @@ public class NodeController {
         String url = masterService.getQueryUrl(queryBody);
         return masterService.queryMaster(url);
     }
-
 
     /**
      * broker method proxy
@@ -116,7 +113,6 @@ public class NodeController {
         }
     }
 
-
     @RequestMapping(value = "/master")
     public @ResponseBody
         TubeMQResult masterMethodProxy(@RequestParam String method, @RequestBody String req) {
@@ -127,6 +123,5 @@ public class NodeController {
                 return TubeMQResult.errorResult(TubeMQErrorConst.NO_SUCH_METHOD);
         }
     }
-
 
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/AddBrokersReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/AddBrokersReq.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 import org.apache.inlong.tubemq.manager.service.TubeConst;
 import org.apache.inlong.tubemq.manager.service.tube.BrokerConf;
 
-
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/AddTopicReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/AddTopicReq.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.controller.node.request;
 
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/CloneBrokersReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/CloneBrokersReq.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import lombok.Data;
 
-
 @Data
 public class CloneBrokersReq {
     private Integer sourceBrokerId;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/OnlineOfflineBrokerReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/OnlineOfflineBrokerReq.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.controller.node.request;
 
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/QueryBrokerCfgReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/QueryBrokerCfgReq.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.manager.controller.node.request;
 import lombok.Data;
 import org.apache.inlong.tubemq.manager.service.TubeConst;
 
-
 @Data
 public class QueryBrokerCfgReq {
 

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/region/RegionController.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/region/RegionController.java
@@ -127,5 +127,4 @@ public class RegionController {
                 brokerList, req.getClusterId());
     }
 
-
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/region/request/CreateRegionReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/region/request/CreateRegionReq.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.controller.region.request;
 
 import java.util.Set;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/region/request/DeleteRegionReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/region/request/DeleteRegionReq.java
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.controller.region.request;
-
 
 import lombok.Data;
 

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/region/request/ModifyRegionReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/region/request/ModifyRegionReq.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.controller.region.request;
 
 import java.util.Set;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/task/TaskController.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/task/TaskController.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.controller.task;
 
-
 import com.google.gson.Gson;
 
 import java.util.Set;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/topic/TopicWebController.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/topic/TopicWebController.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.controller.topic;
 
 import com.google.gson.Gson;
@@ -48,7 +47,6 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class TopicWebController {
 
-
     @Autowired
     private NodeService nodeService;
 
@@ -59,7 +57,6 @@ public class TopicWebController {
 
     @Autowired
     private TopicService topicService;
-
 
     /**
      * broker method proxy

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/topic/request/BatchAddGroupAuthReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/topic/request/BatchAddGroupAuthReq.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.controller.topic.request;
 
 import java.util.List;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/topic/request/GroupAuthItem.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/topic/request/GroupAuthItem.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.controller.topic.request;
 
 import lombok.Data;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/topic/request/TopicAuthItem.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/topic/request/TopicAuthItem.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.controller.topic.request;
 
 import lombok.Data;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/entry/BrokerEntry.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/entry/BrokerEntry.java
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.entry;
-
 
 import java.util.Date;
 import javax.persistence.Entity;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/entry/ClusterEntry.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/entry/ClusterEntry.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.entry;
 
-
 import java.util.Date;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/entry/RegionEntry.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/entry/RegionEntry.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.entry;
 
-
 import java.util.Date;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/entry/TopicEntry.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/entry/TopicEntry.java
@@ -119,7 +119,6 @@ public class TopicEntry {
     @Size(max = 32)
     private String issueMethod;
 
-
     public TopicEntry(String businessName, String schemaName,
                       String username, String passwd, String topic, String encodingType) {
         this.businessName = businessName;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/entry/TopicTaskEntry.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/entry/TopicTaskEntry.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.entry;
 
-
 import java.util.Date;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/enums/ErrorCode.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/enums/ErrorCode.java
@@ -23,7 +23,6 @@ public enum ErrorCode {
     NO_SUCH_TOPIC(101, "no such topic in master"),
     TASK_EXIST(200, "task already exist");
 
-
     private Integer code;
 
     private String message;
@@ -32,7 +31,6 @@ public enum ErrorCode {
         this.code = code;
         this.message = message;
     }
-
 
     public Integer getCode() {
         return code;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/enums/TaskStatusEnum.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/enums/TaskStatusEnum.java
@@ -23,7 +23,6 @@ public enum TaskStatusEnum {
     FAILED(2, "failed"),
     SUCCESS(3, "success");
 
-
     private Integer code;
 
     private String message;
@@ -33,7 +32,6 @@ public enum TaskStatusEnum {
         this.message = message;
     }
 
-
     public Integer getCode() {
         return code;
     }
@@ -41,6 +39,5 @@ public enum TaskStatusEnum {
     public String getMessage() {
         return message;
     }
-
 
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/enums/TaskTypeEnum.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/enums/TaskTypeEnum.java
@@ -29,7 +29,6 @@ public enum TaskTypeEnum {
         this.typeName = typeName;
     }
 
-
     public Integer getTaskType() {
         return taskType;
     }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/executors/AddTopicExecutor.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/executors/AddTopicExecutor.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.executors;
 
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +58,6 @@ public class AddTopicExecutor {
     @Value("${manager.max.config.topic.retry.time:50}")
     private int maxRetryTimes = 5000;
 
-
     @Autowired
     TopicTaskRepository topicTaskRepository;
 
@@ -68,7 +66,6 @@ public class AddTopicExecutor {
 
     @Autowired
     MasterService masterService;
-
 
     @Async("asyncExecutor")
     public void addTopicConfig(Long clusterId, List<TopicTaskEntry> topicTasks) {
@@ -127,7 +124,6 @@ public class AddTopicExecutor {
             topicTaskRepository.save(topicTask);
         }
     }
-
 
     private void handleAddingTopic(MasterEntry masterEntry,
                                    TubeHttpBrokerInfoList brokerInfoList,

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/repository/MasterRepository.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/repository/MasterRepository.java
@@ -23,7 +23,6 @@ import org.apache.inlong.tubemq.manager.entry.MasterEntry;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-
 @Repository
 public interface MasterRepository extends JpaRepository<MasterEntry, Long> {
 

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/repository/TopicTaskRepository.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/repository/TopicTaskRepository.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.repository;
 
-
 import java.util.List;
 
 import org.apache.inlong.tubemq.manager.entry.TopicTaskEntry;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/BrokerServiceImpl.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/BrokerServiceImpl.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.service;
 
 import static org.apache.inlong.tubemq.manager.service.TubeConst.DEFAULT_REGION;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/ClusterServiceImpl.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/ClusterServiceImpl.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.service;
 
 import static org.apache.inlong.tubemq.manager.service.TubeConst.DELETE_FAIL;
@@ -35,7 +34,6 @@ import org.apache.inlong.tubemq.manager.service.interfaces.ClusterService;
 import org.apache.inlong.tubemq.manager.service.interfaces.NodeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
 
 @Component
 @Slf4j
@@ -105,6 +103,5 @@ public class ClusterServiceImpl implements ClusterService {
         masterEntry.setToken(req.getToken());
         nodeService.addNode(masterEntry);
     }
-
 
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/MasterServiceImpl.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/MasterServiceImpl.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.service;
 
 import static org.apache.inlong.tubemq.manager.controller.TubeMQResult.errorResult;
@@ -41,7 +40,6 @@ import org.apache.inlong.tubemq.manager.service.tube.TubeHttpResponse;
 import org.apache.inlong.tubemq.manager.utils.ConvertUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
 
 @Slf4j
 @Component
@@ -100,7 +98,6 @@ public class MasterServiceImpl implements MasterService {
         return gson.toJson(defaultResult);
     }
 
-
     @Override
     public TubeMQResult baseRequestMaster(BaseReq req) {
         if (req.getClusterId() == null) {
@@ -116,7 +113,6 @@ public class MasterServiceImpl implements MasterService {
                 + ConvertUtils.convertReqToQueryStr(req);
         return requestMaster(url);
     }
-
 
     @Override
     public MasterEntry getMasterNode(BaseReq req) {
@@ -141,7 +137,6 @@ public class MasterServiceImpl implements MasterService {
         }
         return master;
     }
-
 
     @Override
     public String getQueryUrl(Map<String, String> queryBody) throws Exception {

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/NodeServiceImpl.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/NodeServiceImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.service;
 
-
 import static org.apache.inlong.tubemq.manager.controller.node.request.AddBrokersReq.getAddBrokerReq;
 
 import com.google.common.collect.Lists;
@@ -69,7 +68,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class NodeServiceImpl implements NodeService {
 
-
     private final CloseableHttpClient httpclient = HttpClients.createDefault();
     private final Gson gson = new Gson();
 
@@ -113,7 +111,6 @@ public class NodeServiceImpl implements NodeService {
         }
         return null;
     }
-
 
     /**
      * clone source broker to generate brokers with the same config and copy the topics in it.
@@ -287,7 +284,6 @@ public class NodeServiceImpl implements NodeService {
         } while (end < needReloadList.size());
     }
 
-
     @Override
     public void close() throws IOException {
         httpclient.close();
@@ -363,7 +359,6 @@ public class NodeServiceImpl implements NodeService {
         }
         return addTopicsToBrokers(masterEntry, req.getBrokerIds(), req.getAddTopicReqs());
     }
-
 
     @Override
     public void addNode(MasterEntry masterEntry) {

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/RegionServiceImpl.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/RegionServiceImpl.java
@@ -33,7 +33,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
-
 @Slf4j
 @Component
 public class RegionServiceImpl implements RegionService {
@@ -148,7 +147,6 @@ public class RegionServiceImpl implements RegionService {
                 .findRegionEntriesByClusterIdEqualsAndRegionIdEquals(clusterId, regionId);
     }
 
-
     private boolean existBrokerIdAlreadyInRegion(Long clusterId, List<Long> newBrokerIdList, Long regionId) {
         if (ValidateUtils.isNull(clusterId) || ValidateUtils.isEmptyList(newBrokerIdList)) {
             return true;
@@ -171,6 +169,5 @@ public class RegionServiceImpl implements RegionService {
         }
         return false;
     }
-
 
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TaskServiceImpl.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TaskServiceImpl.java
@@ -48,7 +48,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-
 @Slf4j
 @Component
 public class TaskServiceImpl implements TaskService {
@@ -115,7 +114,6 @@ public class TaskServiceImpl implements TaskService {
         return taskEntry != null;
     }
 
-
     @Scheduled(cron = "${topic.config.schedule}")
     public void executeTopicConfigTasks() {
         List<ClusterEntry> allClusters = clusterService.getAllClusters();
@@ -127,7 +125,6 @@ public class TaskServiceImpl implements TaskService {
             addTopicExecutor.addTopicConfig(clusterId, topicTasks);
         }
     }
-
 
     @Scheduled(cron = "${broker.reload.schedule}")
     public void reloadBrokers() {
@@ -154,7 +151,6 @@ public class TaskServiceImpl implements TaskService {
         updateCreateTopicTaskStatus(clusterId);
     }
 
-
     @Transactional(rollbackOn = Exception.class)
     public void updateCreateTopicTaskStatus(long clusterId) {
         List<TopicTaskEntry> topicTasks = topicTaskRepository
@@ -175,7 +171,6 @@ public class TaskServiceImpl implements TaskService {
         }
         updateTaskRepo(topicTasks, topicViewMap, brokerInfoList);
     }
-
 
     private void updateTaskRepo(List<TopicTaskEntry> topicTasks,
                                 Map<String, TopicView.TopicViewInfo> topicViewMap,
@@ -199,6 +194,5 @@ public class TaskServiceImpl implements TaskService {
         }
         topicTaskRepository.saveAll(topicTasks);
     }
-
 
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TopicServiceImpl.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TopicServiceImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.service;
 
-
 import com.google.gson.Gson;
 
 import java.io.InputStreamReader;
@@ -115,7 +114,6 @@ public class TopicServiceImpl implements TopicService {
         }
     }
 
-
     @Override
     public TubeMQResult cloneOffsetToOtherGroups(CloneOffsetReq req) {
         MasterEntry master = masterService.getMasterNode(req);
@@ -140,7 +138,6 @@ public class TopicServiceImpl implements TopicService {
         return result;
     }
 
-
     @Override
     public TubeHttpTopicInfoList requestTopicConfigInfo(MasterEntry masterEntry, String topic) {
         String url = TubeConst.SCHEMA + masterEntry.getIp() + ":" + masterEntry.getWebPort()
@@ -160,7 +157,6 @@ public class TopicServiceImpl implements TopicService {
         }
         return null;
     }
-
 
     @Override
     public TubeMQResult rebalanceGroup(RebalanceGroupReq req) {
@@ -193,7 +189,6 @@ public class TopicServiceImpl implements TopicService {
         tubeResult.setData(gson.toJson(rebalanceGroupResult));
         return tubeResult;
     }
-
 
     @Override
     public TubeMQResult deleteOffset(DeleteOffsetReq req) {
@@ -272,7 +267,6 @@ public class TopicServiceImpl implements TopicService {
         }
         return TubeMQResult.errorResult(ErrorCode.TOPIC_NOT_WRITABLE);
     }
-
 
     private void generateOffsetInfo(List<OffsetInfo> offsetPerBroker,
                                     TubeHttpTopicInfoList.TopicInfoList.TopicInfo topicInfo,

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TubeConst.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TubeConst.java
@@ -35,7 +35,6 @@ public class TubeConst {
     public static final String RELOAD_BROKER =
             "/webapi.htm?type=op_modify&method=admin_reload_broker_configure";
 
-
     /**
      * http method type
      */
@@ -62,7 +61,6 @@ public class TubeConst {
     public static final Integer DELETE_FAIL = 0;
     public static final Long DEFAULT_REGION = 0L;
     public static final String TUBEADMIN = "tubeAdmin";
-
 
     /**
      * tube master method name
@@ -92,6 +90,5 @@ public class TubeConst {
     public static final String SCHEMA = "http://";
     public static final String WEB_API = "webapi";
     public static final String TUBE_REQUEST_PATH = "webapi.htm";
-
 
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/interfaces/BrokerService.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/interfaces/BrokerService.java
@@ -81,6 +81,5 @@ public interface BrokerService {
     TubeMQResult deleteOffset(String brokerIp, int brokerWebPort,
                               DeleteOffsetReq req);
 
-
     OffsetQueryRes queryOffset(String brokerIp, int brokerWebPort, QueryOffsetReq req);
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/interfaces/ClusterService.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/interfaces/ClusterService.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.service.interfaces;
 
-
 import java.util.List;
 
 import org.apache.inlong.tubemq.manager.controller.TubeMQResult;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/interfaces/MasterService.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/interfaces/MasterService.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.service.interfaces;
 
 import java.util.Map;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/interfaces/NodeService.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/interfaces/NodeService.java
@@ -82,7 +82,6 @@ public interface NodeService {
     boolean configBrokersForTopics(MasterEntry masterEntry,
                                    Set<String> topics, List<Integer> brokerList, int maxBrokers);
 
-
     void handleReloadBroker(MasterEntry masterEntry, List<Integer> needReloadList);
 
     void close() throws IOException;
@@ -111,7 +110,6 @@ public interface NodeService {
      * @return
      */
     void addNode(MasterEntry masterEntry);
-
 
     /**
      * modify master node

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/interfaces/TopicService.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/interfaces/TopicService.java
@@ -73,7 +73,6 @@ public interface TopicService {
      */
     TubeMQResult deleteOffset(DeleteOffsetReq req);
 
-
     /**
      * query offset given topic and group name
      *

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/AddTopicsResult.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/AddTopicsResult.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import lombok.Data;
 
-
 @Data
 public class AddTopicsResult {
 

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/BrokerConf.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/BrokerConf.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.manager.service.tube;
 
 import lombok.Data;
 
-
 @Data
 public class BrokerConf {
 
@@ -61,7 +60,5 @@ public class BrokerConf {
         this.deletePolicy = other.deletePolicy;
     }
 
-
 }
-
 

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/CleanOffsetResult.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/CleanOffsetResult.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.service.tube;
 
 import com.google.common.collect.Lists;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/IpIdRelation.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/IpIdRelation.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.service.tube;
 
 import lombok.Data;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/RebalanceGroupResult.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/RebalanceGroupResult.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.tubemq.manager.service.tube;
 
 import com.google.common.collect.Lists;

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/TubeHttpGroupDetailInfo.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/TubeHttpGroupDetailInfo.java
@@ -64,5 +64,4 @@ public class TubeHttpGroupDetailInfo {
         return consumerIds;
     }
 
-
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/TubeHttpTopicInfoList.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/tube/TubeHttpTopicInfoList.java
@@ -60,7 +60,6 @@ public class TubeHttpTopicInfoList {
                 private String brokerManageStatus;
             }
 
-
             private String topicName;
             private int topicStatusId;
             private int brokerId;
@@ -90,7 +89,6 @@ public class TubeHttpTopicInfoList {
         private List<TopicInfo> topicInfo;
     }
 
-
     public List<Integer> getTopicBrokerIdList() {
         List<Integer> tmpBrokerIdList = new ArrayList<>();
         if (data != null) {
@@ -104,7 +102,6 @@ public class TubeHttpTopicInfoList {
         }
         return tmpBrokerIdList;
     }
-
 
     public List<TopicInfo> getTopicInfo() {
         if (CollectionUtils.isEmpty(data)) {
@@ -132,7 +129,6 @@ public class TubeHttpTopicInfoList {
         setAttributes(token, req, topicInfo, brokerStr, topic);
         return req;
     }
-
 
     private void setAttributes(String token, AddTopicReq req, TopicInfo topicInfo, String brokerStr,
                                String topic) {

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/utils/ConvertUtils.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/utils/ConvertUtils.java
@@ -39,7 +39,6 @@ import org.apache.inlong.tubemq.manager.controller.topic.request.RebalanceGroupR
 import org.apache.inlong.tubemq.manager.entry.ClusterEntry;
 import org.apache.inlong.tubemq.manager.entry.MasterEntry;
 
-
 @Slf4j
 public class ConvertUtils {
 
@@ -90,7 +89,6 @@ public class ConvertUtils {
         return fieldsList;
     }
 
-
     public static RebalanceConsumerReq convertToRebalanceConsumerReq(RebalanceGroupReq req, String consumerId) {
         RebalanceConsumerReq consumerReq = new RebalanceConsumerReq();
         consumerReq.setConsumerId(consumerId);
@@ -103,7 +101,6 @@ public class ConvertUtils {
         return consumerReq;
     }
 
-
     public static String covertMapToQueryString(Map<String, String> requestMap) throws Exception {
         List<String> queryList = new ArrayList<>();
 
@@ -114,7 +111,6 @@ public class ConvertUtils {
         return StringUtils.join(queryList, "&");
     }
 
-
     public static ClusterVo convertToClusterVo(ClusterEntry clusterEntry, MasterEntry masterEntry) {
         ClusterVo cluster = new ClusterVo();
         cluster.setClusterId(clusterEntry.getClusterId());
@@ -122,6 +118,5 @@ public class ConvertUtils {
         cluster.setClusterName(clusterEntry.getClusterName());
         return cluster;
     }
-
 
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/utils/ValidateUtils.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/utils/ValidateUtils.java
@@ -25,7 +25,6 @@ public class ValidateUtils {
         return object == null;
     }
 
-
     public static boolean isEmptyList(List<?> seq) {
         return isNull(seq) || seq.isEmpty();
     }

--- a/inlong-tubemq/tubemq-manager/src/test/java/org/apache/inlong/tubemq/manager/controller/TestClusterController.java
+++ b/inlong-tubemq/tubemq-manager/src/test/java/org/apache/inlong/tubemq/manager/controller/TestClusterController.java
@@ -145,7 +145,6 @@ public class TestClusterController {
                 result.getResponse().getContentType());
     }
 
-
     private ClusterEntry getOneClusterEntry() {
         ClusterEntry clusterEntry = new ClusterEntry();
         clusterEntry.setClusterId(1);

--- a/inlong-tubemq/tubemq-manager/src/test/java/org/apache/inlong/tubemq/manager/service/region/TestRegionService.java
+++ b/inlong-tubemq/tubemq-manager/src/test/java/org/apache/inlong/tubemq/manager/service/region/TestRegionService.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.manager.service.region;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -49,7 +48,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class TestRegionService {
 
-
     @MockBean
     private RegionRepository regionRepository;
 
@@ -71,7 +69,6 @@ public class TestRegionService {
         TubeMQResult result = regionService.createNewRegion(regionEntry, brokerIdList);
         assertThat(result.getErrMsg().equals(TubeMQErrorConst.RESOURCE_NOT_EXIST));
     }
-
 
     @Test
     public void testCreateNewRegion() {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/Server.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/Server.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server;
 
-
 public interface Server {
 
     void start() throws Exception;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerConfig.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerConfig.java
@@ -173,7 +173,6 @@ public class BrokerConfig extends AbstractFileConfig {
         return socketRecvBuffer;
     }
 
-
     @Override
     protected void loadFileSectAttributes(final Ini iniConf) {
         this.loadBrokerSectConf(iniConf);
@@ -455,10 +454,8 @@ public class BrokerConfig extends AbstractFileConfig {
         return webPort;
     }
 
-
     public String getMasterAddressList() {
         return masterAddressList;
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerServiceServer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerServiceServer.java
@@ -114,7 +114,6 @@ public class BrokerServiceServer implements BrokerReadService, BrokerWriteServic
     // status of broker service.
     private AtomicBoolean started = new AtomicBoolean(false);
 
-
     public BrokerServiceServer(final TubeBroker tubeBroker,
                                final BrokerConfig tubeConfig) {
         this.tubeConfig = tubeConfig;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/TubeBroker.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/TubeBroker.java
@@ -99,7 +99,6 @@ public class TubeBroker implements Stoppable {
     private AtomicLong heartbeatErrors = new AtomicLong(0);
     private int maxReleaseTryCnt = 10;
 
-
     public TubeBroker(final BrokerConfig tubeConfig) throws Exception {
         java.security.Security.setProperty("networkaddress.cache.ttl", "3");
         java.security.Security.setProperty("networkaddress.cache.negative.ttl", "1");
@@ -415,7 +414,6 @@ public class TubeBroker implements Stoppable {
             }
         }
     }
-
 
     private void procConfigFromRegister(StringBuilder sBuilder,
                                         final RegisterResponseM2B response) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/BrokerDefMetadata.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/BrokerDefMetadata.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.broker.metadata;
 
-
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 
@@ -52,7 +51,6 @@ public class BrokerDefMetadata {
     private int memCacheMsgCnt = 5 * 1024;
     // the max interval(milliseconds) that topic's memory cache will flush to disk.
     private int memCacheFlushInterval = 20000;
-
 
     public BrokerDefMetadata() {
 
@@ -184,6 +182,5 @@ public class BrokerDefMetadata {
     public void setMemCacheFlushInterval(int memCacheFlushInterval) {
         this.memCacheFlushInterval = memCacheFlushInterval;
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/ClusterConfigHolder.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/ClusterConfigHolder.java
@@ -24,7 +24,6 @@ import org.apache.inlong.tubemq.corebase.protobuf.generated.ClientMaster;
 import org.apache.inlong.tubemq.corebase.utils.MixedUtils;
 import org.apache.inlong.tubemq.corebase.utils.Tuple2;
 
-
 public class ClusterConfigHolder {
     private static AtomicLong configId =
             new AtomicLong(TBaseConstants.META_VALUE_UNDEFINED);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/MetadataManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/MetadataManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.broker.metadata;
 
-
 import java.beans.PropertyChangeListener;
 import java.util.List;
 import java.util.Map;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/TopicMetadata.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/TopicMetadata.java
@@ -28,7 +28,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.corebase.utils.Tuple2;
 import org.apache.inlong.tubemq.server.common.TStatusConstants;
 
-
 /***
  * Topic's metadata. Contains topic name, partitions count, etc.
  */

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/MessageStoreManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/MessageStoreManager.java
@@ -83,7 +83,6 @@ public class MessageStoreManager implements StoreService {
     // the status that is deleting topic.
     private AtomicBoolean isRemovingTopic = new AtomicBoolean(false);
 
-
     public MessageStoreManager(final TubeBroker tubeBroker,
                                final BrokerConfig tubeConfig) throws IOException {
         super();
@@ -615,7 +614,6 @@ public class MessageStoreManager implements StoreService {
             targetFile.delete();
         }
     }
-
 
     public void refreshMessageStoresHoldVals(Map<String, TopicMetadata> oldTopicConfigMap,
                                              Map<String, TopicMetadata> newTopicConfigMap) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/StoreService.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/StoreService.java
@@ -17,13 +17,11 @@
 
 package org.apache.inlong.tubemq.server.broker.msgstore;
 
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.inlong.tubemq.server.broker.utils.TopicPubStoreInfo;
-
 
 /***
  * Store service interface.

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/FileSegment.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/FileSegment.java
@@ -49,7 +49,6 @@ public class FileSegment implements Segment {
     private AtomicBoolean expired = new AtomicBoolean(false);
     private AtomicBoolean closed = new AtomicBoolean(false);
 
-
     public FileSegment(final long start, final File file, SegmentType type) throws IOException {
         this(start, file, true, type, Long.MAX_VALUE);
     }
@@ -487,6 +486,5 @@ public class FileSegment implements Segment {
             return isEqual;
         }
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/GetMessageResult.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/GetMessageResult.java
@@ -42,7 +42,6 @@ public class GetMessageResult {
     public List<TransferedMessage> transferedMessageList = new ArrayList<>();
     public long maxOffset = TBaseConstants.META_VALUE_UNDEFINED;
 
-
     public GetMessageResult(boolean isSuccess, int retCode, final String errInfo,
                             final long reqOffset, final int lastReadOffset,
                             final long lastRdDataOffset, final int totalSize,
@@ -51,7 +50,6 @@ public class GetMessageResult {
         this(isSuccess, retCode, errInfo, reqOffset, lastReadOffset,
                 lastRdDataOffset, totalSize, tmpCounters, transferedMessageList, false);
     }
-
 
     public GetMessageResult(boolean isSuccess, int retCode, final String errInfo,
                             final long reqOffset, final int lastReadOffset,

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/MsgFileStore.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/MsgFileStore.java
@@ -80,7 +80,6 @@ public class MsgFileStore implements Closeable {
     // close status
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-
     public MsgFileStore(final MessageStore messageStore,
                         final BrokerConfig tubeConfig,
                         final String baseStorePath,

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/mem/GetCacheMsgResult.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/mem/GetCacheMsgResult.java
@@ -33,7 +33,6 @@ public class GetCacheMsgResult {
     public int totalMsgSize;
     public List<ByteBuffer> cacheMsgList;
 
-
     public GetCacheMsgResult(boolean isSuccess, int retCode, long readOffset, String errInfo) {
         this.isSuccess = isSuccess;
         this.retCode = retCode;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/mem/MsgMemStore.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/mem/MsgMemStore.java
@@ -62,7 +62,6 @@ public class MsgMemStore implements Closeable {
     private ByteBuffer cachedIndexSegment;
     private int maxAllowedMsgCount;
 
-
     public MsgMemStore(int maxCacheSize, int maxMsgCount, final BrokerConfig tubeConfig) {
         this.maxDataCacheSize = maxCacheSize;
         this.maxAllowedMsgCount = maxMsgCount;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/nodeinfo/ConsumerNodeInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/nodeinfo/ConsumerNodeInfo.java
@@ -61,7 +61,6 @@ public class ConsumerNodeInfo {
             new AtomicInteger(TBaseConstants.META_VALUE_UNDEFINED);
     private long createTime = System.currentTimeMillis();
 
-
     public ConsumerNodeInfo(final MessageStoreManager storeManager,
                             final String consumerId, Set<String> filterCodes,
                             final String sessionKey, long sessionTime, final String partStr) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/DefaultOffsetManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/DefaultOffsetManager.java
@@ -62,7 +62,6 @@ public class DefaultOffsetManager extends AbstractDaemonService implements Offse
         super.start();
     }
 
-
     @Override
     protected void loopProcess(long intervalMs) {
         while (!super.isStopped()) {
@@ -709,6 +708,5 @@ public class DefaultOffsetManager extends AbstractDaemonService implements Offse
         return new StringBuilder(256).append(topic)
                 .append("-").append(partitionId).toString();
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetService.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetService.java
@@ -26,7 +26,6 @@ import org.apache.inlong.tubemq.corebase.utils.Tuple3;
 import org.apache.inlong.tubemq.server.broker.msgstore.MessageStore;
 import org.apache.inlong.tubemq.server.common.offsetstorage.OffsetStorageInfo;
 
-
 /***
  * Offset manager service interface.
  */

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/stats/CountService.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/stats/CountService.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.server.broker.stats;
 
 import java.util.Map;
 
-
 public interface CountService {
 
     void close(long waitTimeMs);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/stats/GroupCountService.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/stats/GroupCountService.java
@@ -35,7 +35,6 @@ public class GroupCountService extends AbstractDaemonService implements CountSer
     private final CountSet[] countSets = new CountSet[2];
     private AtomicInteger index = new AtomicInteger(0);
 
-
     public GroupCountService(String logFileName, String countType, long scanIntervalMs) {
         super(logFileName, scanIntervalMs);
         this.cntHdr = countType;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/utils/DataStoreUtils.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/utils/DataStoreUtils.java
@@ -91,7 +91,6 @@ public class DataStoreUtils {
     public static final String DATA_FILE_SUFFIX = ".tube";
     public static final String INDEX_FILE_SUFFIX = ".index";
 
-
     public static int getInt(final int offset, final byte[] data) {
         return ByteBuffer.wrap(data, offset, 4).getInt();
     }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/utils/GroupOffsetInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/utils/GroupOffsetInfo.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.server.broker.utils;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.utils.Tuple2;
 
-
 public class GroupOffsetInfo {
     public int partitionId = TBaseConstants.META_VALUE_UNDEFINED;
     public long offsetMin = TBaseConstants.META_VALUE_UNDEFINED;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/utils/TopicPubStoreInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/utils/TopicPubStoreInfo.java
@@ -19,8 +19,6 @@ package org.apache.inlong.tubemq.server.broker.utils;
 
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 
-
-
 public class TopicPubStoreInfo {
 
     public String topicName = null;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/web/AbstractWebHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/web/AbstractWebHandler.java
@@ -29,8 +29,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.inlong.tubemq.server.broker.TubeBroker;
 import org.apache.inlong.tubemq.server.common.webbase.WebMethodMapper.WebApiRegInfo;
 
-
-
 public abstract class AbstractWebHandler extends HttpServlet {
 
     protected final TubeBroker broker;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/web/BrokerAdminServlet.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/web/BrokerAdminServlet.java
@@ -43,12 +43,10 @@ import org.apache.inlong.tubemq.server.common.fielddef.WebFieldDef;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 
-
 /***
  * Broker's web servlet. Used for admin operation, like query consumer's status etc.
  */
 public class BrokerAdminServlet extends AbstractWebHandler {
-
 
     public BrokerAdminServlet(TubeBroker broker) {
         super(broker);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/TServerConstants.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/TServerConstants.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.server.common;
 
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 
-
 public final class TServerConstants {
 
     public static final String TOKEN_JOB_TOPICS = "topics";
@@ -27,7 +26,6 @@ public final class TServerConstants {
     public static final String TOKEN_DEFAULT_FLOW_CONTROL = "default_master_ctrl";
 
     public static final long DEFAULT_DATA_VERSION = 0L;
-
 
     public static final String BLANK_FLOWCTRL_RULES = "[]";
     public static final String BLANK_FILTER_ITEM_STR = ",,";

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/TStatusConstants.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/TStatusConstants.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.common;
 
-
 public class TStatusConstants {
 
     public static final int STATUS_MANAGE_NOT_DEFINED = -2;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/aaaserver/CertificateBrokerHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/aaaserver/CertificateBrokerHandler.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import org.apache.inlong.tubemq.corebase.protobuf.generated.ClientBroker;
 import org.apache.inlong.tubemq.corebase.protobuf.generated.ClientMaster;
 
-
 public interface CertificateBrokerHandler {
 
     void configure(ClientMaster.EnableBrokerFunInfo enableFunInfo);
@@ -33,7 +32,6 @@ public interface CertificateBrokerHandler {
 
     CertifiedResult validProduceAuthorizeInfo(String userName, String topicName,
                                               String msgType, String clientIp);
-
 
     CertifiedResult validConsumeAuthorizeInfo(String userName, String groupName,
                                               String topicName, Set<String> msgTypeLst,

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/aaaserver/CertificateMasterHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/aaaserver/CertificateMasterHandler.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.apache.inlong.tubemq.corebase.protobuf.generated.ClientMaster;
 
-
 public interface CertificateMasterHandler {
 
     CertifiedResult identityValidBrokerInfo(ClientMaster.MasterCertificateInfo authenticInfo);
@@ -34,6 +33,5 @@ public interface CertificateMasterHandler {
 
     CertifiedResult validConsumerAuthorizeInfo(String userName, String groupName, Set<String> topics,
                                                Map<String, TreeSet<String>> topicConds, String clientIp);
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/aaaserver/CertifiedResult.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/aaaserver/CertifiedResult.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.server.common.aaaserver;
 
 import org.apache.inlong.tubemq.corebase.TErrCodeConstants;
 
-
 public class CertifiedResult {
     public boolean result = false;
     public int errCode = TErrCodeConstants.BAD_REQUEST;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/aaaserver/SimpleCertificateBrokerHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/aaaserver/SimpleCertificateBrokerHandler.java
@@ -30,7 +30,6 @@ import org.apache.inlong.tubemq.server.broker.TubeBroker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class SimpleCertificateBrokerHandler implements CertificateBrokerHandler {
 
     private static final Logger logger =

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/aaaserver/SimpleCertificateMasterHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/aaaserver/SimpleCertificateMasterHandler.java
@@ -25,11 +25,9 @@ import org.apache.inlong.tubemq.corebase.protobuf.generated.ClientMaster;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.master.MasterConfig;
 
-
 public class SimpleCertificateMasterHandler implements CertificateMasterHandler {
 
     private final MasterConfig masterConfig;
-
 
     public SimpleCertificateMasterHandler(final MasterConfig masterConfig) {
         this.masterConfig = masterConfig;
@@ -171,6 +169,5 @@ public class SimpleCertificateMasterHandler implements CertificateMasterHandler 
         result.setSuccessResult("", "");
         return result;
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fielddef/CliArgDef.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fielddef/CliArgDef.java
@@ -17,8 +17,6 @@
 
 package org.apache.inlong.tubemq.server.common.fielddef;
 
-
-
 public enum CliArgDef {
 
     // Note: Due to compatibility considerations,
@@ -104,8 +102,6 @@ public enum CliArgDef {
     FILEPATH("f", "file",
             "String: file path.",
             "File path.");
-
-
 
     CliArgDef(String opt, String longOpt, String optDesc) {
         this(opt, longOpt, false, "", optDesc);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fielddef/WebFieldDef.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fielddef/WebFieldDef.java
@@ -22,7 +22,6 @@ import org.apache.inlong.tubemq.corebase.TokenConstants;
 import org.apache.inlong.tubemq.corebase.utils.RegexDef;
 import org.apache.inlong.tubemq.server.common.TServerConstants;
 
-
 public enum WebFieldDef {
 
     // Note: Due to compatibility considerations,
@@ -254,7 +253,6 @@ public enum WebFieldDef {
     ONLYENABLETLS(91, "onlyEnableTLS", "oEtls",
                 WebFieldType.BOOLEAN, "only enable tls broker info.");
 
-
     public final int id;
     public final String name;
     public final String shortName;
@@ -266,7 +264,6 @@ public enum WebFieldDef {
     public final int valMaxLen;
     public final boolean regexCheck;
     public final RegexDef regexDef;
-
 
     WebFieldDef(int id, String name, String shortName, WebFieldType type, String desc) {
         this(id, name, shortName, type, desc, TBaseConstants.META_VALUE_UNDEFINED,

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fielddef/WebFieldType.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fielddef/WebFieldType.java
@@ -17,8 +17,6 @@
 
 package org.apache.inlong.tubemq.server.common.fielddef;
 
-
-
 public enum WebFieldType {
 
     UNKNOWN(-1, "Unknown field type"),
@@ -33,7 +31,6 @@ public enum WebFieldType {
     JSONDICT(9, "Json dict"),
     JSONSET(10, "Json set"),
     DELPOLICY(11, "Delete policy");
-
 
     private int value;
     private String desc;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fileconfig/AbstractFileConfig.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fileconfig/AbstractFileConfig.java
@@ -29,7 +29,6 @@ import org.ini4j.Profile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public abstract class AbstractFileConfig {
     protected static final String SECT_TOKEN_MASTER = "master";
     protected static final String SECT_TOKEN_BROKER = "broker";
@@ -43,7 +42,6 @@ public abstract class AbstractFileConfig {
     private String configPath;
     private long loadFileChkSum = -1;
     private long loadFileModified = -1;
-
 
     public AbstractFileConfig() {
         super();
@@ -81,7 +79,6 @@ public abstract class AbstractFileConfig {
     public void reload() {
         load();
     }
-
 
     /**
      * Get integer configuration value from a specific section with key. It returns a default value if no value
@@ -239,7 +236,6 @@ public abstract class AbstractFileConfig {
         return tlsConfig;
     }
 
-
     protected ZKConfig loadZKeeperSectConf(final Ini iniConf) {
         final Profile.Section zkeeperSect = iniConf.get(SECT_TOKEN_ZKEEPER);
         if (zkeeperSect == null) {
@@ -329,6 +325,5 @@ public abstract class AbstractFileConfig {
         this.loadFileChkSum = FileUtils.checksumCRC32(file);
         return conf;
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/heartbeat/HeartbeatManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/heartbeat/HeartbeatManager.java
@@ -31,7 +31,6 @@ import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class HeartbeatManager {
 
     private static final Logger logger = LoggerFactory.getLogger(HeartbeatManager.class);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/heartbeat/TimeoutListener.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/heartbeat/TimeoutListener.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.common.heartbeat;
 
-
 public interface TimeoutListener {
     void onTimeout(String nodeId, TimeoutInfo timeoutInfo) throws Exception;
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/OffsetStorage.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/OffsetStorage.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-
 public interface OffsetStorage {
 
     void close();

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/OffsetStorageInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/OffsetStorageInfo.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 import org.apache.inlong.tubemq.server.broker.utils.DataStoreUtils;
 
-
 public class OffsetStorageInfo implements Serializable {
 
     private static final long serialVersionUID = -4232003748320500757L;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/ZkOffsetStorage.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/ZkOffsetStorage.java
@@ -35,8 +35,6 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
 /**
  * A offset storage implementation with zookeeper
  */
@@ -69,7 +67,6 @@ public class ZkOffsetStorage implements OffsetStorage {
     private final String strBrokerId;
     private ZKConfig zkConfig;
     private ZooKeeperWatcher zkw;
-
 
     public ZkOffsetStorage(final ZKConfig zkConfig, boolean isBroker, int brokerId) {
         this.zkConfig = zkConfig;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/zookeeper/RecoverableZooKeeper.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/zookeeper/RecoverableZooKeeper.java
@@ -32,7 +32,6 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * A zookeeper that can handle 'recoverable' errors. To handle recoverable errors, developers need
  * to realize that there are two classes of requests: idempotent and non-idempotent requests. Read

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/zookeeper/RetryCounter.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/zookeeper/RetryCounter.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Utility for retry counter.
  *

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/zookeeper/ZKUtil.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/zookeeper/ZKUtil.java
@@ -35,7 +35,6 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Internal utility class for ZooKeeper.
  *
@@ -106,7 +105,6 @@ public class ZKUtil {
         return idx <= 0 ? null : node.substring(0, idx);
     }
 
-
     /**
      * Check if the specified node exists. Sets no watches.
      * <p/>
@@ -132,7 +130,6 @@ public class ZKUtil {
             return -1;
         }
     }
-
 
     /**
      * Get the data at the specified znode and set a watch.
@@ -203,7 +200,6 @@ public class ZKUtil {
             return null;
         }
     }
-
 
     /**
      * Sets the data of the existing znode to be the specified data. Ensures that the current data
@@ -309,7 +305,6 @@ public class ZKUtil {
         }
     }
 
-
     /**
      * Creates the specified node with the specified data and watches it.
      * <p/>
@@ -345,7 +340,6 @@ public class ZKUtil {
             return -1;
         }
     }
-
 
     /**
      * Creates the specified node, if the node does not exist. Does not set a watch and fails
@@ -411,7 +405,6 @@ public class ZKUtil {
         }
     }
 
-
     private static void logRetrievedMsg(final ZooKeeperWatcher zkw, final String znode,
                                         final byte[] data, final boolean watcherSet) {
         if (!logger.isDebugEnabled()) {
@@ -421,7 +414,6 @@ public class ZKUtil {
                 + " byte(s) of data from znode " + znode + (watcherSet ? " and set watcher; " : "; data=")
                 + (data == null ? "null" : data.length == 0 ? "empty" : new String(data))));
     }
-
 
     /**
      * Create a persistent node.
@@ -459,7 +451,6 @@ public class ZKUtil {
     /* The APIs are nearly compatible with old tube */
     /*---------------------------------------------------------*/
     /*---------------------------------------------------------*/
-
 
     /**
      * create the parent path

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/zookeeper/ZooKeeperWatcher.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/offsetstorage/zookeeper/ZooKeeperWatcher.java
@@ -32,7 +32,6 @@ import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Acts as the single ZooKeeper Watcher. One instance of this is instantiated for each Master,
  * RegionServer, and client process.
@@ -163,7 +162,6 @@ public class ZooKeeperWatcher implements Watcher, Abortable {
     public String getBaseZNode() {
         return baseZNode;
     }
-
 
     public void saslLatchAwait() throws InterruptedException {
         saslLatch.await();

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/paramcheck/PBParameterUtils.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/paramcheck/PBParameterUtils.java
@@ -40,9 +40,6 @@ import org.apache.inlong.tubemq.server.master.nodemanage.nodeconsumer.ConsumerBa
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
-
 public class PBParameterUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(PBParameterUtils.class);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/CleanPolType.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/CleanPolType.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.common.statusdef;
 
-
 /*
  * The file clean policy type
  */
@@ -27,7 +26,6 @@ public enum CleanPolType {
     private int code;
     private String description;
 
-
     CleanPolType(int code, String description) {
         this.code = code;
         this.description = description;
@@ -36,7 +34,6 @@ public enum CleanPolType {
     public int getCode() {
         return code;
     }
-
 
     public static CleanPolType valueOf(int code) {
         for (CleanPolType status : CleanPolType.values()) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/EnableStatus.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/EnableStatus.java
@@ -28,7 +28,6 @@ public enum EnableStatus {
     private int code;
     private String description;
 
-
     EnableStatus(int code, String description) {
         this.code = code;
         this.description = description;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/ManageStatus.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/ManageStatus.java
@@ -36,7 +36,6 @@ public enum ManageStatus {
     private boolean isAcceptPublish;
     private boolean isAcceptSubscribe;
 
-
     ManageStatus(int code, String description,
                  boolean acceptPublish,
                  boolean acceptSubscribe) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/StepStatus.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/StepStatus.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.common.statusdef;
 
-
 /*
  * The step status of broker operation
  */
@@ -34,9 +33,6 @@ public enum StepStatus {
     private String description;
     private long normalDelayDurIdnMs;
     private long shortDelayDurIdnMs;
-
-
-
 
     StepStatus(int code, String description,
                long normalDelayDurIdnMs, long shortDelayDurIdnMs) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/TopicStatus.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/TopicStatus.java
@@ -30,7 +30,6 @@ public enum TopicStatus {
     private int code;
     private String description;
 
-
     TopicStatus(int code, String description) {
         this.code = code;
         this.description = description;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/TopicStsChgType.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/statusdef/TopicStsChgType.java
@@ -28,7 +28,6 @@ public enum TopicStsChgType {
     private int code;
     private String description;
 
-
     TopicStsChgType(int code, String description) {
         this.code = code;
         this.description = description;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/Bytes.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/Bytes.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sun.misc.Unsafe;
 
-
 /**
  * Utility class that handles byte arrays, conversions to/from other types, comparisons, hash code
  * generation, manufacturing keys for HashMaps or HashSets, etc.
@@ -151,7 +150,6 @@ public class Bytes {
                 return length1 - length2;
             }
         }
-
 
         enum UnsafeComparer implements Comparer<byte[]> {
             INSTANCE;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/FileUtil.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/FileUtil.java
@@ -68,5 +68,4 @@ public class FileUtil {
         }
     }
 
-
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/HttpUtils.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/HttpUtils.java
@@ -38,8 +38,6 @@ import org.apache.inlong.tubemq.server.common.fielddef.WebFieldDef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
 /**
  * This class is used to process http connection and return result conversion,
  * currently does not support https
@@ -48,7 +46,6 @@ public class HttpUtils {
     // log printer
     private static final Logger logger =
             LoggerFactory.getLogger(HttpUtils.class);
-
 
     /* Send request to target server. */
     public static JsonObject requestWebService(String url,
@@ -122,7 +119,6 @@ public class HttpUtils {
         }
         return jsonRes;
     }
-
 
     public static void main(String[] args) {
         /** Test scenario:

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/SerialIdUtils.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/SerialIdUtils.java
@@ -19,8 +19,6 @@ package org.apache.inlong.tubemq.server.common.utils;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-
-
 public class SerialIdUtils {
 
     public static void updTimeStampSerialIdValue(final AtomicLong serialId) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/WebParameterUtils.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/WebParameterUtils.java
@@ -49,13 +49,10 @@ import org.apache.inlong.tubemq.server.master.metamanage.MetaDataManager;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.BaseEntity;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.TopicPropGroup;
 
-
-
 public class WebParameterUtils {
 
     private static final List<String> allowedDelUnits = Arrays.asList("s", "m", "h");
     private static final List<Integer> allowedPriorityVal = Arrays.asList(1, 2, 3);
-
 
     public static StringBuilder buildFailResult(StringBuilder sBuffer, String errMsg) {
         return sBuffer.append("{\"result\":false,\"errCode\":400,\"errMsg\":\"")
@@ -1600,7 +1597,6 @@ public class WebParameterUtils {
         }
         return false;
     }
-
 
     /**
      * translate broker manage status from int to string value

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/WritableComparator.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/WritableComparator.java
@@ -20,10 +20,8 @@ package org.apache.inlong.tubemq.server.common.utils;
 import java.io.IOException;
 import java.util.HashMap;
 
-
 public class WritableComparator {
     private static HashMap<Class, WritableComparator> comparators = new HashMap();
-
 
     public static int hashBytes(byte[] bytes, int offset, int length) {
         int hash = 1;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/webbase/WebMethodMapper.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/webbase/WebMethodMapper.java
@@ -24,14 +24,12 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class WebMethodMapper {
     // log printer
     private static final Logger logger =
             LoggerFactory.getLogger(WebMethodMapper.class);
     private static final Map<String, WebApiRegInfo> WEB_METHOD_MAP =
             new HashMap<>();
-
 
     public static WebApiRegInfo getWebApiRegInfo(String webMethodName) {
         return WEB_METHOD_MAP.get(webMethodName);
@@ -60,14 +58,11 @@ public class WebMethodMapper {
         return WEB_METHOD_MAP.keySet();
     }
 
-
-
     public static class WebApiRegInfo {
         public Method method;
         public Object webHandler;
         public boolean onlyMasterOp = false;
         public boolean needAuthToken = false;
-
 
         public WebApiRegInfo(Method method,
                              Object webHandler,

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/MasterConfig.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/MasterConfig.java
@@ -34,7 +34,6 @@ import org.ini4j.Profile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Basic config for master service
  */

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/TMaster.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/TMaster.java
@@ -116,7 +116,6 @@ import org.apache.inlong.tubemq.server.master.web.WebServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class TMaster extends HasThread implements MasterService, Stoppable {
 
     private static final Logger logger = LoggerFactory.getLogger(TMaster.class);
@@ -255,7 +254,6 @@ public class TMaster extends HasThread implements MasterService, Stoppable {
     public MasterConfig getMasterConfig() {
         return masterConfig;
     }
-
 
     public MetaDataManager getDefMetaDataManager() {
         return defMetaDataManager;
@@ -1240,7 +1238,6 @@ public class TMaster extends HasThread implements MasterService, Stoppable {
         return initialized;
     }
 
-
     /**
      * Load balance
      */
@@ -1727,7 +1724,6 @@ public class TMaster extends HasThread implements MasterService, Stoppable {
         return outClientConfig;
     }
 
-
     /**
      * build cluster configure info
      *
@@ -1833,7 +1829,6 @@ public class TMaster extends HasThread implements MasterService, Stoppable {
     public ConsumerInfoHolder getConsumerHolder() {
         return consumerHolder;
     }
-
 
     /**
      * check bdb data path, create it if not exist

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/balance/DefaultLoadBalancer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/balance/DefaultLoadBalancer.java
@@ -46,7 +46,6 @@ import org.apache.inlong.tubemq.server.master.nodemanage.nodeconsumer.RebProcess
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /* Load balance class for server side load balance, (partition size) mod (consumer size) */
 public class DefaultLoadBalancer implements LoadBalancer {
     private static final Logger logger = LoggerFactory.getLogger(LoadBalancer.class);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/balance/LoadBalancer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/balance/LoadBalancer.java
@@ -26,7 +26,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.MetaDataManager;
 import org.apache.inlong.tubemq.server.master.nodemanage.nodebroker.BrokerRunManager;
 import org.apache.inlong.tubemq.server.master.nodemanage.nodeconsumer.ConsumerInfoHolder;
 
-
 public interface LoadBalancer {
 
     Map<String, Map<String, List<Partition>>> balanceCluster(
@@ -63,7 +62,6 @@ public interface LoadBalancer {
 
     Map<String, List<Partition>> roundRobinAssignment(List<Partition> partitions,
                                                       List<String> consumers);
-
 
     ConsumerInfo randomAssignment(List<ConsumerInfo> servers);
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/MasterGroupStatus.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/MasterGroupStatus.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.bdbstore;
 
-
 public class MasterGroupStatus {
     private boolean isMaster = false;
     private boolean isWritable = false;
@@ -64,7 +63,6 @@ public class MasterGroupStatus {
     public boolean isReadable() {
         return isReadable;
     }
-
 
     public void setReadable(boolean isReadable) {
         this.isReadable = isReadable;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/MasterNodeInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/MasterNodeInfo.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.bdbstore;
 
-
 public class MasterNodeInfo {
     private String groupName;
     private String nodeName;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbBlackGroupEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbBlackGroupEntity.java
@@ -28,7 +28,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
-
 @Entity
 public class BdbBlackGroupEntity implements Serializable {
 
@@ -66,7 +65,6 @@ public class BdbBlackGroupEntity implements Serializable {
         this.createUser = createUser;
         this.createDate = createDate;
     }
-
 
     public String getAttributes() {
         return attributes;
@@ -139,7 +137,6 @@ public class BdbBlackGroupEntity implements Serializable {
         return TStringUtils.getAttrValFrmAttributes(
                 this.attributes, TStoreConstants.TOKEN_BLK_REASON);
     }
-
 
     public StringBuilder toJsonString(final StringBuilder sBuilder) {
         return sBuilder.append("{\"type\":\"BdbBlackGroupEntity\",")

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbBrokerConfEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbBrokerConfEntity.java
@@ -29,7 +29,6 @@ import org.apache.inlong.tubemq.server.common.TServerConstants;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
-
 @Entity
 public class BdbBrokerConfEntity implements Serializable {
     private static final long serialVersionUID = 3961934697293763691L;
@@ -182,7 +181,6 @@ public class BdbBrokerConfEntity implements Serializable {
     public int getDataStoreType() {
         return dataStoreType;
     }
-
 
     public void setBrokerLoaded() {
         this.isBrokerLoaded = true;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbClusterSettingEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbClusterSettingEntity.java
@@ -27,7 +27,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
-
 /*
  * store the cluster default setting
  *

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbConsumeGroupSettingEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbConsumeGroupSettingEntity.java
@@ -27,7 +27,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
-
 @Entity
 public class BdbConsumeGroupSettingEntity implements Serializable {
 
@@ -40,7 +39,6 @@ public class BdbConsumeGroupSettingEntity implements Serializable {
     private String attributes;
     private String createUser;
     private Date createDate;
-
 
     public BdbConsumeGroupSettingEntity() {
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbConsumerGroupEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbConsumerGroupEntity.java
@@ -25,7 +25,6 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 
-
 @Entity
 public class BdbConsumerGroupEntity implements Serializable {
     private static final long serialVersionUID = 4395735199580415319L;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbGroupFilterCondEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbGroupFilterCondEntity.java
@@ -29,7 +29,6 @@ import org.apache.inlong.tubemq.server.common.statusdef.EnableStatus;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
-
 @Entity
 public class BdbGroupFilterCondEntity implements Serializable {
     private static final long serialVersionUID = 5305233169489425210L;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbGroupFlowCtrlEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbGroupFlowCtrlEntity.java
@@ -29,7 +29,6 @@ import org.apache.inlong.tubemq.server.common.statusdef.EnableStatus;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
-
 @Entity
 public class BdbGroupFlowCtrlEntity implements Serializable {
     private static final long serialVersionUID = 2533735122504168321L;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbTopicAuthControlEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbTopicAuthControlEntity.java
@@ -27,7 +27,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
-
 @Entity
 public class BdbTopicAuthControlEntity implements Serializable {
 
@@ -145,7 +144,6 @@ public class BdbTopicAuthControlEntity implements Serializable {
                         String.valueOf(topicId));
     }
 
-
     public int getMaxMsgSize() {
         String atrVal =
                 TStringUtils.getAttrValFrmAttributes(this.attributes,
@@ -162,7 +160,6 @@ public class BdbTopicAuthControlEntity implements Serializable {
                         TStoreConstants.TOKEN_MAX_MSG_SIZE,
                         String.valueOf(maxMsgSize));
     }
-
 
     public void setCreateInfo(String createUser, Date createDate) {
         if (TStringUtils.isNotBlank(createUser)) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbTopicConfEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbTopicConfEntity.java
@@ -29,7 +29,6 @@ import org.apache.inlong.tubemq.server.common.TServerConstants;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
-
 @Entity
 public class BdbTopicConfEntity implements Serializable {
     private static final long serialVersionUID = -3266492818900652275L;
@@ -57,7 +56,6 @@ public class BdbTopicConfEntity implements Serializable {
     private Date createDate;            //create date
     private String modifyUser;          //modify user
     private Date modifyDate;            //modify date
-
 
     public BdbTopicConfEntity() {
     }
@@ -235,7 +233,6 @@ public class BdbTopicConfEntity implements Serializable {
     public int getBrokerPort() {
         return brokerPort;
     }
-
 
     public String getTopicName() {
         return topicName;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/DataOpErrCode.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/DataOpErrCode.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.metamanage;
 
-
 public enum DataOpErrCode {
     DERR_SUCCESS(200, "Success."),
     DERR_SUCCESS_UNCHANGED(201, "Success, but unchanged"),
@@ -36,7 +35,6 @@ public enum DataOpErrCode {
 
     private int code;
     private String description;
-
 
     DataOpErrCode(int code, String description) {
         this.code = code;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/MetaDataManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/MetaDataManager.java
@@ -67,8 +67,6 @@ import org.apache.inlong.tubemq.server.master.web.model.ClusterGroupVO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
 public class MetaDataManager implements Server {
 
     private static final Logger logger =
@@ -84,8 +82,6 @@ public class MetaDataManager implements Server {
     private volatile boolean isStopped = false;
     private MetaStoreService metaStoreService;
     private long serviceStartTime = System.currentTimeMillis();
-
-
 
     public MetaDataManager(TMaster tMaster) {
         this.tMaster = tMaster;
@@ -323,7 +319,6 @@ public class MetaDataManager implements Server {
         return result.isSuccess();
     }
 
-
     private boolean checkFilterRstrTopics(final String groupName, final String consumerId,
                                           Set<String> enableFltCsmTopicSet,
                                           Map<String, TreeSet<String>> reqTopicCondMap,
@@ -385,7 +380,6 @@ public class MetaDataManager implements Server {
         result.setSuccResult("Ok!");
         return result.isSuccess();
     }
-
 
     // ///////////////////////////////////////////////////////////////////////////////
 
@@ -858,8 +852,6 @@ public class MetaDataManager implements Server {
         return result.isSuccess();
     }
 
-
-
     /**
      * Find the broker and delete all topic info in the broker
      *
@@ -919,7 +911,6 @@ public class MetaDataManager implements Server {
     public Set<String> getTotalConfiguredTopicNames() {
         return metaStoreService.getConfiguredTopicSet();
     }
-
 
     public BrokerConfEntity getBrokerConfByBrokerId(int brokerId) {
         return metaStoreService.getBrokerConfByBrokerId(brokerId);
@@ -1555,8 +1546,6 @@ public class MetaDataManager implements Server {
         return metaStoreService.getTopicCtrlConf(topicNameSet, qryEntity);
     }
 
-
-
     // //////////////////////////////////////////////////////////////////////////////
 
     /**
@@ -2019,6 +2008,5 @@ public class MetaDataManager implements Server {
     }
 
     // //////////////////////////////////////////////////////////////////////////////
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/keepalive/KeepAlive.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/keepalive/KeepAlive.java
@@ -21,7 +21,6 @@ import java.net.InetSocketAddress;
 import org.apache.inlong.tubemq.server.master.bdbstore.MasterGroupStatus;
 import org.apache.inlong.tubemq.server.master.web.model.ClusterGroupVO;
 
-
 public interface KeepAlive {
 
     boolean isMasterNow();

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/BdbMetaStoreServiceImpl.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/BdbMetaStoreServiceImpl.java
@@ -86,10 +86,6 @@ import org.apache.inlong.tubemq.server.master.web.model.ClusterNodeVO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
-
-
 public class BdbMetaStoreServiceImpl implements MetaStoreService {
 
     private static final int REP_HANDLE_RETRY_MAX = 1;
@@ -148,9 +144,6 @@ public class BdbMetaStoreServiceImpl implements MetaStoreService {
     // group consume control configure
     private GroupConsumeCtrlMapper groupConsumeCtrlMapper;
 
-
-
-
     public BdbMetaStoreServiceImpl(String nodeHost, String metaDataPath,
                                    MasterReplicationConfig replicationConfig) {
         this.nodeHost = nodeHost;
@@ -166,7 +159,6 @@ public class BdbMetaStoreServiceImpl implements MetaStoreService {
         this.replicationGroupAdmin =
                 new ReplicationGroupAdmin(this.replicationConfig.getRepGroupName(), helpers);
     }
-
 
     @Override
     public void start() throws Exception {
@@ -568,7 +560,6 @@ public class BdbMetaStoreServiceImpl implements MetaStoreService {
             Set<String> topicNameSet, Set<Integer> brokerIdSet) {
         return topicDeployMapper.getTopicDeployInfoMap(topicNameSet, brokerIdSet);
     }
-
 
     @Override
     public Map<String, List<TopicDeployEntity>> getTopicDepInfoByTopicBrokerId(

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/MetaStoreService.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/MetaStoreService.java
@@ -32,7 +32,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.Gr
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.TopicCtrlEntity;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.TopicDeployEntity;
 
-
 public interface MetaStoreService extends KeepAlive, Server {
 
     boolean checkStoreStatus(boolean checkIsMaster, ProcessResult result);
@@ -219,7 +218,6 @@ public interface MetaStoreService extends KeepAlive, Server {
 
     Map<String, TopicCtrlEntity> getTopicCtrlConf(Set<String> topicNameSet,
                                                   TopicCtrlEntity qryEntity);
-
 
     // group resource configure api
     /**

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/TStoreConstants.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/TStoreConstants.java
@@ -17,9 +17,7 @@
 
 package org.apache.inlong.tubemq.server.master.metamanage.metastore;
 
-
 public final class TStoreConstants {
-
 
     public static final String TOKEN_DEFAULT_CLUSTER_SETTING = "default_cluster_config";
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BaseEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BaseEntity.java
@@ -29,8 +29,6 @@ import org.apache.inlong.tubemq.server.common.TServerConstants;
 import org.apache.inlong.tubemq.server.common.utils.SerialIdUtils;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 
-
-
 // AbstractEntity: entity's abstract class
 public class BaseEntity implements Serializable, Cloneable {
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BrokerConfEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BrokerConfEntity.java
@@ -24,8 +24,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.statusdef.ManageStatus;
 import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbBrokerConfEntity;
 
-
-
 /*
  * store the broker default setting
  *

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/ClusterSettingEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/ClusterSettingEntity.java
@@ -26,8 +26,6 @@ import org.apache.inlong.tubemq.server.common.statusdef.EnableStatus;
 import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbClusterSettingEntity;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
-
-
 /*
  * store the cluster default setting
  *
@@ -51,8 +49,6 @@ public class ClusterSettingEntity extends BaseEntity implements Cloneable {
     private int gloFlowCtrlRuleCnt = TBaseConstants.META_VALUE_UNDEFINED;
     // flow control info
     private String gloFlowCtrlRuleInfo = "";
-
-
 
     public ClusterSettingEntity() {
         super();

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/GroupConsumeCtrlEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/GroupConsumeCtrlEntity.java
@@ -24,7 +24,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.statusdef.EnableStatus;
 import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbGroupFilterCondEntity;
 
-
 /*
  * store the group consume control setting
  *
@@ -39,7 +38,6 @@ public class GroupConsumeCtrlEntity extends BaseEntity implements Cloneable {
     // filter consume setting
     private EnableStatus filterEnable = EnableStatus.STATUS_UNDEFINE;
     private String filterCondStr = "";
-
 
     public GroupConsumeCtrlEntity() {
         super();

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/GroupResCtrlEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/GroupResCtrlEntity.java
@@ -41,7 +41,6 @@ public class GroupResCtrlEntity extends BaseEntity implements Cloneable {
     private int ruleCnt = 0;           // flow control rule count
     private String flowCtrlInfo = "";  // flow control info
 
-
     // only for query
     public GroupResCtrlEntity() {
         super();

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicCtrlEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicCtrlEntity.java
@@ -24,7 +24,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.statusdef.EnableStatus;
 import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbTopicAuthControlEntity;
 
-
 /*
  * store the topic authenticate control setting
  *
@@ -37,7 +36,6 @@ public class TopicCtrlEntity extends BaseEntity implements Cloneable {
     private EnableStatus authCtrlStatus = EnableStatus.STATUS_UNDEFINE;
     private int maxMsgSizeInB = TBaseConstants.META_VALUE_UNDEFINED;
     private int maxMsgSizeInMB = TBaseConstants.META_VALUE_UNDEFINED;
-
 
     public TopicCtrlEntity() {
         super();

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicDeployEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicDeployEntity.java
@@ -24,7 +24,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.statusdef.TopicStatus;
 import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbTopicConfEntity;
 
-
 /*
  * store the topic configure setting
  *
@@ -40,7 +39,6 @@ public class TopicDeployEntity extends BaseEntity implements Cloneable {
     private int brokerPort = TBaseConstants.META_VALUE_UNDEFINED;
     private String brokerAddress = "";
     private int topicNameId = TBaseConstants.META_VALUE_UNDEFINED;
-
 
     public TopicDeployEntity() {
         super();
@@ -113,7 +111,6 @@ public class TopicDeployEntity extends BaseEntity implements Cloneable {
         this.recordKey = KeyBuilderUtils.buildTopicConfRecKey(brokerId, topicName);
         this.brokerAddress = KeyBuilderUtils.buildAddressInfo(brokerIp, brokerPort);
     }
-
 
     public String getRecordKey() {
         return recordKey;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicPropGroup.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicPropGroup.java
@@ -26,7 +26,6 @@ import org.apache.inlong.tubemq.corebase.utils.Tuple2;
 import org.apache.inlong.tubemq.server.common.TServerConstants;
 import org.apache.inlong.tubemq.server.common.statusdef.CleanPolType;
 
-
 /*
  * Topic property group, save topic related storage and configuration information.
  *
@@ -408,7 +407,6 @@ public class TopicPropGroup implements Serializable, Cloneable {
         return changed;
     }
 
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -442,7 +440,6 @@ public class TopicPropGroup implements Serializable, Cloneable {
             return null;
         }
     }
-
 
     private Tuple2<CleanPolType, Long> parseDelPolicy(String delPolicy) {
         long validDuration = 0;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/AbstractMapper.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/AbstractMapper.java
@@ -19,12 +19,10 @@ package org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.mapper;
 
 import org.apache.inlong.tubemq.server.common.exception.LoadMetaException;
 
-
 public interface AbstractMapper {
 
     void close();
 
     void loadConfig() throws LoadMetaException;
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/BrokerConfigMapper.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/BrokerConfigMapper.java
@@ -23,8 +23,6 @@ import java.util.Set;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.BrokerConfEntity;
 
-
-
 public interface BrokerConfigMapper extends AbstractMapper {
 
     boolean addBrokerConf(BrokerConfEntity memEntity, ProcessResult result);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/ClusterConfigMapper.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/ClusterConfigMapper.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.mapper;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.ClusterSettingEntity;
 
-
 public interface ClusterConfigMapper extends AbstractMapper {
 
     boolean addClusterConfig(ClusterSettingEntity memEntity, ProcessResult result);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/GroupConsumeCtrlMapper.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/GroupConsumeCtrlMapper.java
@@ -23,8 +23,6 @@ import java.util.Set;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.GroupConsumeCtrlEntity;
 
-
-
 public interface GroupConsumeCtrlMapper extends AbstractMapper {
 
     boolean addGroupConsumeCtrlConf(GroupConsumeCtrlEntity entity, ProcessResult result);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/GroupResCtrlMapper.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/GroupResCtrlMapper.java
@@ -23,8 +23,6 @@ import java.util.Set;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.GroupResCtrlEntity;
 
-
-
 public interface GroupResCtrlMapper extends AbstractMapper {
 
     boolean addGroupResCtrlConf(GroupResCtrlEntity entity, ProcessResult result);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/TopicCtrlMapper.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/TopicCtrlMapper.java
@@ -24,9 +24,6 @@ import java.util.Set;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.TopicCtrlEntity;
 
-
-
-
 public interface TopicCtrlMapper extends AbstractMapper {
 
     boolean addTopicCtrlConf(TopicCtrlEntity entity, ProcessResult result);
@@ -41,6 +38,5 @@ public interface TopicCtrlMapper extends AbstractMapper {
 
     Map<String, TopicCtrlEntity> getTopicCtrlConf(Set<String> topicNameSet,
                                                   TopicCtrlEntity qryEntity);
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/TopicDeployMapper.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/mapper/TopicDeployMapper.java
@@ -24,8 +24,6 @@ import java.util.Set;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.TopicDeployEntity;
 
-
-
 public interface TopicDeployMapper extends AbstractMapper {
 
     boolean addTopicConf(TopicDeployEntity entity, ProcessResult result);
@@ -35,7 +33,6 @@ public interface TopicDeployMapper extends AbstractMapper {
     boolean delTopicConf(String recordKey, ProcessResult result);
 
     boolean delTopicConfByBrokerId(Integer brokerId, ProcessResult result);
-
 
     boolean hasConfiguredTopics(int brokerId);
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbBrokerConfigMapperImpl.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbBrokerConfigMapperImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.metamanage.metastore.impl.bdbimpl;
 
-
 import com.sleepycat.je.rep.ReplicatedEnvironment;
 import com.sleepycat.persist.EntityCursor;
 import com.sleepycat.persist.EntityStore;
@@ -38,8 +37,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.Br
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.mapper.BrokerConfigMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
 
 public class BdbBrokerConfigMapperImpl implements BrokerConfigMapper {
 
@@ -357,7 +354,6 @@ public class BdbBrokerConfigMapperImpl implements BrokerConfigMapper {
         }
         return true;
     }
-
 
     private void delCacheRecord(int brokerId) {
         BrokerConfEntity curEntity =

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbClusterConfigMapperImpl.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbClusterConfigMapperImpl.java
@@ -35,7 +35,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.mapper.Cl
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class BdbClusterConfigMapperImpl implements ClusterConfigMapper {
 
     private static final Logger logger =

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbGroupConsumeCtrlMapperImpl.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbGroupConsumeCtrlMapperImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.metamanage.metastore.impl.bdbimpl;
 
-
 import com.sleepycat.je.rep.ReplicatedEnvironment;
 import com.sleepycat.persist.EntityCursor;
 import com.sleepycat.persist.EntityStore;
@@ -43,8 +42,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.mapper.Gr
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
 public class BdbGroupConsumeCtrlMapperImpl implements GroupConsumeCtrlMapper {
 
     private static final Logger logger =
@@ -59,8 +56,6 @@ public class BdbGroupConsumeCtrlMapperImpl implements GroupConsumeCtrlMapper {
             grpConsumeCtrlTopicCache = new ConcurrentHashMap<>();
     private ConcurrentHashMap<String/* groupName */, ConcurrentHashSet<String>>
             grpConsumeCtrlGroupCache = new ConcurrentHashMap<>();
-
-
 
     public BdbGroupConsumeCtrlMapperImpl(ReplicatedEnvironment repEnv, StoreConfig storeConfig) {
         groupConsumeStore = new EntityStore(repEnv,

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbGroupResCtrlMapperImpl.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbGroupResCtrlMapperImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.metamanage.metastore.impl.bdbimpl;
 
-
 import com.sleepycat.je.rep.ReplicatedEnvironment;
 import com.sleepycat.persist.EntityCursor;
 import com.sleepycat.persist.EntityStore;
@@ -36,8 +35,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.Gr
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.mapper.GroupResCtrlMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
 
 public class BdbGroupResCtrlMapperImpl implements GroupResCtrlMapper {
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbTopicCtrlMapperImpl.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbTopicCtrlMapperImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.metamanage.metastore.impl.bdbimpl;
 
-
 import com.sleepycat.je.rep.ReplicatedEnvironment;
 import com.sleepycat.persist.EntityCursor;
 import com.sleepycat.persist.EntityStore;
@@ -39,8 +38,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.To
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.mapper.TopicCtrlMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
 
 public class BdbTopicCtrlMapperImpl implements TopicCtrlMapper {
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbTopicDeployMapperImpl.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/BdbTopicDeployMapperImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.metamanage.metastore.impl.bdbimpl;
 
-
 import com.sleepycat.je.rep.ReplicatedEnvironment;
 import com.sleepycat.persist.EntityCursor;
 import com.sleepycat.persist.EntityStore;
@@ -43,8 +42,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.mapper.To
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
 public class BdbTopicDeployMapperImpl implements TopicDeployMapper {
 
     private static final Logger logger =
@@ -62,10 +59,6 @@ public class BdbTopicDeployMapperImpl implements TopicDeployMapper {
             topicNameCacheIndex = new ConcurrentHashMap<>();
     private ConcurrentHashMap<Integer/* brokerId */, ConcurrentHashSet<String>>
             brokerId2TopicCacheIndex = new ConcurrentHashMap<>();
-
-
-
-
 
     public BdbTopicDeployMapperImpl(ReplicatedEnvironment repEnv, StoreConfig storeConfig) {
         topicConfStore = new EntityStore(repEnv,

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/TBDBStoreTables.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/impl/bdbimpl/TBDBStoreTables.java
@@ -17,9 +17,7 @@
 
 package org.apache.inlong.tubemq.server.master.metamanage.metastore.impl.bdbimpl;
 
-
 public final class TBDBStoreTables {
-
 
     public static final String BDB_CLUSTER_SETTING_STORE_NAME = "bdbClusterSetting";
     public static final String BDB_TOPIC_CONFIG_STORE_NAME = "bdbTopicConfig";

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerAbnHolder.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerAbnHolder.java
@@ -36,7 +36,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.Br
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /*
  * The broker node abnormal status reporting management class
  */
@@ -51,7 +50,6 @@ public class BrokerAbnHolder {
     private final MetaDataManager metaDataManager;
     private final AtomicInteger brokerForbiddenCount =
             new AtomicInteger(0);
-
 
     public BrokerAbnHolder(final int maxAutoForbiddenCnt,
                            final MetaDataManager metaDataManager) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerPSInfoHolder.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerPSInfoHolder.java
@@ -26,7 +26,6 @@ import org.apache.inlong.tubemq.corebase.utils.ConcurrentHashSet;
 import org.apache.inlong.tubemq.corebase.utils.Tuple2;
 import org.apache.inlong.tubemq.server.common.statusdef.ManageStatus;
 
-
 /*
  *  Broker publish and subscribe information holder
  */
@@ -40,7 +39,6 @@ public class BrokerPSInfoHolder {
     private final BrokerTopicInfoView subTopicInfoView = new BrokerTopicInfoView();
     // broker publish topic view info
     private final BrokerTopicInfoView pubTopicInfoView = new BrokerTopicInfoView();
-
 
     public BrokerPSInfoHolder() {
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerRunManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerRunManager.java
@@ -32,7 +32,6 @@ import org.apache.inlong.tubemq.server.common.statusdef.ManageStatus;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.BrokerConfEntity;
 
-
 /*
  * Broker operation management class
  */

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerRunStatusInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerRunStatusInfo.java
@@ -35,8 +35,6 @@ import org.apache.inlong.tubemq.server.master.utils.BrokerStatusSamplePrint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
 /*
  * Broker run status management class
  */
@@ -73,8 +71,6 @@ public class BrokerRunStatusInfo {
     private long lastBrokerSyncTime = 0;
     private long maxConfLoadedTimeInMs = 0;
     private long curConfLoadTimeInMs = 0;
-
-
 
     public BrokerRunStatusInfo(BrokerRunManager brokerRunManager, BrokerInfo brokerInfo,
                                ManageStatus mngStatus, String brokerConfInfo,

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerSyncData.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerSyncData.java
@@ -38,7 +38,6 @@ import org.apache.inlong.tubemq.server.common.statusdef.ManageStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /*
  * Broker sync data holder
  */
@@ -64,7 +63,6 @@ public class BrokerSyncData {
     private List<String> syncUpTopicConfInfos = new ArrayList<>();
     Map<String, TopicInfo> syncUpTopicInfoMap = new HashMap<>();
     private long lastDataUpTime = 0;
-
 
     public BrokerSyncData() {
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerTopicInfoView.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/BrokerTopicInfoView.java
@@ -33,7 +33,6 @@ import org.apache.inlong.tubemq.corebase.utils.ConcurrentHashSet;
 import org.apache.inlong.tubemq.corebase.utils.Tuple2;
 import org.apache.inlong.tubemq.server.common.utils.SerialIdUtils;
 
-
 /*
  * Topic view of Broker's current operations
  */

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/DefBrokerRunManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/DefBrokerRunManager.java
@@ -48,7 +48,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.Br
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /*
  * Broker run manager
  */
@@ -174,7 +173,6 @@ public class DefBrokerRunManager implements BrokerRunManager, AliveObserver {
     public Tuple2<Boolean, Boolean> getBrokerPublishStatus(int brokerId) {
         return brokerPubSubInfo.getBrokerPubStatus(brokerId);
     }
-
 
     @Override
     public BrokerAbnHolder getBrokerAbnHolder() {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/ConsumerBandInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/ConsumerBandInfo.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.inlong.tubemq.corebase.cluster.ConsumerInfo;
 
-
 public class ConsumerBandInfo {
 
     private boolean isBandConsume = false;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/ConsumerEventManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/ConsumerEventManager.java
@@ -30,7 +30,6 @@ import org.apache.inlong.tubemq.corebase.cluster.ConsumerInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class ConsumerEventManager {
 
     private static final Logger logger = LoggerFactory.getLogger(ConsumerEventManager.class);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/ConsumerInfoHolder.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/ConsumerInfoHolder.java
@@ -27,7 +27,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.inlong.tubemq.corebase.cluster.ConsumerInfo;
 import org.apache.inlong.tubemq.corebase.utils.Tuple2;
 
-
 public class ConsumerInfoHolder {
 
     private final ConcurrentHashMap<String/* group */, ConsumerBandInfo> groupInfoMap =
@@ -438,7 +437,6 @@ public class ConsumerInfoHolder {
             rwLock.readLock().unlock();
         }
     }
-
 
     public List<String> getAllGroup() {
         try {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/NodeRebInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/NodeRebInfo.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.server.master.nodemanage.nodeconsumer;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-
 public class NodeRebInfo {
 
     private String clientId;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/RebProcessInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeconsumer/RebProcessInfo.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.server.master.nodemanage.nodeconsumer;
 import java.util.ArrayList;
 import java.util.List;
 
-
 public class RebProcessInfo {
 
     public List<String> needProcessList =

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeproducer/ProducerInfoHolder.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/nodemanage/nodeproducer/ProducerInfoHolder.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.inlong.tubemq.corebase.cluster.ProducerInfo;
 
-
 public class ProducerInfoHolder {
 
     final ConcurrentHashMap<String/* producerId */, ProducerInfo> producerInfoMap =

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/utils/BdbStoreSamplePrint.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/utils/BdbStoreSamplePrint.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import org.apache.inlong.tubemq.corebase.utils.AbstractSamplePrint;
 import org.slf4j.Logger;
 
-
 public class BdbStoreSamplePrint extends AbstractSamplePrint {
     /**
      * Log limit class

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/utils/BrokerStatusSamplePrint.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/utils/BrokerStatusSamplePrint.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.server.master.utils;
 import org.apache.inlong.tubemq.corebase.utils.AbstractSamplePrint;
 import org.slf4j.Logger;
 
-
 public class BrokerStatusSamplePrint extends AbstractSamplePrint {
     /**
      * Log limit class

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/utils/SimpleVisitTokenManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/utils/SimpleVisitTokenManager.java
@@ -24,7 +24,6 @@ import org.apache.inlong.tubemq.server.master.MasterConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class SimpleVisitTokenManager extends AbstractDaemonService {
     private static final Logger logger = LoggerFactory.getLogger(SimpleVisitTokenManager.class);
 
@@ -81,6 +80,5 @@ public class SimpleVisitTokenManager extends AbstractDaemonService {
         }
         logger.info("[VisitToken Manager] VisitToken Manager service stopped!");
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/MasterStatusCheckFilter.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/MasterStatusCheckFilter.java
@@ -31,7 +31,6 @@ import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.master.TMaster;
 import org.apache.inlong.tubemq.server.master.metamanage.MetaDataManager;
 
-
 public class MasterStatusCheckFilter implements Filter {
 
     private TMaster master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/UserAuthFilter.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/UserAuthFilter.java
@@ -27,7 +27,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-
 public class UserAuthFilter implements Filter {
 
     @Override

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/WebServer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/WebServer.java
@@ -44,8 +44,6 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
-
-
 public class WebServer implements Server {
 
     private final MasterConfig masterConfig;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/layout/Default.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/layout/Default.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.server.master.web.action.layout;
 import org.apache.inlong.tubemq.server.master.TMaster;
 import org.apache.inlong.tubemq.server.master.web.action.screen.Tubeweb;
 
-
 public class Default extends Tubeweb {
 
     public Default(TMaster master) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/Master.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/Master.java
@@ -42,7 +42,6 @@ import org.apache.inlong.tubemq.server.master.nodemanage.nodeconsumer.ConsumerIn
 import org.apache.inlong.tubemq.server.master.web.simplemvc.Action;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.RequestContext;
 
-
 public class Master implements Action {
 
     private TMaster master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/Tubeweb.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/Tubeweb.java
@@ -23,7 +23,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.MetaDataManager;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.Action;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.RequestContext;
 
-
 public class Tubeweb implements Action {
 
     private TMaster master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/Webapi.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/Webapi.java
@@ -42,7 +42,6 @@ import org.apache.inlong.tubemq.server.master.web.handler.WebTopicDeployHandler;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.Action;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.RequestContext;
 
-
 /**
  * Public APIs for master
  *
@@ -52,7 +51,6 @@ import org.apache.inlong.tubemq.server.master.web.simplemvc.RequestContext;
 public class Webapi implements Action {
 
     private TMaster master;
-
 
     public Webapi(TMaster master) {
         this.master = master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/cluster/ClusterManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/cluster/ClusterManager.java
@@ -29,7 +29,6 @@ import org.apache.inlong.tubemq.server.master.web.model.ClusterGroupVO;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.Action;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.RequestContext;
 
-
 public class ClusterManager implements Action {
 
     private TMaster master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/config/BrokerDetail.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/config/BrokerDetail.java
@@ -21,7 +21,6 @@ import org.apache.inlong.tubemq.server.master.TMaster;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.Action;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.RequestContext;
 
-
 public class BrokerDetail implements Action {
 
     private TMaster master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/config/BrokerList.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/config/BrokerList.java
@@ -34,7 +34,6 @@ import org.apache.inlong.tubemq.server.master.web.model.BrokerVO;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.Action;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.RequestContext;
 
-
 public class BrokerList implements Action {
 
     private TMaster master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/config/TopicDetail.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/config/TopicDetail.java
@@ -21,7 +21,6 @@ import org.apache.inlong.tubemq.server.master.TMaster;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.Action;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.RequestContext;
 
-
 public class TopicDetail implements Action {
 
     private TMaster master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/config/TopicList.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/config/TopicList.java
@@ -21,7 +21,6 @@ import org.apache.inlong.tubemq.server.master.TMaster;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.Action;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.RequestContext;
 
-
 public class TopicList implements Action {
 
     private TMaster master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/consume/Detail.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/action/screen/consume/Detail.java
@@ -21,7 +21,6 @@ import org.apache.inlong.tubemq.server.master.TMaster;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.Action;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.RequestContext;
 
-
 public class Detail implements Action {
 
     private TMaster master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/common/BaseResult.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/common/BaseResult.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 
-
 /**
  * Paging algorithm package.
  *   * <p/>
@@ -348,7 +347,6 @@ public class BaseResult implements Serializable {
 
         return result;
     }
-
 
     public int getPageFirstItem() {
         int cPage = this.getCurrentPage().intValue();

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/common/BrokerQueryResult.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/common/BrokerQueryResult.java
@@ -19,6 +19,5 @@ package org.apache.inlong.tubemq.server.master.web.common;
 
 import org.apache.inlong.tubemq.server.master.web.model.BrokerVO;
 
-
 public class BrokerQueryResult extends QueryResult<BrokerVO> {
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/common/ClusterQueryResult.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/common/ClusterQueryResult.java
@@ -19,6 +19,5 @@ package org.apache.inlong.tubemq.server.master.web.common;
 
 import org.apache.inlong.tubemq.server.master.web.model.ClusterGroupVO;
 
-
 public class ClusterQueryResult extends QueryResult<ClusterGroupVO> {
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/common/QueryResult.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/common/QueryResult.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.server.master.web.common;
 
 import java.util.List;
 
-
 public class QueryResult<E> {
 
     private List<E> resultList;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/AbstractWebHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/AbstractWebHandler.java
@@ -21,8 +21,6 @@ import static org.apache.inlong.tubemq.server.common.webbase.WebMethodMapper.reg
 import org.apache.inlong.tubemq.server.master.TMaster;
 import org.apache.inlong.tubemq.server.master.metamanage.MetaDataManager;
 
-
-
 public abstract class AbstractWebHandler {
 
     protected TMaster master;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/BrokerProcessResult.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/BrokerProcessResult.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.server.master.web.handler;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 
-
 public class BrokerProcessResult extends ProcessResult {
     private int brokerId = TBaseConstants.META_VALUE_UNDEFINED;
     private String brokerIp = "";

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/GroupProcessResult.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/GroupProcessResult.java
@@ -19,8 +19,6 @@ package org.apache.inlong.tubemq.server.master.web.handler;
 
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 
-
-
 public class GroupProcessResult extends ProcessResult {
     private String groupName = "";
     private String topicName = "";

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/TopicProcessResult.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/TopicProcessResult.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.server.master.web.handler;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 
-
 public class TopicProcessResult extends ProcessResult {
     private int brokerId = TBaseConstants.META_VALUE_UNDEFINED;
     private String topicName = "";

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebAdminFlowRuleHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebAdminFlowRuleHandler.java
@@ -33,7 +33,6 @@ import org.apache.inlong.tubemq.server.master.TMaster;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.BaseEntity;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.GroupResCtrlEntity;
 
-
 @Deprecated
 public class WebAdminFlowRuleHandler extends AbstractWebHandler {
 
@@ -41,7 +40,6 @@ public class WebAdminFlowRuleHandler extends AbstractWebHandler {
     private static final List<Integer> allowedPriorityVal = Arrays.asList(1, 2, 3);
     private static final Set<String> rsvGroupNameSet =
             new HashSet<>(Arrays.asList(TServerConstants.TOKEN_DEFAULT_FLOW_CONTROL));
-
 
     public WebAdminFlowRuleHandler(TMaster master) {
         super(master);
@@ -256,6 +254,5 @@ public class WebAdminFlowRuleHandler extends AbstractWebHandler {
         WebParameterUtils.buildSuccessWithDataRetEnd(sBuffer, totalCnt);
         return sBuffer;
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebAdminGroupCtrlHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebAdminGroupCtrlHandler.java
@@ -38,13 +38,11 @@ import org.apache.inlong.tubemq.server.master.nodemanage.nodeconsumer.NodeRebInf
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 @Deprecated
 public class WebAdminGroupCtrlHandler extends AbstractWebHandler {
 
     private static final Logger logger =
             LoggerFactory.getLogger(WebAdminGroupCtrlHandler.class);
-
 
     public WebAdminGroupCtrlHandler(TMaster master) {
         super(master);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebAdminTopicAuthHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebAdminTopicAuthHandler.java
@@ -32,7 +32,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.Ba
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.GroupConsumeCtrlEntity;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.TopicCtrlEntity;
 
-
 @Deprecated
 public class WebAdminTopicAuthHandler extends AbstractWebHandler {
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebBrokerConfHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebBrokerConfHandler.java
@@ -47,7 +47,6 @@ import org.apache.inlong.tubemq.server.master.nodemanage.nodebroker.BrokerAbnHol
 import org.apache.inlong.tubemq.server.master.nodemanage.nodebroker.BrokerRunManager;
 import org.apache.inlong.tubemq.server.master.nodemanage.nodebroker.BrokerRunStatusInfo;
 
-
 /**
  *
  * The class to handle the default config of broker, including:
@@ -674,7 +673,6 @@ public class WebBrokerConfHandler extends AbstractWebHandler {
         WebParameterUtils.buildSuccessWithDataRetEnd(sBuffer, totalCnt);
         return sBuffer;
     }
-
 
     private StringBuilder innAddOrUpdBrokerConfInfo(HttpServletRequest req,
                                                     StringBuilder sBuffer,

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebGroupConsumeCtrlHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebGroupConsumeCtrlHandler.java
@@ -31,9 +31,6 @@ import org.apache.inlong.tubemq.server.master.TMaster;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.BaseEntity;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.GroupConsumeCtrlEntity;
 
-
-
-
 public class WebGroupConsumeCtrlHandler extends AbstractWebHandler {
 
     public WebGroupConsumeCtrlHandler(TMaster master) {
@@ -57,7 +54,6 @@ public class WebGroupConsumeCtrlHandler extends AbstractWebHandler {
         registerModifyWebMethod("admin_delete_group_csmctrl_info",
                 "adminDelGroupConsumeCtrlInfo");
     }
-
 
     /**
      * query group consume control info

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebGroupResCtrlHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebGroupResCtrlHandler.java
@@ -33,8 +33,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.Ba
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.ClusterSettingEntity;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.GroupResCtrlEntity;
 
-
-
 public class WebGroupResCtrlHandler extends AbstractWebHandler {
 
     public WebGroupResCtrlHandler(TMaster master) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebMasterInfoHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebMasterInfoHandler.java
@@ -39,9 +39,6 @@ import org.apache.inlong.tubemq.server.master.nodemanage.nodebroker.BrokerRunMan
 import org.apache.inlong.tubemq.server.master.web.model.ClusterGroupVO;
 import org.apache.inlong.tubemq.server.master.web.model.ClusterNodeVO;
 
-
-
-
 public class WebMasterInfoHandler extends AbstractWebHandler {
 
     /**
@@ -235,7 +232,6 @@ public class WebMasterInfoHandler extends AbstractWebHandler {
         return innAddOrUpdDefFlowControlRule(req, sBuffer, result, false, false);
     }
 
-
     /**
      * Query cluster topic overall view
      *
@@ -361,7 +357,6 @@ public class WebMasterInfoHandler extends AbstractWebHandler {
         return buildRetInfo(sBuffer, false);
     }
 
-
     /**
      * add default flow control rule
      *
@@ -465,7 +460,6 @@ public class WebMasterInfoHandler extends AbstractWebHandler {
         }
         return buildRetInfo(sBuffer, isNewVer);
     }
-
 
     private StringBuilder buildRetInfo(StringBuilder sBuffer, boolean isNewVer) {
         int totalCnt = 0;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebOtherInfoHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebOtherInfoHandler.java
@@ -39,8 +39,6 @@ import org.apache.inlong.tubemq.server.master.nodemanage.nodeconsumer.ConsumerBa
 import org.apache.inlong.tubemq.server.master.nodemanage.nodeconsumer.ConsumerInfoHolder;
 import org.apache.inlong.tubemq.server.master.nodemanage.nodeconsumer.NodeRebInfo;
 
-
-
 public class WebOtherInfoHandler extends AbstractWebHandler {
 
     /**

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebTopicCtrlHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebTopicCtrlHandler.java
@@ -32,9 +32,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.Ba
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.ClusterSettingEntity;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.TopicCtrlEntity;
 
-
-
-
 public class WebTopicCtrlHandler extends AbstractWebHandler {
 
     /**
@@ -45,8 +42,6 @@ public class WebTopicCtrlHandler extends AbstractWebHandler {
     public WebTopicCtrlHandler(TMaster master) {
         super(master);
     }
-
-
 
     @Override
     public void registerWebApiMethod() {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebTopicDeployHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebTopicDeployHandler.java
@@ -45,9 +45,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.To
 import org.apache.inlong.tubemq.server.master.nodemanage.nodebroker.BrokerRunManager;
 import org.apache.inlong.tubemq.server.master.nodemanage.nodebroker.BrokerRunStatusInfo;
 
-
-
-
 public class WebTopicDeployHandler extends AbstractWebHandler {
 
     /**
@@ -58,8 +55,6 @@ public class WebTopicDeployHandler extends AbstractWebHandler {
     public WebTopicDeployHandler(TMaster master) {
         super(master);
     }
-
-
 
     @Override
     public void registerWebApiMethod() {
@@ -108,7 +103,6 @@ public class WebTopicDeployHandler extends AbstractWebHandler {
                 "adminRmvTopicDeployInfo");
         // Deprecated methods end
     }
-
 
     /**
      * Query topic info with new format return
@@ -936,7 +930,6 @@ public class WebTopicDeployHandler extends AbstractWebHandler {
         WebParameterUtils.buildSuccessWithDataRetEnd(sBuffer, totalCnt);
         return sBuffer;
     }
-
 
     /**
      * Internal method to perform topic deploy status change

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/model/BrokerVO.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/model/BrokerVO.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.server.master.web.model;
 
 import java.util.Date;
 
-
 public class BrokerVO {
 
     private int id;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/model/ClusterGroupVO.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/model/ClusterGroupVO.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.server.master.web.model;
 
 import java.util.List;
 
-
 public class ClusterGroupVO {
     private String groupName = "";
     private boolean isPrimaryNodeActive = true;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/model/ClusterNodeVO.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/model/ClusterNodeVO.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.web.model;
 
-
 public class ClusterNodeVO {
     private String nodeName;
     private String hostName;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/Action.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/Action.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.web.simplemvc;
 
-
 public interface Action {
 
     void execute(RequestContext context);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/Context.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/Context.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.server.master.web.simplemvc;
 
 import java.util.Set;
 
-
 public interface Context {
 
     void put(String key, Object value);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/ControlTool.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/ControlTool.java
@@ -20,7 +20,6 @@ package org.apache.inlong.tubemq.server.master.web.simplemvc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class ControlTool {
 
     private static final Logger logger =

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/MappedContext.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/MappedContext.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-
 public class MappedContext implements Context {
 
     private Map map;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/RequestContext.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/RequestContext.java
@@ -23,7 +23,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.conf.WebConfig;
 
-
 public class RequestContext extends MappedContext {
 
     private WebConfig config;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/RequestDispatcher.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/RequestDispatcher.java
@@ -35,7 +35,6 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.CommonAnnotationBeanPostProcessor;
 import org.springframework.context.support.GenericXmlApplicationContext;
 
-
 public class RequestDispatcher {
 
     private static final String TYPE_LAYOUT = "layout";

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/TemplateEngine.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/TemplateEngine.java
@@ -19,7 +19,6 @@ package org.apache.inlong.tubemq.server.master.web.simplemvc;
 
 import java.io.Writer;
 
-
 public interface TemplateEngine {
 
     void init() throws Exception;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/VelocityTemplateEngine.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/VelocityTemplateEngine.java
@@ -26,7 +26,6 @@ import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 
-
 public class VelocityTemplateEngine implements TemplateEngine {
 
     private WebConfig config;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/conf/ConfigFileParser.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/conf/ConfigFileParser.java
@@ -26,7 +26,6 @@ import org.dom4j.Document;
 import org.dom4j.Element;
 import org.dom4j.io.SAXReader;
 
-
 public class ConfigFileParser {
     private static final String ROOT_ELEMENT = "simpleMVConfig";
     private static final String DEFAULT_PAGE = "default-page";

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/conf/WebConfig.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/conf/WebConfig.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.master.web.simplemvc.Action;
 
-
 public class WebConfig {
 
     private final HashMap<String, Object> tools = new HashMap<>();

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/exception/InvalidConfigException.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/exception/InvalidConfigException.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.web.simplemvc.exception;
 
-
 public class InvalidConfigException extends Exception {
 
     public InvalidConfigException() {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/exception/TemplateNotFoundException.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/exception/TemplateNotFoundException.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.web.simplemvc.exception;
 
-
 public class TemplateNotFoundException extends Exception {
 
     public TemplateNotFoundException() {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/BrokerStartup.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/BrokerStartup.java
@@ -23,7 +23,6 @@ import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class BrokerStartup {
 
     private static final Logger logger =

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/CliUtils.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/CliUtils.java
@@ -27,8 +27,6 @@ import org.apache.commons.cli.Options;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.utils.ProcessResult;
 
-
-
 public class CliUtils {
 
     public static boolean getConfigFilePath(final String[] args, ProcessResult result) {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/StoreRepairAdmin.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/StoreRepairAdmin.java
@@ -43,7 +43,6 @@ import org.apache.inlong.tubemq.server.common.utils.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class StoreRepairAdmin {
     private static final Logger logger =
             LoggerFactory.getLogger(StoreRepairAdmin.class);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/cli/CliAbstractBase.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/cli/CliAbstractBase.java
@@ -25,7 +25,6 @@ import org.apache.commons.cli.Options;
 import org.apache.inlong.tubemq.server.common.TubeServerVersion;
 import org.apache.inlong.tubemq.server.common.fielddef.CliArgDef;
 
-
 public abstract class CliAbstractBase {
 
     protected final String commandName;
@@ -67,9 +66,7 @@ public abstract class CliAbstractBase {
         options.addOption(option);
     }
 
-
     protected abstract void initCommandOptions();
-
 
     public abstract boolean processParams(String[] args) throws Exception;
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/cli/CliBrokerAdmin.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/cli/CliBrokerAdmin.java
@@ -28,8 +28,6 @@ import org.apache.inlong.tubemq.server.common.utils.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
 /**
  * This class is use to process CLI Broker Admin process.
  *
@@ -41,7 +39,6 @@ public class CliBrokerAdmin extends CliAbstractBase {
             LoggerFactory.getLogger(CliBrokerAdmin.class);
 
     private static final String defBrokerPortal = "127.0.0.1:8081";
-
 
     public CliBrokerAdmin() {
         super("tubemq-broker-admin.sh");
@@ -108,6 +105,5 @@ public class CliBrokerAdmin extends CliAbstractBase {
         }
 
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/cli/CliConsumer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/cli/CliConsumer.java
@@ -48,8 +48,6 @@ import org.apache.inlong.tubemq.server.common.fielddef.CliArgDef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
 /**
  * This class is use to process CLI Consumer process.
  *
@@ -80,7 +78,6 @@ public class CliConsumer extends CliAbstractBase {
     private boolean isPushConsume = false;
 
     private boolean isStarted = false;
-
 
     public CliConsumer() {
         super("tubemq-consumer-test.sh");
@@ -272,7 +269,6 @@ public class CliConsumer extends CliAbstractBase {
         }
     }
 
-
     private static class TupleValue {
         public Thread[] fetchRunners = null;
 
@@ -288,7 +284,6 @@ public class CliConsumer extends CliAbstractBase {
         }
 
     }
-
 
     // for push consumer callback process
     private static class DefaultMessageListener implements MessageListener {
@@ -385,6 +380,5 @@ public class CliConsumer extends CliAbstractBase {
         }
 
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/cli/CliProducer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/cli/CliProducer.java
@@ -47,7 +47,6 @@ import org.apache.inlong.tubemq.server.common.fielddef.CliArgDef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * This class is use to process CLI Producer process.
  *
@@ -84,7 +83,6 @@ public class CliProducer extends CliAbstractBase {
     private boolean withoutDelay = false;
     private boolean isStarted = false;
     private ExecutorService sendExecutorService = null;
-
 
     public CliProducer() {
         super("tubemq-producer-test.sh");
@@ -369,6 +367,5 @@ public class CliProducer extends CliAbstractBase {
         }
 
     }
-
 
 }

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/common/WebParameterUtilsTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/common/WebParameterUtilsTest.java
@@ -32,9 +32,6 @@ import org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity.To
 import org.junit.Assert;
 import org.junit.Test;
 
-
-
-
 public class WebParameterUtilsTest {
 
     @Test
@@ -282,7 +279,6 @@ public class WebParameterUtilsTest {
         Assert.assertTrue(retValue);
         Assert.assertTrue(result.isSuccess());
         retEntry = (TopicPropGroup) result.getRetData();
-
 
     }
 

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/MasterConfigTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/MasterConfigTest.java
@@ -24,7 +24,6 @@ import org.apache.inlong.tubemq.server.common.fileconfig.ZKConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
-
 public class MasterConfigTest {
     @Test
     public void loadFileSectAttributes() {

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BaseEntityTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BaseEntityTest.java
@@ -24,8 +24,6 @@ import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-
-
 public class BaseEntityTest {
 
     @Test

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BrokerConfEntityTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BrokerConfEntityTest.java
@@ -23,9 +23,6 @@ import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbBrokerConfE
 import org.junit.Assert;
 import org.junit.Test;
 
-
-
-
 public class BrokerConfEntityTest {
 
     @Test
@@ -191,7 +188,6 @@ public class BrokerConfEntityTest {
                 confEntity31.buildBdbBrokerConfEntity();
         BrokerConfEntity confEntity32 = new BrokerConfEntity(bdbEntry3);
         Assert.assertTrue(confEntity32.isDataEquals(confEntity31));
-
 
     }
 

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/ClusterSettingEntityTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/ClusterSettingEntityTest.java
@@ -26,8 +26,6 @@ import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbClusterSett
 import org.junit.Assert;
 import org.junit.Test;
 
-
-
 public class ClusterSettingEntityTest {
 
     @Test

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/GroupConsumeCtrlEntityTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/GroupConsumeCtrlEntityTest.java
@@ -23,9 +23,6 @@ import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbGroupFilter
 import org.junit.Assert;
 import org.junit.Test;
 
-
-
-
 public class GroupConsumeCtrlEntityTest {
 
     @Test
@@ -87,9 +84,6 @@ public class GroupConsumeCtrlEntityTest {
         Assert.assertEquals(ctrlEntry2.getAttributes(), bdbEntity3.getAttributes());
         Assert.assertEquals(ctrlEntry2.getDisableReason(), bdbEntity3.getDisableConsumeReason());
         Assert.assertEquals(ctrlEntry2.getRecordKey(), bdbEntity3.getRecordKey());
-
-
-
 
     }
 

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/GroupResCtrlEntityTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/GroupResCtrlEntityTest.java
@@ -25,8 +25,6 @@ import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbGroupFlowCt
 import org.junit.Assert;
 import org.junit.Test;
 
-
-
 public class GroupResCtrlEntityTest {
 
     @Test
@@ -129,8 +127,6 @@ public class GroupResCtrlEntityTest {
         Assert.assertEquals(resEntry4.getCreateDateStr(), bdbEntity5.getStrCreateDate());
         Assert.assertEquals(resEntry4.getModifyUser(), bdbEntity5.getModifyUser());
         Assert.assertEquals(resEntry4.getModifyDateStr(), bdbEntity5.getStrModifyDate());
-
-
 
     }
 

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicCtrlEntityTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicCtrlEntityTest.java
@@ -25,8 +25,6 @@ import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbTopicAuthCo
 import org.junit.Assert;
 import org.junit.Test;
 
-
-
 public class TopicCtrlEntityTest {
 
     @Test

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicDeployEntityTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicDeployEntityTest.java
@@ -25,8 +25,6 @@ import org.apache.inlong.tubemq.server.master.bdbstore.bdbentitys.BdbTopicConfEn
 import org.junit.Assert;
 import org.junit.Test;
 
-
-
 public class TopicDeployEntityTest {
 
     @Test

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicPropGroupTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/TopicPropGroupTest.java
@@ -22,9 +22,6 @@ import org.apache.inlong.tubemq.server.common.statusdef.CleanPolType;
 import org.junit.Assert;
 import org.junit.Test;
 
-
-
-
 public class TopicPropGroupTest {
 
     @Test

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/TopicPSInfoManagerTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/nodemanage/nodebroker/TopicPSInfoManagerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.nodemanage.nodebroker;
 
-
 import java.util.Arrays;
 import java.util.HashSet;
 import org.apache.inlong.tubemq.corebase.utils.ConcurrentHashSet;


### PR DESCRIPTION
Fixes #1593

### Motivation

There are some empty lines in current codebase, maybe two empty lines or three empty lines.
It's better to checks for empty line separator between tokens, and make them keep the style consistent.

### Modifications

Add EmptyLineSeparator java code checkstyle rule.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
