### PR TITLE
[INLONG-1746][Dataproxy] [improve] the log4j properties for dataproxy contains some useless code and some class name are incorrect

### DIFF
--- a/inlong-dataproxy/conf/log4j.properties
+++ b/inlong-dataproxy/conf/log4j.properties
@@ -25,17 +25,12 @@ log.file.debug.name.postfix=.debug
 log.file.warn.name.postfix=.warn
 log.file.error.name.postfix=.error
 log.file.stat.name=flume_stat.log
-log.file.flume.measure.name=flume_measure.log
-log.file.agent.measure.name=agent_measure.log
-log.file.agent.pcgmeasure.name=agent_pcg_measure.log
-log.file.agent.hourmeasure.name=agent_hour_measure.log
-log.file.agent.pcgcheckmeasure.name=agent_pcg_check_measure.log
 log.file.monitors.name=flume_monitors.log
 log.file.index.name=flume_index.log
 
 
-log4j.logger.org.apache.flume.util.MonitorIndexExt=info,monitor
-log4j.additivity.org.apache.flume.util.MonitorIndexExt = false
+log4j.logger.org.apache.inlong.dataproxy.utils.MonitorIndexExt = info,monitor
+log4j.additivity.org.apache.inlong.dataproxy.utils.MonitorIndexExt = false
 log4j.appender.monitor=org.apache.log4j.RollingFileAppender
 log4j.appender.monitor.MaxFileSize=100MB
 log4j.appender.monitor.MaxBackupIndex=10
@@ -47,8 +42,8 @@ log4j.appender.monitor.Threshold = INFO
 log4j.appender.monitor.Append=true
 log4j.appender.monitor.File=${log.dir}/${log.file.monitors.name}
 
-log4j.logger.org.apache.flume.util.MonitorIndex=info,index
-log4j.additivity.org.apache.flume.util.MonitorIndex = false
+log4j.logger.org.apache.inlong.dataproxy.utils.MonitorIndex=info,index
+log4j.additivity.org.apache.inlong.dataproxy.utils.MonitorIndex = false
 log4j.appender.index=org.apache.log4j.RollingFileAppender
 log4j.appender.index.MaxFileSize=100MB
 log4j.appender.index.MaxBackupIndex=10
@@ -59,23 +54,6 @@ log4j.appender.index.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %m%n
 log4j.appender.index.Threshold = INFO 
 log4j.appender.index.Append=true
 log4j.appender.index.File=${log.dir}/${log.file.index.name}
-
-log4j.logger.com.tencent.tdbank.monitor.StatRunner=info,stat
-log4j.additivity.com.tencent.tdbank.monitor.StatRunner = false
-
-log4j.logger.com.tencent.tdbank.monitor.StatRunnerExt=info,flume-measure
-log4j.additivity.com.tencent.tdbank.monitor.StatRunnerExt = false
-
-log4j.logger.org.apache.flume.sink.AgentMeasureLogger=info,agent-measure
-log4j.additivity.org.apache.flume.sink.AgentMeasureLogger=false
-
-log4j.logger.org.apache.flume.util.PcgMetricsCollectorMin=info,agent-min-measure
-log4j.additivity.org.apache.flume.util.PcgMetricsCollectorMin=false
-log4j.logger.org.apache.flume.util.PcgMetricsCollectorHour=info,agent-hour-measure
-log4j.additivity.org.apache.flume.util.PcgMetricsCollectorHour=false
-
-log4j.logger.org.apache.flume.util.PcgMetricsCheckCollector=info,agent-pcg-check-measure
-log4j.additivity.org.apache.flume.util.PcgMetricsCheckCollector=false
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -91,66 +69,6 @@ log4j.appender.stat.layout.ConversionPattern=%d{ISO8601} %p %c{2} (%F:%M:%L): %m
 log4j.appender.stat.Threshold = INFO 
 log4j.appender.stat.Append=true
 log4j.appender.stat.File=${log.dir}/${log.file.stat.name}
-
-
-log4j.appender.flume-measure=org.apache.log4j.RollingFileAppender
-log4j.appender.flume-measure.MaxFileSize=100MB
-log4j.appender.flume-measure.MaxBackupIndex=10
-log4j.appender.flume-measure.BufferedIO=false
-log4j.appender.flume-measure.BufferSize=8192
-log4j.appender.flume-measure.layout=org.apache.log4j.PatternLayout
-log4j.appender.flume-measure.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %m%n
-log4j.appender.flume-measure.Threshold = INFO 
-log4j.appender.flume-measure.Append=true
-log4j.appender.flume-measure.File=${log.dir}/${log.file.flume.measure.name}
-
-log4j.appender.agent-measure=org.apache.log4j.RollingFileAppender
-log4j.appender.agent-measure.MaxFileSize=100MB
-log4j.appender.agent-measure.MaxBackupIndex=10
-log4j.appender.agent-measure.BufferedIO=false
-log4j.appender.agent-measure.BufferSize=512
-log4j.appender.agent-measure.layout=org.apache.log4j.PatternLayout
-log4j.appender.agent-measure.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %m%n
-log4j.appender.agent-measure.Threshold = INFO 
-log4j.appender.agent-measure.Append=true
-log4j.appender.agent-measure.File=${log.dir}/${log.file.agent.measure.name}
-
-
-log4j.appender.agent-min-measure=org.apache.log4j.RollingFileAppender
-log4j.appender.agent-min-measure.MaxFileSize=100MB
-log4j.appender.agent-min-measure.MaxBackupIndex=10
-log4j.appender.agent-min-measure.BufferedIO=false
-log4j.appender.agent-min-measure.BufferSize=512
-log4j.appender.agent-min-measure.layout=org.apache.log4j.PatternLayout
-log4j.appender.agent-min-measure.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %m%n
-log4j.appender.agent-min-measure.Threshold = INFO 
-log4j.appender.agent-min-measure.Append=true
-log4j.appender.agent-min-measure.File=${log.dir}/${log.file.agent.pcgmeasure.name}
-
-log4j.appender.agent-hour-measure=org.apache.log4j.RollingFileAppender
-log4j.appender.agent-hour-measure.MaxFileSize=100MB
-log4j.appender.agent-hour-measure.MaxBackupIndex=10
-log4j.appender.agent-hour-measure.BufferedIO=false
-log4j.appender.agent-hour-measure.BufferSize=512
-log4j.appender.agent-hour-measure.layout=org.apache.log4j.PatternLayout
-log4j.appender.agent-hour-measure.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %m%n
-log4j.appender.agent-hour-measure.Threshold = INFO 
-log4j.appender.agent-hour-measure.Append=true
-log4j.appender.agent-hour-measure.File=${log.dir}/${log.file.agent.hourmeasure.name}
-
-
-
-log4j.appender.agent-pcg-check-measure=org.apache.log4j.RollingFileAppender
-log4j.appender.agent-pcg-check-measure.MaxFileSize=100MB
-log4j.appender.agent-pcg-check-measure.MaxBackupIndex=10
-log4j.appender.agent-pcg-check-measure.BufferedIO=false
-log4j.appender.agent-pcg-check-measure.BufferSize=512
-log4j.appender.agent-pcg-check-measure.layout=org.apache.log4j.PatternLayout
-log4j.appender.agent-pcg-check-measure.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %m%n
-log4j.appender.agent-pcg-check-measure.Threshold = INFO 
-log4j.appender.agent-pcg-check-measure.Append=true
-log4j.appender.agent-pcg-check-measure.File=${log.dir}/${log.file.agent.pcgcheckmeasure.name}
-
 
 log4j.logger.info=info
 log4j.appender.info=org.apache.log4j.RollingFileAppender
@@ -187,7 +105,6 @@ log4j.appender.warn.layout.ConversionPattern=%d{ISO8601} %p %c{2} (%F:%M:%L): %m
 log4j.appender.warn.Threshold = WARN 
 log4j.appender.warn.Append=true
 log4j.appender.warn.File=${log.dir}/${log.file.name.prefix}${log.file.warn.name.postfix}
-
 
 log4j.logger.error=error
 log4j.appender.error=org.apache.log4j.RollingFileAppender


### PR DESCRIPTION
### Title Name: [INLONG-1746][Dataproxy] [improve] the log4j properties for dataproxy contains some useless code and some class name are incorrect

Fixes #1746 

### Motivation

the log4j properties for dataproxy contains some useless code and some class name are incorrect
### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation
  - Does this pull request introduce a new feature? (no)
