### PR TITLE
[INLONG-1978][Bug][InLong-Agent] Create multiple file import tasks, and inlong-agent reports an error when registering metric

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -169,6 +169,15 @@ public class AgentUtils {
     }
 
     /**
+     * Get uniq id with prefix and index.
+     *
+     * @return uniq id.
+     */
+    public static String getUniqId(String prefix, long index) {
+        return getUniqId(prefix, "", index);
+    }
+
+    /**
      * Get uniq id with timestamp and index.
      * @param id - job id
      * @param index - job index

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.inlong.agent.common.AgentThreadFactory;
 import org.apache.inlong.agent.conf.JobProfile;
@@ -87,7 +88,7 @@ public class ProxySink extends AbstractSink {
             0L, TimeUnit.MILLISECONDS,
             new LinkedBlockingQueue<>(), new AgentThreadFactory("ProxySink"));
     private volatile boolean shutdown = false;
-
+    private static AtomicLong index = new AtomicLong(0);
     // key is stream id, value is a batch of messages belong to the same stream id
     private ConcurrentHashMap<String, PackProxyMessage> cache;
     private long dataTime;
@@ -96,9 +97,9 @@ public class ProxySink extends AbstractSink {
 
     public ProxySink() {
         if (ConfigUtil.isPrometheusEnabled()) {
-            this.sinkMetrics = new SinkPrometheusMetrics(PROXY_SINK_TAG_NAME);
+            this.sinkMetrics = new SinkPrometheusMetrics(AgentUtils.getUniqId(PROXY_SINK_TAG_NAME, index.incrementAndGet()));
         } else {
-            this.sinkMetrics = new SinkJmxMetric(PROXY_SINK_TAG_NAME);
+            this.sinkMetrics = new SinkJmxMetric(AgentUtils.getUniqId(PROXY_SINK_TAG_NAME, index.incrementAndGet()));
         }
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
@@ -97,9 +97,11 @@ public class ProxySink extends AbstractSink {
 
     public ProxySink() {
         if (ConfigUtil.isPrometheusEnabled()) {
-            this.sinkMetrics = new SinkPrometheusMetrics(AgentUtils.getUniqId(PROXY_SINK_TAG_NAME, index.incrementAndGet()));
+            this.sinkMetrics = new SinkPrometheusMetrics(AgentUtils.getUniqId(
+                PROXY_SINK_TAG_NAME, index.incrementAndGet()));
         } else {
-            this.sinkMetrics = new SinkJmxMetric(AgentUtils.getUniqId(PROXY_SINK_TAG_NAME, index.incrementAndGet()));
+            this.sinkMetrics = new SinkJmxMetric(AgentUtils.getUniqId(
+                PROXY_SINK_TAG_NAME, index.incrementAndGet()));
         }
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/PulsarSink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/PulsarSink.java
@@ -89,11 +89,15 @@ public class PulsarSink extends AbstractDaemon implements Sink {
 
     public PulsarSink() {
         if (ConfigUtil.isPrometheusEnabled()) {
-            this.pluginMetricNew = new PluginPrometheusMetric(AgentUtils.getUniqId(PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
-            this.sinkMetrics = new SinkPrometheusMetrics(AgentUtils.getUniqId(PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
+            this.pluginMetricNew = new PluginPrometheusMetric(AgentUtils.getUniqId(
+                PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
+            this.sinkMetrics = new SinkPrometheusMetrics(AgentUtils.getUniqId(
+                PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
         } else {
-            this.pluginMetricNew = new PluginJmxMetric(AgentUtils.getUniqId(PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
-            this.sinkMetrics = new SinkJmxMetric(AgentUtils.getUniqId(PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
+            this.pluginMetricNew = new PluginJmxMetric(AgentUtils.getUniqId(
+                PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
+            this.sinkMetrics = new SinkJmxMetric(AgentUtils.getUniqId(
+                PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
         }
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/PulsarSink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/PulsarSink.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.inlong.agent.common.AbstractDaemon;
 import org.apache.inlong.agent.conf.JobProfile;
 import org.apache.inlong.agent.plugin.Message;
@@ -84,14 +85,15 @@ public class PulsarSink extends AbstractDaemon implements Sink {
     private final PluginMetric pluginMetricNew;
     private final SinkMetrics sinkMetrics;
     private PulsarClient client;
+    private static AtomicLong metricsIndex = new AtomicLong(0);
 
     public PulsarSink() {
         if (ConfigUtil.isPrometheusEnabled()) {
-            this.pluginMetricNew = new PluginPrometheusMetric(PULSAR_SINK_TAG_NAME);
-            this.sinkMetrics = new SinkPrometheusMetrics(PULSAR_SINK_TAG_NAME);
+            this.pluginMetricNew = new PluginPrometheusMetric(AgentUtils.getUniqId(PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
+            this.sinkMetrics = new SinkPrometheusMetrics(AgentUtils.getUniqId(PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
         } else {
-            this.pluginMetricNew = new PluginJmxMetric(PULSAR_SINK_TAG_NAME);
-            this.sinkMetrics = new SinkJmxMetric(PULSAR_SINK_TAG_NAME);
+            this.pluginMetricNew = new PluginJmxMetric(AgentUtils.getUniqId(PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
+            this.sinkMetrics = new SinkJmxMetric(AgentUtils.getUniqId(PULSAR_SINK_TAG_NAME, metricsIndex.incrementAndGet()));
         }
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/SqlReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/SqlReader.java
@@ -96,9 +96,11 @@ public class SqlReader implements Reader {
         this.sql = sql;
 
         if (ConfigUtil.isPrometheusEnabled()) {
-            this.sqlFileMetric = new PluginPrometheusMetric(AgentUtils.getUniqId(SQL_READER_TAG_NAME, metricsIndex.incrementAndGet()));
+            this.sqlFileMetric = new PluginPrometheusMetric(
+                AgentUtils.getUniqId(SQL_READER_TAG_NAME, metricsIndex.incrementAndGet()));
         } else {
-            this.sqlFileMetric = new PluginJmxMetric(AgentUtils.getUniqId(SQL_READER_TAG_NAME, metricsIndex.incrementAndGet()));
+            this.sqlFileMetric = new PluginJmxMetric(
+                AgentUtils.getUniqId(SQL_READER_TAG_NAME, metricsIndex.incrementAndGet()));
         }
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/SqlReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/SqlReader.java
@@ -29,6 +29,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.CharUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -89,14 +90,15 @@ public class SqlReader implements Reader {
     private boolean finished = false;
     private String separator;
     private final PluginMetric sqlFileMetric;
+    private static AtomicLong metricsIndex = new AtomicLong(0);
 
     public SqlReader(String sql) {
         this.sql = sql;
 
         if (ConfigUtil.isPrometheusEnabled()) {
-            this.sqlFileMetric = new PluginPrometheusMetric(SQL_READER_TAG_NAME);
+            this.sqlFileMetric = new PluginPrometheusMetric(AgentUtils.getUniqId(SQL_READER_TAG_NAME, metricsIndex.incrementAndGet()));
         } else {
-            this.sqlFileMetric = new PluginJmxMetric(SQL_READER_TAG_NAME);
+            this.sqlFileMetric = new PluginJmxMetric(AgentUtils.getUniqId(SQL_READER_TAG_NAME, metricsIndex.incrementAndGet()));
         }
     }
 


### PR DESCRIPTION
### Title Name: [INLONG-1978][Bug][InLong-Agent] Create multiple file import tasks, and inlong-agent reports an error when registering metric

Fixes #1978 

### Motivation

Multiple import tasks run normally

Create multiple data streams for the same data access service, and each data stream is configured with file import tasks


### Modifications

add uniq id when register metric

### Documentation

  - Does this pull request introduce a new feature? (no)

