### PR TITLE
[INLONG-1981][Bug] When compiling the project, the InLong-audit module reported Warning errors (addendum)

### DIFF
--- a/inlong-agent/agent-release/assembly.xml
+++ b/inlong-agent/agent-release/assembly.xml
@@ -22,6 +22,7 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
     <id>bin</id>
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
 

--- a/inlong-agent/agent-release/pom.xml
+++ b/inlong-agent/agent-release/pom.xml
@@ -61,8 +61,6 @@
                             <goal>single</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>target</outputDirectory>
-                            <appendAssemblyId>false</appendAssemblyId>
                             <finalName>apache-inlong-agent-${project.version}</finalName>
                             <descriptors>
                                 <descriptor>assembly.xml</descriptor>

--- a/inlong-audit/audit-dist/assembly/assembly.xml
+++ b/inlong-audit/audit-dist/assembly/assembly.xml
@@ -25,6 +25,7 @@
     <id>bin</id>
 
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>

--- a/inlong-audit/audit-dist/pom.xml
+++ b/inlong-audit/audit-dist/pom.xml
@@ -59,8 +59,6 @@
                             <goal>single</goal>
                         </goals>
                         <configuration>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <outputDirectory>target</outputDirectory>
                             <descriptors>
                                 <descriptor>assembly/assembly.xml</descriptor>
                             </descriptors>

--- a/inlong-audit/audit-source/assembly/assembly.xml
+++ b/inlong-audit/audit-source/assembly/assembly.xml
@@ -25,6 +25,7 @@
     <id>bin</id>
 
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>

--- a/inlong-audit/audit-source/pom.xml
+++ b/inlong-audit/audit-source/pom.xml
@@ -95,7 +95,6 @@
                         <configuration>
                             <finalName>apache-inlong-audit-source-${project.version}</finalName>
                             <outputDirectory>target</outputDirectory>
-                            <appendAssemblyId>false</appendAssemblyId>
                             <descriptors>
                                 <descriptor>assembly/assembly.xml</descriptor>
                             </descriptors>

--- a/inlong-audit/audit-store/assembly/assembly.xml
+++ b/inlong-audit/audit-store/assembly/assembly.xml
@@ -20,6 +20,7 @@
 <assembly>
     <id>bin</id>
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>true</includeBaseDirectory>

--- a/inlong-audit/audit-store/pom.xml
+++ b/inlong-audit/audit-store/pom.xml
@@ -109,7 +109,6 @@
                 <configuration>
                     <finalName>apache-inlong-audit-store-${project.version}</finalName>
                     <outputDirectory>target</outputDirectory>
-                    <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
                         <descriptor>assembly/assembly.xml</descriptor>
                     </descriptors>

--- a/inlong-dataproxy/dataproxy-dist/pom.xml
+++ b/inlong-dataproxy/dataproxy-dist/pom.xml
@@ -60,7 +60,6 @@
                         </goals>
                         <configuration>
                             <finalName>apache-inlong-dataproxy-${project.version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
                             <descriptors>
                                 <descriptor>src/main/assembly/assembly.xml</descriptor>
                             </descriptors>

--- a/inlong-dataproxy/dataproxy-dist/src/main/assembly/assembly.xml
+++ b/inlong-dataproxy/dataproxy-dist/src/main/assembly/assembly.xml
@@ -25,6 +25,7 @@
     <id>bin</id>
 
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>

--- a/inlong-manager/manager-web/assembly.xml
+++ b/inlong-manager/manager-web/assembly.xml
@@ -23,6 +23,7 @@
 
     <!-- Types of packaging, if there are N, N types of packages will be printed -->
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
 

--- a/inlong-manager/manager-web/pom.xml
+++ b/inlong-manager/manager-web/pom.xml
@@ -219,7 +219,6 @@
                         </goals>
                         <configuration>
                             <finalName>apache-inlong-${project.artifactId}-${project.version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
                             <descriptors>
                                 <descriptor>assembly.xml</descriptor>
                             </descriptors>

--- a/inlong-sort-standalone/sort-standalone-dist/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-dist/pom.xml
@@ -60,7 +60,6 @@
                         </goals>
                         <configuration>
                             <finalName>apache-inlong-sort-standalone-${project.version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
                             <descriptors>
                                 <descriptor>src/main/assembly/assembly.xml</descriptor>
                             </descriptors>

--- a/inlong-sort-standalone/sort-standalone-dist/src/main/assembly/assembly.xml
+++ b/inlong-sort-standalone/sort-standalone-dist/src/main/assembly/assembly.xml
@@ -25,6 +25,7 @@
     <id>bin</id>
 
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>

--- a/inlong-tubemq/tubemq-client/pom.xml
+++ b/inlong-tubemq/tubemq-client/pom.xml
@@ -38,7 +38,6 @@
                 <version>${plugin.assembly.version}</version>
                 <configuration>
                     <finalName>apache-inlong-tubemq-client-${project.version}</finalName>
-                    <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
                         <descriptor>src/main/assembly/assembly.xml</descriptor>
                     </descriptors>

--- a/inlong-tubemq/tubemq-client/src/main/assembly/assembly.xml
+++ b/inlong-tubemq/tubemq-client/src/main/assembly/assembly.xml
@@ -18,6 +18,7 @@
 <assembly>
     <id>bin</id>
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
     <dependencySets>

--- a/inlong-tubemq/tubemq-example/pom.xml
+++ b/inlong-tubemq/tubemq-example/pom.xml
@@ -38,7 +38,6 @@
                 <version>${plugin.assembly.version}</version>
                 <configuration>
                     <finalName>apache-inlong-tubemq-example-${project.version}</finalName>
-                    <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
                         <descriptor>src/main/assembly/assembly.xml</descriptor>
                     </descriptors>

--- a/inlong-tubemq/tubemq-example/src/main/assembly/assembly.xml
+++ b/inlong-tubemq/tubemq-example/src/main/assembly/assembly.xml
@@ -18,6 +18,7 @@
 <assembly>
     <id>demo</id>
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
     <dependencySets>

--- a/inlong-tubemq/tubemq-manager/pom.xml
+++ b/inlong-tubemq/tubemq-manager/pom.xml
@@ -185,7 +185,6 @@
                         </goals>
                         <configuration>
                             <finalName>apache-inlong-tubemq-manager-${project.version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
                             <descriptors>
                                 <descriptor>src/main/assembly/assembly.xml</descriptor>
                             </descriptors>

--- a/inlong-tubemq/tubemq-manager/src/main/assembly/assembly.xml
+++ b/inlong-tubemq/tubemq-manager/src/main/assembly/assembly.xml
@@ -21,6 +21,7 @@
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
     <id>bin</id>
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>

--- a/inlong-tubemq/tubemq-server/pom.xml
+++ b/inlong-tubemq/tubemq-server/pom.xml
@@ -56,7 +56,6 @@
                 <version>${plugin.assembly.version}</version>
                 <configuration>
                     <finalName>apache-inlong-tubemq-server-${project.version}</finalName>
-                    <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
                         <descriptor>src/main/assembly/assembly.xml</descriptor>
                     </descriptors>

--- a/inlong-tubemq/tubemq-server/src/main/assembly/assembly.xml
+++ b/inlong-tubemq/tubemq-server/src/main/assembly/assembly.xml
@@ -18,6 +18,7 @@
 <assembly>
     <id>bin</id>
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>


### PR DESCRIPTION
Fixes #1981

Rollback the modification of [1], the empty deliverables will be formed when the version is packaged

![企业微信截图_1639486305759](https://user-images.githubusercontent.com/14038849/146107543-b3a40b1d-513c-480b-afeb-d014ba34e5bc.png)


1. https://github.com/apache/incubator-inlong/pull/1982/commits/7ec403d6b0a3520b8631a595adfdbbaf7e8bec01