### PR TITLE
[INLONG-1911] add pulling metric of prometheus, pulling metric value will not be resetted.

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/commons/config/metrics/MetricItemMBean.java
+++ b/inlong-common/src/main/java/org/apache/inlong/commons/config/metrics/MetricItemMBean.java
@@ -19,12 +19,15 @@ package org.apache.inlong.commons.config.metrics;
 
 import java.util.Map;
 
+import javax.management.MXBean;
+
 /**
  * MetricItemMBean<br>
  * Provide access interface of a metric item with JMX.<br>
  * Decouple between metric item and monitor system, in particular scene, <br>
  * inlong can depend on user-defined monitor system.
  */
+@MXBean
 public interface MetricItemMBean {
 
     String ATTRIBUTE_KEY = "DimensionsKey";

--- a/inlong-common/src/main/java/org/apache/inlong/commons/config/metrics/MetricItemSetMBean.java
+++ b/inlong-common/src/main/java/org/apache/inlong/commons/config/metrics/MetricItemSetMBean.java
@@ -19,6 +19,8 @@ package org.apache.inlong.commons.config.metrics;
 
 import java.util.List;
 
+import javax.management.MXBean;
+
 /**
  * 
  * MetricItemSetMBean<br>
@@ -26,6 +28,7 @@ import java.util.List;
  * Decouple between metric item and monitor system, in particular scene, <br>
  * inlong can depend on user-defined monitor system.
  */
+@MXBean
 public interface MetricItemSetMBean {
 
     String METHOD_SNAPSHOT = "snapshot";

--- a/inlong-common/src/main/java/org/apache/inlong/commons/config/metrics/MetricRegister.java
+++ b/inlong-common/src/main/java/org/apache/inlong/commons/config/metrics/MetricRegister.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 public class MetricRegister {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(MetricRegister.class);
+    public static final String JMX_DOMAIN = "org.apache.inlong";
 
     /**
      * register MetricItem
@@ -41,8 +42,8 @@ public class MetricRegister {
     public static void register(MetricItem obj) {
         final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         StringBuilder beanName = new StringBuilder();
-        beanName.append(MetricUtils.getDomain(obj.getClass())).append(MetricItemMBean.DOMAIN_SEPARATOR)
-                .append(obj.getDimensionsKey());
+        beanName.append(JMX_DOMAIN).append(MetricItemMBean.DOMAIN_SEPARATOR).append("type=")
+                .append(MetricUtils.getDomain(obj.getClass())).append(",").append(obj.getDimensionsKey());
         String strBeanName = beanName.toString();
         try {
             ObjectName objName = new ObjectName(strBeanName);
@@ -61,8 +62,8 @@ public class MetricRegister {
     public static void register(MetricItemSet<? extends MetricItem> obj) {
         final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         StringBuilder beanName = new StringBuilder();
-        beanName.append(MetricUtils.getDomain(obj.getClass())).append(MetricItemMBean.DOMAIN_SEPARATOR).append("name=")
-                .append(obj.getName());
+        beanName.append(JMX_DOMAIN).append(MetricItemMBean.DOMAIN_SEPARATOR).append("type=")
+                .append(MetricUtils.getDomain(obj.getClass())).append(",name=").append(obj.getName());
         String strBeanName = beanName.toString();
         try {
             ObjectName objName = new ObjectName(strBeanName);

--- a/inlong-common/src/test/java/org/apache/inlong/commons/config/metrics/item/TestMetricItemMBean.java
+++ b/inlong-common/src/test/java/org/apache/inlong/commons/config/metrics/item/TestMetricItemMBean.java
@@ -70,9 +70,11 @@ public class TestMetricItemMBean {
         //
         final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         StringBuilder beanName = new StringBuilder();
-        beanName.append(MetricUtils.getDomain(AgentMetricItem.class)).append(MetricItemMBean.DOMAIN_SEPARATOR)
-                .append("module=").append(MODULE).append(MetricItemMBean.PROPERTY_SEPARATOR)
+        beanName.append(MetricRegister.JMX_DOMAIN).append(MetricItemMBean.DOMAIN_SEPARATOR)
+                .append("type=").append(MetricUtils.getDomain(AgentMetricItem.class))
+                .append(MetricItemMBean.PROPERTY_SEPARATOR)
                 .append("aspect=").append(ASPECT).append(MetricItemMBean.PROPERTY_SEPARATOR)
+                .append("module=").append(MODULE).append(MetricItemMBean.PROPERTY_SEPARATOR)
                 .append("tag=").append(TAG);
         String strBeanName = beanName.toString();
         ObjectName objName = new ObjectName(strBeanName);

--- a/inlong-common/src/test/java/org/apache/inlong/commons/config/metrics/set/TestMetricItemSetMBean.java
+++ b/inlong-common/src/test/java/org/apache/inlong/commons/config/metrics/set/TestMetricItemSetMBean.java
@@ -122,9 +122,10 @@ public class TestMetricItemSetMBean {
         // report
         final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         StringBuilder beanName = new StringBuilder();
-        beanName.append(MetricUtils.getDomain(DataProxyMetricItemSet.class)).append(MetricItemMBean.DOMAIN_SEPARATOR)
-                .append("name=")
-                .append(itemSet.getName());
+        beanName.append(MetricRegister.JMX_DOMAIN).append(MetricItemMBean.DOMAIN_SEPARATOR)
+                .append("type=").append(MetricUtils.getDomain(DataProxyMetricItemSet.class))
+                .append(MetricItemMBean.PROPERTY_SEPARATOR)
+                .append("name=").append(itemSet.getName());
         String strBeanName = beanName.toString();
         ObjectName objName = new ObjectName(strBeanName);
         {

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -22,3 +22,7 @@ cluster_id=1
 manager_hosts=ip:port
 # check interval of local config (millisecond)
 configCheckInterval=10000
+
+metricDomains=DataProxy
+metricDomains.DataProxy.domainListeners=org.apache.inlong.dataproxy.metrics.prometheus.PrometheusMetricListener
+metricDomains.DataProxy.snapshotInterval=60000

--- a/inlong-dataproxy/dataproxy-source/pom.xml
+++ b/inlong-dataproxy/dataproxy-source/pom.xml
@@ -26,8 +26,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<compiler.source>1.8</compiler.source>
 		<compiler.target>1.8</compiler.target>
-		<junit.version>4.13</junit.version>
 		<guava.version>19.0</guava.version>
+		<powermock.version>2.0.9</powermock.version>
 		<skipTests>false</skipTests>
 	</properties>
 
@@ -46,19 +46,13 @@
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
-			<version>2.0.2</version>
+			<version>${powermock.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito2</artifactId>
-			<version>2.0.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<version>${powermock.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/DataProxyMetricItem.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/DataProxyMetricItem.java
@@ -114,4 +114,143 @@ public class DataProxyMetricItem extends MetricItem {
         dimensions.put(KEY_INLONG_GROUP_ID, inlongGroupId);
         dimensions.put(KEY_INLONG_STREAM_ID, inlongStreamId);
     }
+
+    /**
+     * get clusterId
+     * 
+     * @return the clusterId
+     */
+    public String getClusterId() {
+        return clusterId;
+    }
+
+    /**
+     * get readSuccessCount
+     * 
+     * @return the readSuccessCount
+     */
+    public long getReadSuccessCount() {
+        return readSuccessCount.get();
+    }
+
+    /**
+     * get readSuccessSize
+     * 
+     * @return the readSuccessSize
+     */
+    public long getReadSuccessSize() {
+        return readSuccessSize.get();
+    }
+
+    /**
+     * get readFailCount
+     * 
+     * @return the readFailCount
+     */
+    public long getReadFailCount() {
+        return readFailCount.get();
+    }
+
+    /**
+     * get readFailSize
+     * 
+     * @return the readFailSize
+     */
+    public long getReadFailSize() {
+        return readFailSize.get();
+    }
+
+    /**
+     * get sendCount
+     * 
+     * @return the sendCount
+     */
+    public long getSendCount() {
+        return sendCount.get();
+    }
+
+    /**
+     * get sendSize
+     * 
+     * @return the sendSize
+     */
+    public long getSendSize() {
+        return sendSize.get();
+    }
+
+    /**
+     * get sendSuccessCount
+     * 
+     * @return the sendSuccessCount
+     */
+    public long getSendSuccessCount() {
+        return sendSuccessCount.get();
+    }
+
+    /**
+     * get sendSuccessSize
+     * 
+     * @return the sendSuccessSize
+     */
+    public long getSendSuccessSize() {
+        return sendSuccessSize.get();
+    }
+
+    /**
+     * get sendFailCount
+     * 
+     * @return the sendFailCount
+     */
+    public long getSendFailCount() {
+        return sendFailCount.get();
+    }
+
+    /**
+     * get sendFailSize
+     * 
+     * @return the sendFailSize
+     */
+    public long getSendFailSize() {
+        return sendFailSize.get();
+    }
+
+    /**
+     * get sinkDuration
+     * 
+     * @return the sinkDuration
+     */
+    public long getSinkAverageDuration() {
+        long longSendSuccessCount = sendSuccessCount.get();
+        if (longSendSuccessCount <= 0) {
+            return 0;
+        }
+        return sinkDuration.get() / longSendSuccessCount;
+    }
+
+    /**
+     * get nodeDuration
+     * 
+     * @return the nodeDuration
+     */
+    public long getNodeAverageDuration() {
+        long longSendSuccessCount = sendSuccessCount.get();
+        if (longSendSuccessCount <= 0) {
+            return 0;
+        }
+        return nodeDuration.get() / longSendSuccessCount;
+    }
+
+    /**
+     * get wholeDuration
+     * 
+     * @return the wholeDuration
+     */
+    public long getWholeAverageDuration() {
+        long longSendSuccessCount = sendSuccessCount.get();
+        if (longSendSuccessCount <= 0) {
+            return 0;
+        }
+        return wholeDuration.get() / longSendSuccessCount;
+    }
+
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/MetricListenerRunnable.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/MetricListenerRunnable.java
@@ -36,6 +36,8 @@ import org.apache.commons.lang.ClassUtils;
 import org.apache.inlong.commons.config.metrics.MetricItem;
 import org.apache.inlong.commons.config.metrics.MetricItemMBean;
 import org.apache.inlong.commons.config.metrics.MetricItemSetMBean;
+import org.apache.inlong.commons.config.metrics.MetricRegister;
+import org.apache.inlong.commons.config.metrics.MetricUtils;
 import org.apache.inlong.commons.config.metrics.MetricValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +96,12 @@ public class MetricListenerRunnable implements Runnable {
     @SuppressWarnings("unchecked")
     private List<MetricItemValue> getItemValues() throws InstanceNotFoundException, AttributeNotFoundException,
             ReflectionException, MBeanException, MalformedObjectNameException, ClassNotFoundException {
-        ObjectName objName = new ObjectName(domain + MetricItemMBean.DOMAIN_SEPARATOR + "*");
+        StringBuilder beanName = new StringBuilder();
+        beanName.append(MetricRegister.JMX_DOMAIN).append(MetricItemMBean.DOMAIN_SEPARATOR)
+                .append("type=").append(MetricUtils.getDomain(DataProxyMetricItemSet.class))
+                .append(MetricItemMBean.PROPERTY_SEPARATOR)
+                .append("*");
+        ObjectName objName = new ObjectName(beanName.toString());
         final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         Set<ObjectInstance> mbeans = mbs.queryMBeans(objName, null);
         LOG.info("getItemValues for domain:{},queryMBeans:{}", domain, mbeans);

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestDataProxyMetricItemSet.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestDataProxyMetricItemSet.java
@@ -22,8 +22,10 @@ import static org.junit.Assert.assertEquals;
 import java.lang.management.ManagementFactory;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 
 import org.apache.inlong.commons.config.metrics.MetricItem;
@@ -117,13 +119,14 @@ public class TestDataProxyMetricItemSet {
         String keySink2 = MetricUtils.getDimensionsKey(dimSink);
         // report
         final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        StringBuilder beanName = new StringBuilder();
-        beanName.append(MetricUtils.getDomain(DataProxyMetricItemSet.class)).append(MetricItemMBean.DOMAIN_SEPARATOR)
-                .append("name=")
-                .append(itemSet.getName());
-        String strBeanName = beanName.toString();
-        ObjectName objName = new ObjectName(strBeanName);
         {
+            StringBuilder beanName = new StringBuilder();
+            beanName.append(MetricRegister.JMX_DOMAIN).append(MetricItemMBean.DOMAIN_SEPARATOR)
+                    .append("type=").append(MetricUtils.getDomain(DataProxyMetricItemSet.class))
+                    .append(MetricItemMBean.PROPERTY_SEPARATOR)
+                    .append("name=").append(itemSet.getName());
+            String strBeanName = beanName.toString();
+            ObjectName objName = new ObjectName(strBeanName);
             List<MetricItem> items = (List<MetricItem>) mbs.invoke(objName, MetricItemSetMBean.METHOD_SNAPSHOT, null,
                     null);
             for (MetricItem itemObj : items) {
@@ -151,6 +154,18 @@ public class TestDataProxyMetricItemSet {
                     System.out.println("bad MetricItem:" + itemObj.getDimensionsKey());
                 }
             }
+        }
+        {
+            StringBuilder beanName = new StringBuilder();
+            beanName.append(MetricRegister.JMX_DOMAIN).append(MetricItemMBean.DOMAIN_SEPARATOR)
+                    .append("type=").append(MetricUtils.getDomain(DataProxyMetricItemSet.class))
+                    .append(MetricItemMBean.PROPERTY_SEPARATOR)
+                    .append("*");
+
+            String strBeanName = beanName.toString();
+            ObjectName objName = new ObjectName(strBeanName);
+            Set<ObjectInstance> mbeans = mbs.queryMBeans(objName, null);
+            assertEquals(mbeans.size(), 1);
         }
     }
 }

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/sink/pulsar/federation/TestPulsarProducerFederation.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/sink/pulsar/federation/TestPulsarProducerFederation.java
@@ -27,7 +27,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.flume.Context;
 import org.apache.flume.Event;
-import org.apache.inlong.dataproxy.config.loader.TestContextIdTopicConfigLoader;
 import org.apache.inlong.dataproxy.utils.MockUtils;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.MessageId;
@@ -51,10 +50,10 @@ import org.slf4j.LoggerFactory;
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")
 @PrepareForTest({PulsarClient.class, ClientBuilder.class, MessageId.class,
-    Producer.class, ProducerBuilder.class, TypedMessageBuilder.class})
+        Producer.class, ProducerBuilder.class, TypedMessageBuilder.class})
 public class TestPulsarProducerFederation {
 
-    public static final Logger LOG = LoggerFactory.getLogger(TestContextIdTopicConfigLoader.class);
+    public static final Logger LOG = LoggerFactory.getLogger(TestPulsarProducerFederation.class);
     public static Context context;
     public static Context sinkContext;
 


### PR DESCRIPTION
[INLONG-1911] add pulling metric of Prometheus, pulling metric value will not be reset.

### Title Name: [INLONG-1911][DataProxy]  add pulling metric of Prometheus, pulling metric value will not be reset.

Fixes #1911

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
