### PR TITLE
[INLONG-1783]Make topic filters take effect in Go SDK

### DIFF
--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub/info.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub/info.go
@@ -61,9 +61,13 @@ func NewSubInfo(config *config.Config) *SubInfo {
 		topicFilters:    config.Consumer.TopicFilters,
 	}
 	s.topicConds = make([]string, 0, len(config.Consumer.TopicFilters))
+	s.topicFilter = make(map[string]bool)
 	for topic, filters := range config.Consumer.TopicFilters {
 		cond := topic + "#"
 		count := 0
+		if len(filters) > 0 {
+			s.topicFilter[topic] = true
+		}
 		for _, filter := range filters {
 			if count > 0 {
 				cond += ","

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub/info_test.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub/info_test.go
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sub
+
+import (
+	"testing"
+
+	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSubInfo(t *testing.T) {
+	address := "127.0.0.1:9092,127.0.0.1:9093?topic=Topic1&filters=12312323&filters=1212&topic=Topic2&filters=121212&filters=2321323&group=Group&tlsEnable=false&msgNotFoundWait=10000&heartbeatMaxRetryTimes=6"
+	c, err := config.ParseAddress(address)
+	assert.Nil(t, err)
+
+	topicFilters := make(map[string][]string)
+	topicFilters["Topic1"] = []string{"12312323", "1212"}
+	topicFilters["Topic2"] = []string{"121212", "2321323"}
+
+	s := NewSubInfo(c)
+	assert.Equal(t, s.topics, []string{"Topic1", "Topic2"})
+	assert.Equal(t, s.topicFilters, topicFilters)
+	assert.Equal(t, s.topicFilter, map[string]bool{"Topic1": true, "Topic2": true})
+}


### PR DESCRIPTION
Signed-off-by: Zijie Lu <wslzj40@gmail.com>


### Title Name: [INLONG-XYZ][component] Title of the pull request

where *XYZ* should be replaced by the actual issue number.

Fixes #1783 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*
Topic filters does not take effect in Go SDK
### Modifications

*Describe the modifications you've done.*
Make topic filters take effect in Go SDK
### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
