### PR TITLE
[Inlong-1595] inlong-dataproxy start with the configuration data from inlong-manager.

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/commons/pojo/dataproxy/IDataProxyConfigHolder.java
+++ b/inlong-common/src/main/java/org/apache/inlong/commons/pojo/dataproxy/IDataProxyConfigHolder.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.commons.pojo.dataproxy;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * 
+ * IDataProxyConfigHolder
+ */
+public interface IDataProxyConfigHolder {
+
+    void setDataProxyConfig(AtomicReference<DataProxyCluster> proxyClusterObjectRef);
+}

--- a/inlong-dataproxy/bin/flume-ng
+++ b/inlong-dataproxy/bin/flume-ng
@@ -23,7 +23,7 @@
 # constants
 ################################
 
-FLUME_AGENT_CLASS="org.apache.flume.node.Application"
+FLUME_AGENT_CLASS="org.apache.inlong.dataproxy.node.Application"
 FLUME_AVRO_CLIENT_CLASS="org.apache.flume.client.avro.AvroCLIClient"
 FLUME_VERSION_CLASS="org.apache.flume.tools.VersionInfo"
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/DefaultManagerIpListParser.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/DefaultManagerIpListParser.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.config;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * 
+ * DefaultManagerIpListParser
+ */
+public class DefaultManagerIpListParser implements IManagerIpListParser {
+
+    private Map<String, String> commonProperties;
+
+    /**
+     * setCommonProperties
+     * 
+     * @param commonProperties
+     */
+    @Override
+    public void setCommonProperties(Map<String, String> commonProperties) {
+        this.commonProperties = commonProperties;
+    }
+
+    /**
+     * getIpList
+     * 
+     * @return
+     */
+    @Override
+    public List<String> getIpList() {
+        String managerHosts = this.commonProperties.get(KEY_MANAGER_HOSTS);
+        String[] hostList = StringUtils.split(managerHosts, SEPARATOR);
+        return Arrays.asList(hostList);
+    }
+
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/IManagerIpListParser.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/IManagerIpListParser.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.config;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * IManagerIpListParser
+ */
+public interface IManagerIpListParser {
+
+    String KEY_MANAGER_HOSTS = "manager_hosts";
+    String SEPARATOR = ",";
+    String KEY_MANAGER_TYPE = "manager_type";
+
+    void setCommonProperties(Map<String, String> commonProperties);
+
+    /**
+     * getIpList
+     * @return ip:port list
+     */
+    List<String> getIpList();
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
@@ -1,0 +1,460 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.config;
+
+import java.security.SecureRandom;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.apache.inlong.commons.pojo.dataproxy.CacheClusterObject;
+import org.apache.inlong.commons.pojo.dataproxy.CacheClusterSetObject;
+import org.apache.inlong.commons.pojo.dataproxy.CacheTopicObject;
+import org.apache.inlong.commons.pojo.dataproxy.DataProxyCluster;
+import org.apache.inlong.commons.pojo.dataproxy.DataProxyConfigResponse;
+import org.apache.inlong.commons.pojo.dataproxy.IRepository;
+import org.apache.inlong.commons.pojo.dataproxy.InLongIdObject;
+import org.apache.inlong.commons.pojo.dataproxy.ProxyChannel;
+import org.apache.inlong.commons.pojo.dataproxy.ProxyClusterObject;
+import org.apache.inlong.commons.pojo.dataproxy.ProxySink;
+import org.apache.inlong.commons.pojo.dataproxy.ProxySource;
+import org.apache.inlong.commons.pojo.dataproxy.RepositoryTimerTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+/**
+ * RemoteConfigManager
+ */
+public class RemoteConfigManager implements IRepository {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoteConfigManager.class);
+    public static final String KEY_CONFIG_CHECK_INTERVAL = "configCheckInterval";
+    public static final String KEY_PROXY_CLUSTER_NAME = "proxy_cluster_name";
+    public static final String KEY_SET_NAME = "set_name";
+    public static final char FLUME_SEPARATOR = '.';
+    private static volatile boolean isInit = false;
+    private static RemoteConfigManager instance = null;
+
+    private long reloadInterval;
+    private Timer reloadTimer;
+
+    //
+    private IManagerIpListParser ipListParser;
+    private CloseableHttpClient httpClient;
+    private Gson gson = new Gson();
+    private AtomicInteger managerIpListIndex = new AtomicInteger(0);
+    // config
+    private String dataProxyConfigMd5;
+    private DataProxyCluster currentClusterConfig;
+    private AtomicReference<DataProxyCluster> currentClusterConfigRef;
+    // flume properties
+    private Map<String, String> flumeProperties;
+    // inlong id map
+    private Map<String, InLongIdObject> inlongIdMap;
+
+    private RemoteConfigManager() {
+    }
+
+    /**
+     * get instance for manager
+     * 
+     * @return RemoteConfigManager
+     */
+    @SuppressWarnings("unchecked")
+    public static RemoteConfigManager getInstance() {
+        LOGGER.info("create repository for {}" + RemoteConfigManager.class.getSimpleName());
+        if (isInit && instance != null) {
+            return instance;
+        }
+        synchronized (RemoteConfigManager.class) {
+            if (!isInit) {
+                instance = new RemoteConfigManager();
+                try {
+                    String strReloadInterval = ConfigManager.getInstance().getCommonProperties()
+                            .get(KEY_CONFIG_CHECK_INTERVAL);
+                    instance.reloadInterval = NumberUtils.toLong(strReloadInterval, DEFAULT_HEARTBEAT_INTERVAL_MS);
+                    //
+                    String ipListParserType = ConfigManager.getInstance().getCommonProperties()
+                            .get(IManagerIpListParser.KEY_MANAGER_TYPE);
+                    Class<? extends IManagerIpListParser> ipListParserClass;
+                    ipListParserClass = (Class<? extends IManagerIpListParser>) Class
+                            .forName(ipListParserType);
+                    instance.ipListParser = ipListParserClass.getDeclaredConstructor().newInstance();
+                    //
+                    SecureRandom random = new SecureRandom(String.valueOf(System.currentTimeMillis()).getBytes());
+                    instance.managerIpListIndex.set(random.nextInt());
+                    //
+                    instance.httpClient = constructHttpClient();
+                    //
+                    instance.reload();
+                    instance.setReloadTimer();
+                    isInit = true;
+                } catch (Throwable t) {
+                    LOGGER.error(t.getMessage(), t);
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * reload
+     */
+    public void reload() {
+        LOGGER.info("start to reload config.");
+        String proxyClusterName = ConfigManager.getInstance().getCommonProperties().get(KEY_PROXY_CLUSTER_NAME);
+        String setName = ConfigManager.getInstance().getCommonProperties().get(KEY_SET_NAME);
+        if (StringUtils.isBlank(proxyClusterName) || StringUtils.isBlank(setName)) {
+            return;
+        }
+        //
+        this.ipListParser.setCommonProperties(ConfigManager.getInstance().getCommonProperties());
+        List<String> managerIpList = this.ipListParser.getIpList();
+        for (int i = 0; i < managerIpList.size(); i++) {
+            String host = managerIpList.get(managerIpListIndex.getAndIncrement());
+            if (this.reloadDataProxyConfig(proxyClusterName, setName, host)) {
+                // parse inlong id
+                this.parseInlongIds();
+                // generate flume properties
+                this.generateFlumeProperties();
+                break;
+            }
+        }
+
+        LOGGER.info("end to reload config.");
+    }
+
+    /**
+     * setReloadTimer
+     */
+    private void setReloadTimer() {
+        reloadTimer = new Timer(true);
+        TimerTask task = new RepositoryTimerTask<RemoteConfigManager>(this);
+        reloadTimer.schedule(task, new Date(System.currentTimeMillis() + reloadInterval), reloadInterval);
+    }
+
+    /**
+     * reloadDataProxyConfig
+     * 
+     * @param  host
+     * @return
+     */
+    private boolean reloadDataProxyConfig(String proxyClusterName, String setName, String host) {
+        HttpGet httpGet = null;
+        try {
+            String url = "http://" + host + "/api/inlong/manager/openapi/dataproxy/getAllConfig?clusterName="
+                    + proxyClusterName + "&setName=" + setName;
+            if (StringUtils.isNotBlank(this.dataProxyConfigMd5)) {
+                url += "&md5=" + this.dataProxyConfigMd5;
+            }
+            LOGGER.info("start to request {} to get config info", url);
+            httpGet = new HttpGet(url);
+            httpGet.addHeader(HttpHeaders.CONNECTION, "close");
+
+            // request with get
+            CloseableHttpResponse response = httpClient.execute(httpGet);
+            String returnStr = EntityUtils.toString(response.getEntity());
+            // get bid <-> topic and m value.
+
+            DataProxyConfigResponse proxyResponse = gson.fromJson(returnStr, DataProxyConfigResponse.class);
+            if (!proxyResponse.isResult()) {
+                LOGGER.info("Fail to get config info from url:{}, error code is {}", url, proxyResponse.getErrCode());
+                return false;
+            }
+
+            this.dataProxyConfigMd5 = proxyResponse.getMd5();
+            DataProxyCluster clusterObj = proxyResponse.getData();
+            this.currentClusterConfig = clusterObj;
+            this.currentClusterConfigRef.set(clusterObj);
+        } catch (Exception ex) {
+            LOGGER.error("exception caught", ex);
+            return false;
+        } finally {
+            if (httpGet != null) {
+                httpGet.releaseConnection();
+            }
+        }
+        return true;
+    }
+
+    /**
+     * constructHttpClient
+     * 
+     * @return
+     */
+    private static synchronized CloseableHttpClient constructHttpClient() {
+        long timeoutInMs = TimeUnit.MILLISECONDS.toMillis(50000);
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout((int) timeoutInMs)
+                .setSocketTimeout((int) timeoutInMs).build();
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+        httpClientBuilder.setDefaultRequestConfig(requestConfig);
+        return httpClientBuilder.build();
+    }
+
+    /**
+     * getZone
+     * 
+     * @return
+     */
+    public String getZone() {
+        if (this.currentClusterConfig != null) {
+            return this.currentClusterConfig.getProxyCluster().getZone();
+        }
+        return null;
+    }
+
+    /**
+     * getProxyClusterName
+     * 
+     * @return
+     */
+    public String getProxyClusterName() {
+        if (this.currentClusterConfig != null) {
+            return this.currentClusterConfig.getProxyCluster().getName();
+        }
+        return ConfigManager.getInstance().getCommonProperties().get(KEY_PROXY_CLUSTER_NAME);
+    }
+
+    /**
+     * getProxyClusterName
+     * 
+     * @return
+     */
+    public String getSetName() {
+        if (this.currentClusterConfig != null) {
+            return this.currentClusterConfig.getProxyCluster().getSetName();
+        }
+        return ConfigManager.getInstance().getCommonProperties().get(KEY_SET_NAME);
+    }
+
+    /**
+     * parseInlongIds
+     */
+    private void parseInlongIds() {
+        Map<String, InLongIdObject> newConfig = new HashMap<>();
+        ProxyClusterObject proxyClusterObject = currentClusterConfig.getProxyCluster();
+        for (InLongIdObject obj : proxyClusterObject.getInlongIds()) {
+            String inlongId = obj.getInlongId();
+            newConfig.put(inlongId, obj);
+        }
+        this.inlongIdMap = newConfig;
+    }
+
+    /**
+     * 
+     * generateFlumeProperties
+     */
+    private void generateFlumeProperties() {
+        Map<String, String> newConfig = new HashMap<>();
+        // channels
+        this.generateFlumeChannels(newConfig);
+        // sinks
+        this.generateFlumeSinks(newConfig);
+        // sources
+        this.generateFlumeSources(newConfig);
+        //
+        this.flumeProperties = newConfig;
+    }
+
+    /**
+     * generateFlumeChannels
+     * 
+     * @param proxyClusterObject
+     * @param newConfig
+     */
+    private void generateFlumeChannels(Map<String, String> newConfig) {
+        StringBuilder builder = new StringBuilder();
+        ProxyClusterObject proxyClusterObject = currentClusterConfig.getProxyCluster();
+        String proxyClusterName = proxyClusterObject.getName();
+        // channels
+        // ${proxyClusterName}.channels.${channelName}.type=xxx
+        // ${proxyClusterName}.channels.${channelName}.${paramName}=${paramValue}
+        for (ProxyChannel channel : proxyClusterObject.getChannels()) {
+            builder.setLength(0);
+            builder.append(proxyClusterName).append(".channels.").append(channel.getName()).append(FLUME_SEPARATOR);
+            String prefix = builder.toString();
+            builder.append("type");
+            newConfig.put(builder.toString(), channel.getType());
+            for (Entry<String, String> entry : channel.getParams().entrySet()) {
+                builder.setLength(0);
+                builder.append(prefix).append(entry.getKey());
+                newConfig.put(builder.toString(), entry.getValue());
+            }
+        }
+    }
+
+    /**
+     * generateFlumeSink
+     * 
+     * @param proxyClusterObject
+     * @param newConfig
+     */
+    private void generateFlumeSinks(Map<String, String> newConfig) {
+        StringBuilder builder = new StringBuilder();
+        ProxyClusterObject proxyClusterObject = currentClusterConfig.getProxyCluster();
+        String proxyClusterName = proxyClusterObject.getName();
+        // sinks
+        // ${proxyClusterName}.sinks.${sinkName}.channel=xxx
+        // ${proxyClusterName}.sinks.${sinkName}.type=xxx
+        // ${proxyClusterName}.sinks.${sinkName}.${paramName}=${paramValue}
+        for (ProxySink sink : proxyClusterObject.getSinks()) {
+            builder.setLength(0);
+            builder.append(proxyClusterName).append(".sinks.").append(sink.getName()).append(FLUME_SEPARATOR);
+            String prefix = builder.toString();
+            builder.setLength(0);
+            builder.append(prefix).append("channel");
+            newConfig.put(builder.toString(), sink.getChannel());
+            builder.setLength(0);
+            builder.append(prefix).append("type");
+            newConfig.put(builder.toString(), sink.getType());
+            for (Entry<String, String> entry : sink.getParams().entrySet()) {
+                builder.setLength(0);
+                builder.append(prefix).append(entry.getKey());
+                newConfig.put(builder.toString(), entry.getValue());
+            }
+            // ${proxyClusterName}.sinks.${sinkName}.cache.type=Pulsar
+            builder.setLength(0);
+            builder.append(prefix).append("cache.type");
+            CacheClusterSetObject cacheSetObject = currentClusterConfig.getCacheClusterSet();
+            newConfig.put(builder.toString(), cacheSetObject.getType());
+            // ${proxyClusterName}.sinks.${sinkName}.cache.topics.${topic}.partitionNum=xxx
+            builder.setLength(0);
+            builder.append(prefix).append("cache.topics").append(FLUME_SEPARATOR);
+            String topicPrefix = builder.toString();
+            for (CacheTopicObject topicObject : cacheSetObject.getTopics()) {
+                builder.setLength(0);
+                builder.append(topicPrefix).append(topicObject.getTopic()).append(".partitionNum");
+                newConfig.put(builder.toString(), String.valueOf(topicObject.getPartitionNum()));
+            }
+            // ${proxyClusterName}.sinks.${sinkName}.cache.clusters.${cacheProxyName}.zone=xxx
+            // ${proxyClusterName}.sinks.${sinkName}.cache.clusters.${cacheProxyName}.${paramName}=${paramValue}
+            for (CacheClusterObject cacheClusterObject : cacheSetObject.getCacheClusters()) {
+                builder.setLength(0);
+                builder.append(prefix).append("cache.clusters.").append(cacheClusterObject.getName())
+                        .append(FLUME_SEPARATOR);
+                String cachePrefix = builder.toString();
+                builder.append("zone");
+                newConfig.put(builder.toString(), cacheClusterObject.getZone());
+                for (Entry<String, String> entry : sink.getParams().entrySet()) {
+                    builder.setLength(0);
+                    builder.append(cachePrefix).append(entry.getKey());
+                    newConfig.put(builder.toString(), entry.getValue());
+                }
+            }
+        }
+    }
+
+    /**
+     * generateFlumeSources
+     * 
+     * @param proxyClusterObject
+     * @param newConfig
+     */
+    private void generateFlumeSources(Map<String, String> newConfig) {
+        StringBuilder builder = new StringBuilder();
+        ProxyClusterObject proxyClusterObject = currentClusterConfig.getProxyCluster();
+        String proxyClusterName = proxyClusterObject.getName();
+        // sources
+        // ${proxyClusterName}.sources.${sourceName}.channels=xxx xxx xxx
+        // ${proxyClusterName}.sources.${sourceName}.type=xxx
+        // ${proxyClusterName}.sources.${sourceName}.selector.type=xxx
+        // ${proxyClusterName}.sources.${sourceName}.${paramName}=${paramValue}
+        for (ProxySource source : proxyClusterObject.getSources()) {
+            builder.setLength(0);
+            builder.append(proxyClusterName).append(".sources.").append(source.getName()).append(FLUME_SEPARATOR);
+            String prefix = builder.toString();
+            builder.setLength(0);
+            builder.append(prefix).append("channels");
+            String channelsKey = builder.toString();
+            builder.setLength(0);
+            for (String channel : source.getChannels()) {
+                builder.append(channel).append(" ");
+            }
+            String channelsValue = builder.toString().trim();
+            newConfig.put(channelsKey, channelsValue);
+            builder.setLength(0);
+            builder.append(prefix).append("type");
+            newConfig.put(builder.toString(), source.getType());
+            builder.setLength(0);
+            builder.append(prefix).append("selector.type");
+            newConfig.put(builder.toString(), source.getSelectorType());
+            for (Entry<String, String> entry : source.getParams().entrySet()) {
+                builder.setLength(0);
+                builder.append(prefix).append(entry.getKey());
+                newConfig.put(builder.toString(), entry.getValue());
+            }
+        }
+    }
+
+    /**
+     * getFlumeProperties
+     * 
+     * @return
+     */
+    public Map<String, String> getFlumeProperties() {
+        return flumeProperties;
+    }
+
+    /**
+     * getInlongIdMap
+     * 
+     * @return
+     */
+    public Map<String, InLongIdObject> getInlongIdMap() {
+        return inlongIdMap;
+    }
+
+    /**
+     * 
+     * getCurrentClusterConfig
+     * 
+     * @return
+     */
+    public DataProxyCluster getCurrentClusterConfig() {
+        return currentClusterConfig;
+    }
+
+    /**
+     * get currentClusterConfigRef
+     * 
+     * @return the currentClusterConfigRef
+     */
+    public AtomicReference<DataProxyCluster> getCurrentClusterConfigRef() {
+        return currentClusterConfigRef;
+    }
+
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/node/Application.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/node/Application.java
@@ -1,0 +1,427 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.node;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.flume.Channel;
+import org.apache.flume.Constants;
+import org.apache.flume.Context;
+import org.apache.flume.SinkRunner;
+import org.apache.flume.SourceRunner;
+import org.apache.flume.instrumentation.MonitorService;
+import org.apache.flume.instrumentation.MonitoringType;
+import org.apache.flume.lifecycle.LifecycleAware;
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.flume.lifecycle.LifecycleSupervisor;
+import org.apache.flume.lifecycle.LifecycleSupervisor.SupervisorPolicy;
+import org.apache.flume.node.MaterializedConfiguration;
+import org.apache.flume.node.PollingPropertiesFileConfigurationProvider;
+import org.apache.flume.node.PollingZooKeeperConfigurationProvider;
+import org.apache.flume.node.PropertiesFileConfigurationProvider;
+import org.apache.flume.node.StaticZooKeeperConfigurationProvider;
+import org.apache.flume.util.SSLUtil;
+import org.apache.inlong.commons.pojo.dataproxy.IDataProxyConfigHolder;
+import org.apache.inlong.dataproxy.config.ConfigManager;
+import org.apache.inlong.dataproxy.config.RemoteConfigManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+
+/**
+ * 
+ * Application
+ */
+public class Application {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(Application.class);
+
+    public static final String CONF_MONITOR_CLASS = "flume.monitoring.type";
+    public static final String CONF_MONITOR_PREFIX = "flume.monitoring.";
+
+    private final List<LifecycleAware> components;
+    private final LifecycleSupervisor supervisor;
+    private MaterializedConfiguration materializedConfiguration;
+    private MonitorService monitorServer;
+    private final ReentrantLock lifecycleLock = new ReentrantLock();
+
+    public Application() {
+        this(new ArrayList<LifecycleAware>(0));
+    }
+
+    public Application(List<LifecycleAware> components) {
+        this.components = components;
+        supervisor = new LifecycleSupervisor();
+    }
+
+    public void start() {
+        lifecycleLock.lock();
+        try {
+            for (LifecycleAware component : components) {
+                // update dataproxy config
+                if (component instanceof IDataProxyConfigHolder) {
+                    ((IDataProxyConfigHolder) component)
+                            .setDataProxyConfig(
+                                    RemoteConfigManager.getInstance().getCurrentClusterConfigRef());
+                }
+                supervisor.supervise(component,
+                        new SupervisorPolicy.AlwaysRestartPolicy(), LifecycleState.START);
+            }
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    @Subscribe
+    public void handleConfigurationEvent(MaterializedConfiguration conf) {
+        try {
+            lifecycleLock.lockInterruptibly();
+            stopAllComponents();
+            startAllComponents(conf);
+        } catch (InterruptedException e) {
+            logger.info("Interrupted while trying to handle configuration event");
+            return;
+        } finally {
+            // If interrupted while trying to lock, we don't own the lock, so must not attempt to unlock
+            if (lifecycleLock.isHeldByCurrentThread()) {
+                lifecycleLock.unlock();
+            }
+        }
+    }
+
+    public void stop() {
+        lifecycleLock.lock();
+        stopAllComponents();
+        try {
+            supervisor.stop();
+            if (monitorServer != null) {
+                monitorServer.stop();
+            }
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    private void stopAllComponents() {
+        if (this.materializedConfiguration != null) {
+            logger.info("Shutting down configuration: {}", this.materializedConfiguration);
+            for (Entry<String, SourceRunner> entry : this.materializedConfiguration
+                    .getSourceRunners().entrySet()) {
+                try {
+                    logger.info("Stopping Source " + entry.getKey());
+                    supervisor.unsupervise(entry.getValue());
+                } catch (Exception e) {
+                    logger.error("Error while stopping {}", entry.getValue(), e);
+                }
+            }
+
+            for (Entry<String, SinkRunner> entry : this.materializedConfiguration.getSinkRunners()
+                    .entrySet()) {
+                try {
+                    logger.info("Stopping Sink " + entry.getKey());
+                    supervisor.unsupervise(entry.getValue());
+                } catch (Exception e) {
+                    logger.error("Error while stopping {}", entry.getValue(), e);
+                }
+            }
+
+            for (Entry<String, Channel> entry : this.materializedConfiguration.getChannels()
+                    .entrySet()) {
+                try {
+                    logger.info("Stopping Channel " + entry.getKey());
+                    supervisor.unsupervise(entry.getValue());
+                } catch (Exception e) {
+                    logger.error("Error while stopping {}", entry.getValue(), e);
+                }
+            }
+        }
+        if (monitorServer != null) {
+            monitorServer.stop();
+        }
+    }
+
+    private void startAllComponents(MaterializedConfiguration materializedConfiguration) {
+        logger.info("Starting new configuration:{}", materializedConfiguration);
+
+        this.materializedConfiguration = materializedConfiguration;
+
+        for (Entry<String, Channel> entry : materializedConfiguration.getChannels().entrySet()) {
+            try {
+                logger.info("Starting Channel " + entry.getKey());
+                supervisor.supervise(entry.getValue(),
+                        new SupervisorPolicy.AlwaysRestartPolicy(), LifecycleState.START);
+            } catch (Exception e) {
+                logger.error("Error while starting {}", entry.getValue(), e);
+            }
+        }
+
+        /*
+         * Wait for all channels to start.
+         */
+        for (Channel ch : materializedConfiguration.getChannels().values()) {
+            while (ch.getLifecycleState() != LifecycleState.START
+                    && !supervisor.isComponentInErrorState(ch)) {
+                try {
+                    logger.info("Waiting for channel: " + ch.getName()
+                            + " to start. Sleeping for 500 ms");
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    logger.error("Interrupted while waiting for channel to start.", e);
+                    Throwables.propagate(e);
+                }
+            }
+        }
+
+        for (Entry<String, SinkRunner> entry : materializedConfiguration.getSinkRunners()
+                .entrySet()) {
+            try {
+                logger.info("Starting Sink " + entry.getKey());
+                supervisor.supervise(entry.getValue(),
+                        new SupervisorPolicy.AlwaysRestartPolicy(), LifecycleState.START);
+            } catch (Exception e) {
+                logger.error("Error while starting {}", entry.getValue(), e);
+            }
+        }
+
+        for (Entry<String, SourceRunner> entry : materializedConfiguration.getSourceRunners()
+                .entrySet()) {
+            try {
+                logger.info("Starting Source " + entry.getKey());
+                supervisor.supervise(entry.getValue(),
+                        new SupervisorPolicy.AlwaysRestartPolicy(), LifecycleState.START);
+            } catch (Exception e) {
+                logger.error("Error while starting {}", entry.getValue(), e);
+            }
+        }
+
+        this.loadMonitoring();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void loadMonitoring() {
+        Properties systemProps = System.getProperties();
+        Set<String> keys = systemProps.stringPropertyNames();
+        try {
+            if (keys.contains(CONF_MONITOR_CLASS)) {
+                String monitorType = systemProps.getProperty(CONF_MONITOR_CLASS);
+                Class<? extends MonitorService> klass;
+                try {
+                    // Is it a known type?
+                    klass = MonitoringType.valueOf(
+                            monitorType.toUpperCase(Locale.ENGLISH)).getMonitorClass();
+                } catch (Exception e) {
+                    // Not a known type, use FQCN
+                    klass = (Class<? extends MonitorService>) Class.forName(monitorType);
+                }
+                this.monitorServer = klass.getDeclaredConstructor().newInstance();
+                Context context = new Context();
+                for (String key : keys) {
+                    if (key.startsWith(CONF_MONITOR_PREFIX)) {
+                        context.put(key.substring(CONF_MONITOR_PREFIX.length()),
+                                systemProps.getProperty(key));
+                    }
+                }
+                monitorServer.configure(context);
+                monitorServer.start();
+            }
+        } catch (Exception e) {
+            logger.warn("Error starting monitoring. "
+                    + "Monitoring might not be available.", e);
+        }
+
+    }
+
+    public static void main(String[] args) {
+
+        try {
+            SSLUtil.initGlobalSSLParameters();
+
+            Options options = new Options();
+
+            Option option = new Option("n", "name", true, "the name of this agent");
+            option.setRequired(true);
+            options.addOption(option);
+
+            option = new Option("f", "conf-file", true,
+                    "specify a config file (required if -z missing)");
+            option.setRequired(false);
+            options.addOption(option);
+
+            option = new Option(null, "no-reload-conf", false,
+                    "do not reload config file if changed");
+            options.addOption(option);
+
+            // Options for Zookeeper
+            option = new Option("z", "zkConnString", true,
+                    "specify the ZooKeeper connection to use (required if -f missing)");
+            option.setRequired(false);
+            options.addOption(option);
+
+            option = new Option("p", "zkBasePath", true,
+                    "specify the base path in ZooKeeper for agent configs");
+            option.setRequired(false);
+            options.addOption(option);
+
+            option = new Option("h", "help", false, "display help text");
+            options.addOption(option);
+
+            // load configuration data from manager
+            option = new Option(null, "load-conf-from-manager", false,
+                    "load configuration data from manager");
+            option.setRequired(false);
+            options.addOption(option);
+
+            CommandLineParser parser = new GnuParser();
+            CommandLine commandLine = parser.parse(options, args);
+
+            if (commandLine.hasOption('h')) {
+                new HelpFormatter().printHelp("flume-ng agent", options, true);
+                return;
+            }
+
+            // start by manager configuation
+            if (commandLine.hasOption("load-conf-from-manager")) {
+                startByManagerConf(commandLine);
+                return;
+            }
+
+            String agentName = commandLine.getOptionValue('n');
+            boolean reload = !commandLine.hasOption("no-reload-conf");
+
+            boolean isZkConfigured = false;
+            if (commandLine.hasOption('z') || commandLine.hasOption("zkConnString")) {
+                isZkConfigured = true;
+            }
+
+            Application application;
+            if (isZkConfigured) {
+                // get options
+                String zkConnectionStr = commandLine.getOptionValue('z');
+                String baseZkPath = commandLine.getOptionValue('p');
+
+                if (reload) {
+                    EventBus eventBus = new EventBus(agentName + "-event-bus");
+                    List<LifecycleAware> components = Lists.newArrayList();
+                    PollingZooKeeperConfigurationProvider zProvider = new PollingZooKeeperConfigurationProvider(
+                            agentName, zkConnectionStr, baseZkPath, eventBus);
+                    components.add(zProvider);
+                    application = new Application(components);
+                    eventBus.register(application);
+                } else {
+                    StaticZooKeeperConfigurationProvider zProvider = new StaticZooKeeperConfigurationProvider(
+                            agentName, zkConnectionStr, baseZkPath);
+                    application = new Application();
+                    application.handleConfigurationEvent(zProvider.getConfiguration());
+                }
+            } else {
+                File configurationFile = new File(commandLine.getOptionValue('f'));
+
+                // The following is to ensure that by default the agent will fail on startup
+                // if the file does not exist.
+                if (!configurationFile.exists()) {
+                    // If command line invocation, then need to fail fast
+                    if (System.getProperty(Constants.SYSPROP_CALLED_FROM_SERVICE) == null) {
+                        String path = configurationFile.getPath();
+                        try {
+                            path = configurationFile.getCanonicalPath();
+                        } catch (IOException ex) {
+                            logger.error("Failed to read canonical path for file: " + path,
+                                    ex);
+                        }
+                        throw new ParseException(
+                                "The specified configuration file does not exist: " + path);
+                    }
+                }
+                List<LifecycleAware> components = Lists.newArrayList();
+
+                if (reload) {
+                    EventBus eventBus = new EventBus(agentName + "-event-bus");
+                    PollingPropertiesFileConfigurationProvider configurationProvider;
+                    configurationProvider = new PollingPropertiesFileConfigurationProvider(
+                            agentName, configurationFile, eventBus, 30);
+                    components.add(configurationProvider);
+                    application = new Application(components);
+                    eventBus.register(application);
+                } else {
+                    PropertiesFileConfigurationProvider configurationProvider;
+                    configurationProvider = new PropertiesFileConfigurationProvider(
+                            agentName, configurationFile);
+                    application = new Application();
+                    application.handleConfigurationEvent(configurationProvider.getConfiguration());
+                }
+            }
+            application.start();
+
+            final Application appReference = application;
+            Runtime.getRuntime().addShutdownHook(new Thread("agent-shutdown-hook") {
+
+                @Override
+                public void run() {
+                    appReference.stop();
+                }
+            });
+
+        } catch (Exception e) {
+            logger.error("A fatal error occurred while running. Exception follows.", e);
+        }
+    }
+
+    /**
+     * startByManagerConf
+     * 
+     * @param commandLine
+     */
+    private static void startByManagerConf(CommandLine commandLine) {
+        String proxyName = ConfigManager.getInstance().getCommonProperties()
+                .get(RemoteConfigManager.KEY_PROXY_CLUSTER_NAME);
+        ManagerPropertiesConfigurationProvider configurationProvider = new ManagerPropertiesConfigurationProvider(
+                proxyName);
+        Application application = new Application();
+        application.handleConfigurationEvent(configurationProvider.getConfiguration());
+        application.start();
+
+        final Application appReference = application;
+        Runtime.getRuntime().addShutdownHook(new Thread("agent-shutdown-hook") {
+
+            @Override
+            public void run() {
+                appReference.stop();
+            }
+        });
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/node/ManagerPropertiesConfigurationProvider.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/node/ManagerPropertiesConfigurationProvider.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.node;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.flume.conf.FlumeConfiguration;
+import org.apache.flume.node.AbstractConfigurationProvider;
+import org.apache.inlong.dataproxy.config.RemoteConfigManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * ManagerPropertiesConfigurationProvider
+ */
+public class ManagerPropertiesConfigurationProvider extends
+        AbstractConfigurationProvider {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(ManagerPropertiesConfigurationProvider.class);
+
+    /**
+     * ManagerPropertiJesConfigurationProvider
+     * 
+     * @param agentName
+     */
+    public ManagerPropertiesConfigurationProvider(String agentName) {
+        super(agentName);
+    }
+
+    /**
+     * getFlumeConfiguration
+     * 
+     * @return
+     */
+    @Override
+    public FlumeConfiguration getFlumeConfiguration() {
+        try {
+            Map<String, String> flumeProperties = RemoteConfigManager.getInstance().getFlumeProperties();
+            return new FlumeConfiguration(flumeProperties);
+        } catch (Exception e) {
+            LOGGER.error("exception catch:" + e.getMessage(), e);
+        }
+        return new FlumeConfiguration(new HashMap<String, String>());
+    }
+}


### PR DESCRIPTION
### Title Name: [INLONG-1595][component] Title of the pull request

where *1595* should be replaced by the actual issue number.

Fixes #1595

### Motivation

*Inlong software package must be no-coupling with business configuration.*
*As cloud service, inlong-manager need to have the whole business configuration.*

### Modifications

*In inlong-dataproxy command line, add a new command option(load-conf-from-manager).*
*When inlong-dataproxy start by command option(load-conf-from-manager),*
*at first, inlong-proxy will get configuration data(flume.conf, bid-mapping, topic......) from inlong-manager,*
*the second, flume application will start all components defined in configuration data.*
