### PR TITLE
[INLONG-1926] Inlong-Sort-Standalone support JMX metrics listener for pulling.

### DIFF
--- a/inlong-sort-standalone/conf/common.properties
+++ b/inlong-sort-standalone/conf/common.properties
@@ -17,3 +17,7 @@
 # under the License.
 #
 clusterName=sort-standalone-hive-1
+
+metricDomains=Sort
+metricDomains.Sort.domainListeners=org.apache.inlong.sort.standalone.metrics.prometheus.PrometheusMetricListener
+metricDomains.Sort.snapshotInterval=60000

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/prometheus/PrometheusMetricListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/prometheus/PrometheusMetricListener.java
@@ -65,8 +65,7 @@ public class PrometheusMetricListener implements MetricListener {
             ObjectName objName = new ObjectName(strBeanName);
             mbs.registerMBean(metricItem, objName);
         } catch (Exception ex) {
-            LOG.error("exception while register mbean:{},error:{}", strBeanName, ex.getMessage());
-            LOG.error(ex.getMessage(), ex);
+            LOG.error("exception while register mbean:{},error:{}", strBeanName, ex);
         }
         // prepare metric value map
         metricValueMap.put(SortMetricItem.M_READ_SUCCESS_COUNT, metricItem.readSuccessCount);
@@ -106,5 +105,4 @@ public class PrometheusMetricListener implements MetricListener {
             }
         }
     }
-
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/prometheus/PrometheusMetricListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/prometheus/PrometheusMetricListener.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.metrics.prometheus;
+
+import static org.apache.inlong.commons.config.metrics.MetricItemMBean.DOMAIN_SEPARATOR;
+import static org.apache.inlong.commons.config.metrics.MetricRegister.JMX_DOMAIN;
+import static org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder.KEY_CLUSTER_ID;
+
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.apache.inlong.commons.config.metrics.MetricRegister;
+import org.apache.inlong.commons.config.metrics.MetricValue;
+import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.sort.standalone.metrics.MetricItemValue;
+import org.apache.inlong.sort.standalone.metrics.MetricListener;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * PrometheusMetricListener
+ */
+public class PrometheusMetricListener implements MetricListener {
+
+    public static final Logger LOG = LoggerFactory.getLogger(MetricRegister.class);
+
+    //
+    private SortMetricItem metricItem;
+    private Map<String, AtomicLong> metricValueMap = new ConcurrentHashMap<>();
+
+    /**
+     * Constructor
+     */
+    public PrometheusMetricListener() {
+        this.metricItem = new SortMetricItem();
+        this.metricItem.clusterId = CommonPropertiesHolder.getString(KEY_CLUSTER_ID);
+        final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        StringBuilder beanName = new StringBuilder();
+        beanName.append(JMX_DOMAIN).append(DOMAIN_SEPARATOR).append("type=DataProxyCounter");
+        String strBeanName = beanName.toString();
+        try {
+            ObjectName objName = new ObjectName(strBeanName);
+            mbs.registerMBean(metricItem, objName);
+        } catch (Exception ex) {
+            LOG.error("exception while register mbean:{},error:{}", strBeanName, ex.getMessage());
+            LOG.error(ex.getMessage(), ex);
+        }
+        //
+        metricValueMap.put(SortMetricItem.M_READ_SUCCESS_COUNT, metricItem.readSuccessCount);
+        metricValueMap.put(SortMetricItem.M_READ_SUCCESS_SIZE, metricItem.readSuccessSize);
+        metricValueMap.put(SortMetricItem.M_READ_FAIL_COUNT, metricItem.readFailCount);
+        metricValueMap.put(SortMetricItem.M_READ_FAIL_SIZE, metricItem.readFailSize);
+        //
+        metricValueMap.put(SortMetricItem.M_SEND_COUNT, metricItem.sendCount);
+        metricValueMap.put(SortMetricItem.M_SEND_SIZE, metricItem.sendSize);
+        //
+        metricValueMap.put(SortMetricItem.M_SEND_SUCCESS_COUNT, metricItem.sendSuccessCount);
+        metricValueMap.put(SortMetricItem.M_SEND_SUCCESS_SIZE, metricItem.sendSuccessSize);
+        metricValueMap.put(SortMetricItem.M_SEND_FAIL_COUNT, metricItem.sendFailCount);
+        metricValueMap.put(SortMetricItem.M_SEND_FAIL_SIZE, metricItem.sendFailSize);
+        //
+        metricValueMap.put(SortMetricItem.M_SINK_DURATION, metricItem.sinkDuration);
+        metricValueMap.put(SortMetricItem.M_NODE_DURATION, metricItem.nodeDuration);
+        metricValueMap.put(SortMetricItem.M_WHOLE_DURATION, metricItem.wholeDuration);
+    }
+
+    /**
+     * snapshot
+     * 
+     * @param domain
+     * @param itemValues
+     */
+    @Override
+    public void snapshot(String domain, List<MetricItemValue> itemValues) {
+        for (MetricItemValue itemValue : itemValues) {
+            for (Entry<String, MetricValue> entry : itemValue.getMetrics().entrySet()) {
+                String fieldName = entry.getValue().name;
+                AtomicLong metricValue = this.metricValueMap.get(fieldName);
+                if (metricValue != null) {
+                    long fieldValue = entry.getValue().value;
+                    metricValue.addAndGet(fieldValue);
+                }
+            }
+        }
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/prometheus/PrometheusMetricListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/prometheus/PrometheusMetricListener.java
@@ -48,7 +48,6 @@ public class PrometheusMetricListener implements MetricListener {
 
     public static final Logger LOG = LoggerFactory.getLogger(MetricRegister.class);
 
-    //
     private SortMetricItem metricItem;
     private Map<String, AtomicLong> metricValueMap = new ConcurrentHashMap<>();
 
@@ -69,7 +68,7 @@ public class PrometheusMetricListener implements MetricListener {
             LOG.error("exception while register mbean:{},error:{}", strBeanName, ex.getMessage());
             LOG.error(ex.getMessage(), ex);
         }
-        //
+        // prepare metric value map
         metricValueMap.put(SortMetricItem.M_READ_SUCCESS_COUNT, metricItem.readSuccessCount);
         metricValueMap.put(SortMetricItem.M_READ_SUCCESS_SIZE, metricItem.readSuccessSize);
         metricValueMap.put(SortMetricItem.M_READ_FAIL_COUNT, metricItem.readFailCount);


### PR DESCRIPTION
### Title Name: [INLONG-1926][Inlong-Sort-Standalone] Inlong-Sort-Standalone support JMX metrics listener for pulling.

Fixes #1926 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
