### PR TITLE
[INLONG-1980][Bug][InLong-Dataproxy] the content of topics.properties generated incorrectly，and too much backup files generate automatically

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigJson.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigJson.java
@@ -35,12 +35,12 @@ public class RemoteConfigJson {
 
     public static class DataItem {
 
-        private String groupId;
+        private String inlongGroupId;
         private String topic;
         private String m;
 
         public String getGroupId() {
-            return groupId;
+            return inlongGroupId;
         }
 
         public String getTopic() {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/PropertiesConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/PropertiesConfigHolder.java
@@ -93,8 +93,12 @@ public class PropertiesConfigHolder extends ConfigHolder {
         boolean isSuccess = false;
         try {
             File sourceFile = new File(getFilePath());
+            File targetFile = new File(getNextBackupFileName());
             File tmpNewFile = new File(getFileName() + ".tmp");
 
+            if (sourceFile.exists()) {
+                FileUtils.copyFile(sourceFile, targetFile);
+            }
             List<String> lines = getStringListFromHolder(tmpHolder);
             FileUtils.writeLines(tmpNewFile, lines);
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/PropertiesConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/PropertiesConfigHolder.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/PropertiesConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/PropertiesConfigHolder.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -93,12 +94,7 @@ public class PropertiesConfigHolder extends ConfigHolder {
         boolean isSuccess = false;
         try {
             File sourceFile = new File(getFilePath());
-            File targetFile = new File(getNextBackupFileName());
             File tmpNewFile = new File(getFileName() + ".tmp");
-
-            if (sourceFile.exists()) {
-                FileUtils.copyFile(sourceFile, targetFile);
-            }
 
             List<String> lines = getStringListFromHolder(tmpHolder);
             FileUtils.writeLines(tmpNewFile, lines);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/remote/ConfigMessageServlet.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/remote/ConfigMessageServlet.java
@@ -56,7 +56,7 @@ public class ConfigMessageServlet extends HttpServlet {
     private boolean handleTopicConfig(RequestContent requestContent) {
         Map<String, String> groupIdToTopic = new HashMap<String, String>();
         for (Map<String, String> item : requestContent.getContent()) {
-            groupIdToTopic.put(item.get("groupId"), item.get("topic"));
+            groupIdToTopic.put(item.get("inlongGroupId"), item.get("topic"));
         }
         if ("add".equals(requestContent.getOperationType())) {
             return configManager.addTopicProperties(groupIdToTopic);
@@ -69,7 +69,7 @@ public class ConfigMessageServlet extends HttpServlet {
     private boolean handleMxConfig(RequestContent requestContent) {
         Map<String, String> groupIdToMValue = new HashMap<String, String>();
         for (Map<String, String> item : requestContent.getContent()) {
-            groupIdToMValue.put(item.get("groupId"), item.get("m"));
+            groupIdToMValue.put(item.get("inlongGroupId"), item.get("m"));
         }
         if ("add".equals(requestContent.getOperationType())) {
             return configManager.addMxProperties(groupIdToMValue);


### PR DESCRIPTION
### Title Name: [INLONG-1980][Bug][InLong-Dataproxy] the content of topics.properties generated incorrectly，and too much backup files generate automatically

Fixes #1980 

### Motivation

inlong groupId instead of null will be in the left side of "="(as p1)，and dataproxy generates too much junk files in a short period of time(as p2), it's not easy to clear after a long time.

### Modifications

fix bug
and remove backup files


### Documentation

  - Does this pull request introduce a new feature? (no)

