### PR TITLE
[INLONG-1798]RestTemplate does not read configuration from the config…

### DIFF
--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/config/RestTemplateConfig.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/config/RestTemplateConfig.java
@@ -31,6 +31,7 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.protocol.HttpContext;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -51,27 +52,33 @@ public class RestTemplateConfig {
     /**
      * Max total
      */
-    private int maxTotal = 5000;
+    @Value("${common.http-client.maxTotal}")
+    private int maxTotal;
     /**
      * Concurrency
      */
-    private int defaultMaxPerRoute = 2000;
+    @Value("${common.http-client.defaultMaxPerRoute}")
+    private int defaultMaxPerRoute;
 
-    private int validateAfterInactivity = 5000;
+    @Value("${common.http-client.validateAfterInactivity}")
+    private int validateAfterInactivity;
 
     /**
      * Time to connect to the server (successful handshake), timeout throws connect timeout
      */
-    private int connectionTimeout = 3000;
+    @Value("${common.http-client.connectionTimeout}")
+    private int connectionTimeout;
     /**
      * The time for the server to return data (response), timeout throws read timeout
      */
-    private int readTimeout = 10000;
+    @Value("${common.http-client.readTimeout}")
+    private int readTimeout;
     /**
      * Get the timeout time of the connection from the connection pool,
      * and throw ConnectionPoolTimeoutException when timeout
      */
-    private int connectionRequestTimeout = 3000;
+    @Value("${common.http-client.connectionRequestTimeout}")
+    private int connectionRequestTimeout;
 
     @Bean
     public PoolingHttpClientConnectionManager httpClientConnectionManager() {

--- a/inlong-manager/manager-web/src/main/resources/application-test.properties
+++ b/inlong-manager/manager-web/src/main/resources/application-test.properties
@@ -61,9 +61,9 @@ cluster.zk.root=inlong_hive
 sort.appName=inlong_app
 
 # Configure http client
-common.http-client.maxTotal=5001
-common.http-client.defaultMaxPerRoute=2001
-common.http-client.validateAfterInactivity=5001
-common.http-client.connectionTimeout=3001
-common.http-client.readTimeout=10001
-common.http-client.connectionRequestTimeout=3001
+#common.http-client.maxTotal=5001
+#common.http-client.defaultMaxPerRoute=2001
+#common.http-client.validateAfterInactivity=5001
+#common.http-client.connectionTimeout=3001
+#common.http-client.readTimeout=10001
+#common.http-client.connectionRequestTimeout=3001


### PR DESCRIPTION
### Title Name: [INLONG-1798][improve][InLong-Manager] Modify the RestTemplate to read the configuration from the configuration file.
Fixes #1798

### Motivation
RestTemplate does not read configuration from the configuration file.

### Modifications
Describe the modifications you've done.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
Does this pull request introduce a new feature? no