### PR TITLE
[INLONG-1729] [sort] Avoid using constant value as version when referencing other modules

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -18,7 +18,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/docs/themes/book" vcs="Git" />
   </component>
    <component name="IssueNavigationConfiguration">
     <option name="links">

--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -29,7 +29,6 @@
         <version>0.12.0-incubating-SNAPSHOT</version>
     </parent>
     <artifactId>inlong-sort</artifactId>
-    <version>0.12.0-incubating-SNAPSHOT</version>
 
     <name>Apache InLong - Sort</name>
     <packaging>pom</packaging>
@@ -121,7 +120,7 @@
             <dependency>
                 <groupId>org.apache.inlong</groupId>
                 <artifactId>inlong-common</artifactId>
-                <version>0.12.0-incubating-SNAPSHOT</version>
+                <version>${project.version}</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,20 +33,20 @@
   <name>Apache InLong</name>
 
   <description>InLong is a one-stop data streaming platform that provides automatic,
-    ecure, distributed, and efficient data publishing and subscription capabilities.
+    secure, distributed, and efficient data publishing and subscription capabilities.
     This platform helps you easily build stream-based data applications.</description>
   <url>https://github.com/apache/incubator-inlong</url>
 
   <organization>
     <name>Apache Software Foundation</name>
-    <url>http://www.apache.org/</url>
+    <url>https://www.apache.org/</url>
   </organization>
   <inceptionYear>2013</inceptionYear>
 
   <developers>
     <developer>
       <organization>Apache InLong(incubating) developers</organization>
-      <organizationUrl>http://inlong.apache.org/</organizationUrl>
+      <organizationUrl>https://inlong.apache.org/</organizationUrl>
     </developer>
   </developers>
 


### PR DESCRIPTION

Fixes #1729

### Motivation


Avoid using constant value as version when referencing other modules, we can use `${project.version}`

```
<dependency>
    <groupId>org.apache.inlong</groupId>
    <artifactId>inlong-common</artifactId>
    <version>0.12.0-incubating-SNAPSHOT</version>
    <exclusions>
        <exclusion>
            <artifactId>slf4j-api</artifactId>
            <groupId>org.slf4j</groupId>
        </exclusion>
        <exclusion>
            <artifactId>snappy-java</artifactId>
            <groupId>org.xerial.snappy</groupId>
        </exclusion>
        <exclusion>
            <artifactId>guava</artifactId>
            <groupId>com.google.guava</groupId>
        </exclusion>
    </exclusions>
</dependency>
```

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
