### PR TITLE
[INLONG-1826][Feature][InLong-Agent] Use jmx metric defined in inlong-common

### DIFF
--- a/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/metrics/TestMetrics.java
+++ b/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/metrics/TestMetrics.java
@@ -42,7 +42,7 @@ public class TestMetrics {
     }
 
     @Test
-    public void testMetric() throws Exception {
+    public void testMetric() {
         MetricTest metricTest = MetricTest.getMetrics();
         Assert.assertNotNull(metricTest.counterInt);
         Assert.assertNotNull(metricTest.counterLong);

--- a/inlong-agent/agent-core/pom.xml
+++ b/inlong-agent/agent-core/pom.xml
@@ -60,5 +60,11 @@
             <artifactId>agent-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>inlong-common</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobManager.java
@@ -106,7 +106,7 @@ public class JobManager extends AbstractDaemon {
                 LOGGER.warn("{} has been added to running pool, "
                     + "cannot be added repeatedly", job.getJobInstanceId());
             } else {
-                jobMetrics.runningJobs.incr();
+                jobMetrics.runningJobs.incrementAndGet();
             }
         } catch (Exception rje) {
             LOGGER.debug("reject job {}", job.getJobInstanceId(), rje);
@@ -199,7 +199,7 @@ public class JobManager extends AbstractDaemon {
     public void markJobAsSuccess(String jobId) {
         JobWrapper wrapper = jobs.remove(jobId);
         if (wrapper != null) {
-            jobMetrics.runningJobs.decr();
+            jobMetrics.runningJobs.decrementAndGet();
             LOGGER.info("job instance {} is success", jobId);
             // mark job as success.
             jobConfDB.updateJobState(jobId, StateSearchKey.SUCCESS);
@@ -210,8 +210,8 @@ public class JobManager extends AbstractDaemon {
         JobWrapper wrapper = jobs.remove(jobId);
         if (wrapper != null) {
             LOGGER.info("job instance {} is failed", jobId);
-            jobMetrics.runningJobs.decr();
-            jobMetrics.fatalJobs.incr();
+            jobMetrics.runningJobs.decrementAndGet();
+            jobMetrics.fatalJobs.incrementAndGet();
             // mark job as success.
             jobConfDB.updateJobState(jobId, StateSearchKey.FAILED);
         }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobMetrics.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobMetrics.java
@@ -18,29 +18,36 @@
 package org.apache.inlong.agent.core.job;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.inlong.agent.metrics.Metric;
-import org.apache.inlong.agent.metrics.Metrics;
-import org.apache.inlong.agent.metrics.MetricsRegister;
-import org.apache.inlong.agent.metrics.gauge.GaugeInt;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.inlong.commons.config.metrics.CountMetric;
+import org.apache.inlong.commons.config.metrics.Dimension;
+import org.apache.inlong.commons.config.metrics.MetricDomain;
+import org.apache.inlong.commons.config.metrics.MetricItem;
+import org.apache.inlong.commons.config.metrics.MetricRegister;
 
-@Metrics
-public class JobMetrics {
+@MetricDomain(name = "AgentJob")
+public class JobMetrics extends MetricItem {
+
     private static final JobMetrics JOB_METRICS = new JobMetrics();
+
     private static final AtomicBoolean REGISTER_ONCE = new AtomicBoolean(false);
+    private static final String AGENT_JOB_METRIC = "AgentJobMetric";
 
-    @Metric
-    GaugeInt runningJobs;
+    @Dimension
+    public String tagName;
 
-    @Metric
-    GaugeInt fatalJobs;
+    @CountMetric
+    public AtomicLong runningJobs = new AtomicLong(0);
 
-    private JobMetrics() {
-    }
+    @CountMetric
+    public AtomicLong fatalJobs = new AtomicLong(0);
 
-    static JobMetrics create() {
+    public static JobMetrics create() {
         if (REGISTER_ONCE.compareAndSet(false, true)) {
-            MetricsRegister.register("Job", "STateSummary", null, JOB_METRICS);
+            JOB_METRICS.tagName = AGENT_JOB_METRIC;
+            MetricRegister.register(JOB_METRICS);
         }
         return JOB_METRICS;
     }
 }
+

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
@@ -120,7 +120,7 @@ public class TaskManager extends AbstractDaemon {
                     LOGGER.warn("reject task {}", wrapper.getTask().getTaskId(), ex);
                 }
             }
-            taskMetrics.runningTasks.incr();
+            taskMetrics.runningTasks.incrementAndGet();
         }
     }
 
@@ -137,7 +137,7 @@ public class TaskManager extends AbstractDaemon {
                 LOGGER.error("cannot submit to retry queue, max {}, current {}", taskMaxCapacity,
                         retryTasks.size());
             } else {
-                taskMetrics.retryingTasks.incr();
+                taskMetrics.retryingTasks.incrementAndGet();
             }
             return success;
         } catch (Exception ex) {
@@ -180,7 +180,7 @@ public class TaskManager extends AbstractDaemon {
      * @param taskId - task id
      */
     public void removeTask(String taskId) {
-        taskMetrics.runningTasks.decr();
+        taskMetrics.runningTasks.decrementAndGet();
         TaskWrapper taskWrapper = tasks.remove(taskId);
         if (taskWrapper != null) {
             taskWrapper.waitForFinish();
@@ -224,7 +224,7 @@ public class TaskManager extends AbstractDaemon {
                     while (!retryTasks.isEmpty()) {
                         TaskWrapper taskWrapper = retryTasks.poll();
                         if (taskWrapper != null) {
-                            taskMetrics.retryingTasks.decr();
+                            taskMetrics.retryingTasks.decrementAndGet();
                             submitTask(taskWrapper);
                         }
                     }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskMetrics.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskMetrics.java
@@ -18,38 +18,41 @@
 package org.apache.inlong.agent.core.task;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.inlong.agent.metrics.Metric;
-import org.apache.inlong.agent.metrics.Metrics;
-import org.apache.inlong.agent.metrics.MetricsRegister;
-import org.apache.inlong.agent.metrics.counter.CounterLong;
-import org.apache.inlong.agent.metrics.gauge.GaugeInt;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.inlong.commons.config.metrics.CountMetric;
+import org.apache.inlong.commons.config.metrics.Dimension;
+import org.apache.inlong.commons.config.metrics.MetricDomain;
+import org.apache.inlong.commons.config.metrics.MetricItem;
+import org.apache.inlong.commons.config.metrics.MetricRegister;
 
 /**
- * Metric collector for task level.
+ * metrics for agent task
  */
-@Metrics
-public class TaskMetrics {
+@MetricDomain(name = "AgentTask")
+public class TaskMetrics extends MetricItem {
 
-    private static final TaskMetrics TASK_METRICS = new TaskMetrics();
+    private static final TaskMetrics JOB_METRICS = new TaskMetrics();
     private static final AtomicBoolean REGISTER_ONCE = new AtomicBoolean(false);
+    public static final String AGENT_TASK = "AgentTaskMetric";
 
-    @Metric
-    GaugeInt runningTasks;
+    @Dimension
+    public String module;
 
-    @Metric
-    GaugeInt retryingTasks;
+    @CountMetric
+    public AtomicLong runningTasks = new AtomicLong(0);
 
-    @Metric
-    CounterLong fatalTasks;
+    @CountMetric
+    public AtomicLong retryingTasks = new AtomicLong(0);
 
-    private TaskMetrics() {
-    }
+    @CountMetric
+    public AtomicLong fatalTasks = new AtomicLong(0);
 
     public static TaskMetrics create() {
         // register one time.
         if (REGISTER_ONCE.compareAndSet(false, true)) {
-            MetricsRegister.register("Task", "StateSummary", null, TASK_METRICS);
+            JOB_METRICS.module = AGENT_TASK;
+            MetricRegister.register(JOB_METRICS);
         }
-        return TASK_METRICS;
+        return JOB_METRICS;
     }
 }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskWrapper.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskWrapper.java
@@ -163,7 +163,7 @@ public class TaskWrapper extends AbstractStateWrapper {
             retryTime.incrementAndGet();
             if (!shouldRetry()) {
                 doChangeState(State.FATAL);
-                taskManager.getTaskMetrics().fatalTasks.incr();
+                taskManager.getTaskMetrics().fatalTasks.incrementAndGet();
             }
         }).addCallback(State.FAILED, State.FATAL, (before, after) -> {
 

--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/TestTaskMetrics.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/TestTaskMetrics.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.agent.core;
 
 import org.apache.inlong.agent.core.task.TaskMetrics;

--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/TestTaskMetrics.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/TestTaskMetrics.java
@@ -1,0 +1,24 @@
+package org.apache.inlong.agent.core;
+
+import org.apache.inlong.agent.core.task.TaskMetrics;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestTaskMetrics {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AgentBaseTestsHelper.class);
+
+    @Test
+    public void testAgentMetrics() {
+        try {
+            TaskMetrics taskMetrics = TaskMetrics.create();
+            taskMetrics.retryingTasks.addAndGet(1);
+            Assert.assertEquals(taskMetrics.module, "AgentTaskMetric");
+        } catch (Exception ex) {
+            LOGGER.error("error happens" + ex);
+        }
+    }
+
+}

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/channel/MemoryChannel.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/channel/MemoryChannel.java
@@ -33,7 +33,7 @@ public class MemoryChannel implements Channel {
 
     private LinkedBlockingQueue<Message> queue;
 
-    private final PluginMetric metric = new PluginMetric();
+    private final PluginMetric pluginMetricNew = new PluginMetric("AgentMemoryPlugin");
 
     /**
      * {@inheritDoc}
@@ -42,12 +42,12 @@ public class MemoryChannel implements Channel {
     public void push(Message message) {
         try {
             if (message != null) {
-                metric.readNum.incr();
+                pluginMetricNew.readNum.incrementAndGet();
                 queue.put(message);
-                metric.readSuccessNum.incr();
+                pluginMetricNew.readSuccessNum.incrementAndGet();
             }
         } catch (InterruptedException ex) {
-            metric.readFailedNum.incr();
+            pluginMetricNew.readFailedNum.incrementAndGet();
             Thread.currentThread().interrupt();
         }
     }
@@ -56,17 +56,17 @@ public class MemoryChannel implements Channel {
     public boolean push(Message message, long timeout, TimeUnit unit) {
         try {
             if (message != null) {
-                metric.readNum.incr();
+                pluginMetricNew.readNum.incrementAndGet();
                 boolean result = queue.offer(message, timeout, unit);
                 if (result) {
-                    metric.readSuccessNum.incr();
+                    pluginMetricNew.readSuccessNum.incrementAndGet();
                 } else {
-                    metric.readFailedNum.incr();
+                    pluginMetricNew.readFailedNum.incrementAndGet();
                 }
                 return result;
             }
         } catch (InterruptedException ex) {
-            metric.readFailedNum.incr();
+            pluginMetricNew.readFailedNum.incrementAndGet();
             Thread.currentThread().interrupt();
         }
         return false;
@@ -80,11 +80,11 @@ public class MemoryChannel implements Channel {
         try {
             Message message = queue.poll(timeout, unit);
             if (message != null) {
-                metric.sendSuccessNum.incr();
+                pluginMetricNew.sendSuccessNum.incrementAndGet();
             }
             return message;
         } catch (InterruptedException ex) {
-            metric.sendFailedNum.incr();
+            pluginMetricNew.sendFailedNum.incrementAndGet();
             Thread.currentThread().interrupt();
             throw new IllegalStateException(ex);
         }
@@ -104,7 +104,8 @@ public class MemoryChannel implements Channel {
         }
         LOGGER.info("destroy channel, memory channel metric, readNum: {}, readSuccessNum: {}, "
             + "readFailedNum: {}, sendSuccessNum: {}, sendFailedNum: {}",
-            metric.readNum.snapshot(), metric.readSuccessNum.snapshot(), metric.readFailedNum.snapshot(),
-            metric.sendSuccessNum.snapshot(), metric.sendFailedNum.snapshot());
+            pluginMetricNew.readNum.get(), pluginMetricNew.readSuccessNum.get(),
+            pluginMetricNew.readFailedNum.get(), pluginMetricNew.sendSuccessNum.get(),
+            pluginMetricNew.sendFailedNum.get());
     }
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/metrics/PluginMetric.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/metrics/PluginMetric.java
@@ -17,41 +17,43 @@
 
 package org.apache.inlong.agent.plugin.metrics;
 
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.inlong.agent.metrics.Metric;
-import org.apache.inlong.agent.metrics.Metrics;
-import org.apache.inlong.agent.metrics.MetricsRegister;
-import org.apache.inlong.agent.metrics.Tag;
-import org.apache.inlong.agent.metrics.counter.CounterLong;
+import org.apache.inlong.commons.config.metrics.Dimension;
+import org.apache.inlong.commons.config.metrics.MetricDomain;
+import org.apache.inlong.commons.config.metrics.MetricItem;
+import org.apache.inlong.commons.config.metrics.MetricRegister;
 
 /**
- * Common plugin metrics
+ * metrics for agent plugin
  */
-@Metrics
-public class PluginMetric {
+@MetricDomain(name = "PluginMetric")
+public class PluginMetric extends MetricItem {
+
+    @Dimension
+    public String tagName;
 
     @Metric
-    public Tag tagName;
+    public AtomicLong readNum = new AtomicLong(0);
 
     @Metric
-    public CounterLong readNum;
+    public AtomicLong sendNum = new AtomicLong(0);
 
     @Metric
-    public CounterLong sendNum;
+    public AtomicLong sendFailedNum = new AtomicLong(0);
 
     @Metric
-    public CounterLong sendFailedNum;
+    public AtomicLong readFailedNum = new AtomicLong(0);
 
     @Metric
-    public CounterLong readFailedNum;
+    public AtomicLong readSuccessNum = new AtomicLong(0);
 
     @Metric
-    public CounterLong readSuccessNum;
+    public AtomicLong sendSuccessNum = new AtomicLong(0);
 
-    @Metric
-    public CounterLong sendSuccessNum;
-
-    public PluginMetric() {
-        // every metric should register, otherwise not working.
-        MetricsRegister.register("Plugin", "PluginSummary", null, this);
+    public PluginMetric(String tagName) {
+        this.tagName = tagName;
+        MetricRegister.register(this);
     }
+
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/PulsarSink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/PulsarSink.java
@@ -72,7 +72,7 @@ public class PulsarSink extends AbstractDaemon implements Sink {
     private LinkedBlockingQueue<byte[]> cache;
     private final List<Producer<byte[]>> producerList = new ArrayList<>();
 
-    private final PluginMetric metric = new PluginMetric();
+    private final PluginMetric pluginMetricNew = new PluginMetric("AgentPulsarMetric");
     private PulsarClient client;
 
     @Override
@@ -81,7 +81,7 @@ public class PulsarSink extends AbstractDaemon implements Sink {
             // if message is not null
             try {
                 // put message to cache, wait until cache is not full.
-                metric.sendNum.incr();
+                pluginMetricNew.sendNum.incrementAndGet();
                 cache.put(message.getBody());
             } catch (Exception ignored) {
                 // ignore it
@@ -116,7 +116,7 @@ public class PulsarSink extends AbstractDaemon implements Sink {
         try {
             stop();
             LOGGER.info("send success num is {}, failed num is {}",
-                metric.sendSuccessNum.snapshot(), metric.sendFailedNum.snapshot());
+                pluginMetricNew.sendSuccessNum.get(), pluginMetricNew.sendFailedNum.get());
         } catch (Exception ex) {
             LOGGER.error("exception caught", ex);
         }
@@ -136,12 +136,12 @@ public class PulsarSink extends AbstractDaemon implements Sink {
                 // exception is not null, that means not success.
                 // TODO: add metric or retry sending message.
                 if (t != null) {
-                    metric.sendFailedNum.incr();
+                    pluginMetricNew.sendFailedNum.incrementAndGet();
                     if (!cache.offer(item)) {
                         LOGGER.warn("message {} not add back to retry", m);
                     }
                 } else {
-                    metric.sendSuccessNum.incr();
+                    pluginMetricNew.sendSuccessNum.incrementAndGet();
                 }
             });
         } else {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
@@ -83,7 +83,7 @@ public class SenderManager {
     private TaskPositionManager taskPositionManager;
     private final int maxSenderPerGroup;
     private final String sourceFilePath;
-    private final PluginMetric metric = new PluginMetric();
+    private final PluginMetric metric = new PluginMetric("AgentSenderManager");
 
     public SenderManager(JobProfile jobConf, String inlongGroupId, String sourceFilePath) {
         AgentConfiguration conf = AgentConfiguration.getAgentConf();
@@ -194,7 +194,7 @@ public class SenderManager {
                 sendBatch(jobId, groupId, streamId, bodyList, retry + 1, dataTime);
                 return;
             }
-            metric.sendSuccessNum.incr(bodyList.size());
+            metric.sendSuccessNum.addAndGet(bodyList.size());
             taskPositionManager.updateFileSinkPosition(jobId, sourceFilePath, bodyList.size());
         }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/TextFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/TextFileReader.java
@@ -65,8 +65,7 @@ public class TextFileReader implements Reader {
         this.file = file;
         this.position = position;
         this.md5 = md5;
-        textFileMetric = new PluginMetric();
-        textFileMetric.tagName.setName(file.getAbsolutePath());
+        textFileMetric = new PluginMetric("AgentTextMetric");
     }
 
     public TextFileReader(File file) {
@@ -78,7 +77,7 @@ public class TextFileReader implements Reader {
         if (iterator != null && iterator.hasNext()) {
             String message = iterator.next();
             if (validateMessage(message)) {
-                textFileMetric.readNum.incr();
+                textFileMetric.readNum.incrementAndGet();
                 return new DefaultMessage(message.getBytes(StandardCharsets.UTF_8));
             }
         }
@@ -164,6 +163,6 @@ public class TextFileReader implements Reader {
     public void destroy() {
         AgentUtils.finallyClose(stream);
         LOGGER.info("destroy reader with read {} num {}",
-                textFileMetric.tagName.getName(), textFileMetric.readNum.snapshot());
+            textFileMetric.tagName, textFileMetric.readNum.get());
     }
 }


### PR DESCRIPTION
### [INLONG-1826][Feature][InLong-Agent] Use jmx metric defined in inlong-common

Fixes #1826 

### Motivation

The agent metric now cannot cope with the inlong-common metric
Should use jmx metric defined in inlong-common

### Modifications

Use jmx metric defined in inlong-common

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Documentation

  - Does this pull request introduce a new feature? (no)
