### PR TITLE
[INLONG-1892][Inlong-sort-standalone] Sort-standalone support consume events from Pulsar.

### DIFF
--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/Constants.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/Constants.java
@@ -29,7 +29,8 @@ public interface Constants {
     String HEADER_KEY_MSG_TIME = "msgTime";
     String HEADER_KEY_SOURCE_IP = "sourceIp";
     String HEADER_KEY_SOURCE_TIME = "sourceTime";
-    String MESSAGE_KEY = "messageKey";
+    String HEADER_KEY_MESSAGE_KEY = "messageKey";
+    String HEADER_KEY_MSG_OFFSET = "msgOffset";
     
     String RELOAD_INTERVAL = "reloadInterval";
 }

--- a/inlong-sort-standalone/sort-standalone-source/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-source/pom.xml
@@ -42,5 +42,16 @@
             <artifactId>sort-standalone-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-sdk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>2.0.2</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/inlong-sort-standalone/sort-standalone-source/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-source/pom.xml
@@ -42,16 +42,39 @@
             <artifactId>sort-standalone-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.inlong</groupId>
             <artifactId>sort-sdk</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
             <version>2.0.2</version>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <artifactId>powermock-module-junit4</artifactId>
+            <groupId>org.powermock</groupId>
+            <scope>test</scope>
+            <version>2.0.2</version>
+        </dependency>
+
+        <dependency>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <groupId>org.powermock</groupId>
+            <scope>test</scope>
+            <version>2.0.2</version>
+        </dependency>
+
+        <dependency>
+            <artifactId>mockito-core</artifactId>
+            <groupId>org.mockito</groupId>
+            <scope>test</scope>
+            <version>2.23.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarProducerCluster.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarProducerCluster.java
@@ -225,7 +225,7 @@ public class PulsarProducerCluster implements LifecycleAware {
             this.addMetric(event, topic, false, 0);
             return false;
         }
-        String messageKey = headers.get(Constants.MESSAGE_KEY);
+        String messageKey = headers.get(Constants.HEADER_KEY_MESSAGE_KEY);
         if (messageKey == null) {
             messageKey = headers.get(Constants.HEADER_KEY_SOURCE_IP);
         }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/SourceContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/SourceContext.java
@@ -30,8 +30,11 @@ import javax.validation.constraints.NotNull;
  */
 public class SourceContext {
 
-    // The reload interval of source.
+    // The key of reload interval of source.
     private static final String KEY_RELOAD_INTERVAL = "reloadInterval";
+
+    // the default reload interval value in ms.
+    private static final long DEFAULT_RELOAD_INTERVAL_MS = 6000L;
 
     // The configured source context.
     private final Context sourceContext;
@@ -63,7 +66,7 @@ public class SourceContext {
      * @return Reload interval of source.
      */
     public final long getReloadInterval() {
-        return sourceContext.getLong(SourceContext.KEY_RELOAD_INTERVAL, 60000L);
+        return sourceContext.getLong(SourceContext.KEY_RELOAD_INTERVAL, DEFAULT_RELOAD_INTERVAL_MS);
     }
 
     /**

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/SourceContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/SourceContext.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.source;
+
+import org.apache.flume.Context;
+import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Base source context <b>WITHOUT</b> metric reporter.
+ * The derived classes of SourceContext may implement {@link org.apache.inlong.commons.config.metrics.MetricItem} and
+ * realize methods to report customized metrics.
+ */
+public class SourceContext {
+
+    /** The reload interval of source.*/
+    private static final String KEY_RELOAD_INTERVAL = "reloadInterval";
+
+    /** The configured source context.*/
+    private final Context sourceContext;
+
+    /** Name of source. Usually the class name of source.*/
+    private final String sourceName;
+
+    /** Cluster Id of source.*/
+    @NotNull
+    private final String clusterId;
+
+    /**
+     * Constructor of {@link SourceContext}.
+     *
+     * @param sourceName Name of source. Usually the class name of source.
+     * @param context The configured source context.
+     */
+    public SourceContext(
+            @NotBlank(message = "sourceName should not be empty or null") final String sourceName,
+            @NotNull(message = "context should not be null") final Context context) {
+
+        this.sourceName = sourceName;
+        this.sourceContext = context;
+        this.clusterId = context.getString(CommonPropertiesHolder.KEY_CLUSTER_ID);
+    }
+
+    /**
+     * Obtain the reload interval of source.
+     * @return Reload interval of source.
+     */
+    final public long getReloadInterval() {
+        return sourceContext.getLong(SourceContext.KEY_RELOAD_INTERVAL, 60000L);
+    }
+
+    /**
+     * Obtain the cluster Id of source.
+     * @return Cluster Id of source.
+     */
+    final public String getClusterId() {
+        return clusterId;
+    }
+
+    /**
+     * Obtain the name of source.
+     * @return Name of source.
+     */
+    final public String getSourceName() {
+        return sourceName;
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/SourceContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/SourceContext.java
@@ -30,16 +30,16 @@ import javax.validation.constraints.NotNull;
  */
 public class SourceContext {
 
-    /** The reload interval of source.*/
+    // The reload interval of source.
     private static final String KEY_RELOAD_INTERVAL = "reloadInterval";
 
-    /** The configured source context.*/
+    // The configured source context.
     private final Context sourceContext;
 
-    /** Name of source. Usually the class name of source.*/
+    // Name of source. Usually the class name of source.
     private final String sourceName;
 
-    /** Cluster Id of source.*/
+    // Cluster Id of source.
     @NotNull
     private final String clusterId;
 

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/SourceContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/SourceContext.java
@@ -62,7 +62,7 @@ public class SourceContext {
      * Obtain the reload interval of source.
      * @return Reload interval of source.
      */
-    final public long getReloadInterval() {
+    public final long getReloadInterval() {
         return sourceContext.getLong(SourceContext.KEY_RELOAD_INTERVAL, 60000L);
     }
 
@@ -70,7 +70,7 @@ public class SourceContext {
      * Obtain the cluster Id of source.
      * @return Cluster Id of source.
      */
-    final public String getClusterId() {
+    public final String getClusterId() {
         return clusterId;
     }
 
@@ -78,7 +78,7 @@ public class SourceContext {
      * Obtain the name of source.
      * @return Name of source.
      */
-    final public String getSourceName() {
+    public final String getSourceName() {
         return sourceName;
     }
 

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/DefaultTopicChangeListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/DefaultTopicChangeListener.java
@@ -31,7 +31,10 @@ import java.util.Set;
 public class DefaultTopicChangeListener implements InLongTopicChangeListener {
 
     @Override
-    public boolean onAssignmentsChange(Set<InLongTopic> allInLongTopics, Set<InLongTopic> newInLongTopics, Set<InLongTopic> removedInLongTopics) {
+    public boolean onAssignmentsChange(
+            Set<InLongTopic> allInLongTopics,
+            Set<InLongTopic> newInLongTopics,
+            Set<InLongTopic> removedInLongTopics) {
         return true;
     }
 

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/DefaultTopicChangeListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/DefaultTopicChangeListener.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.source.sortsdk;
+
+import org.apache.inlong.sdk.sort.api.InLongTopicChangeListener;
+import org.apache.inlong.sdk.sort.entity.InLongTopic;
+
+import java.util.Set;
+
+/**
+ * Default implementation of {@link InLongTopicChangeListener}.
+ *
+ * Do nothing when the topic assignments change.
+ *
+ */
+public class DefaultTopicChangeListener implements InLongTopicChangeListener {
+
+    @Override
+    public boolean onAssignmentsChange(Set<InLongTopic> allInLongTopics, Set<InLongTopic> newInLongTopics, Set<InLongTopic> removedInLongTopics) {
+        return true;
+    }
+
+    @Override
+    public boolean requestAck(String sortTaskId) {
+        return true;
+    }
+
+    @Override
+    public String offlineAndGetAckOffset(String msgKey) {
+        return "";
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
@@ -83,7 +83,7 @@ public class FetchCallback implements ReadCallback {
     @Override
     public void onFinished(final MessageRecord messageRecord) {
         try {
-            Preconditions.checkNotNull(messageRecord);
+            Preconditions.checkState(messageRecord != null, "Fetched msg is null.");
             final SubscribeFetchResult result = SubscribeFetchResult.Factory.create(sortId, messageRecord);
             final ProfileEvent profileEvent = new ProfileEvent(result.getBody(), result.getHeaders());
             channelProcessor.processEvent(profileEvent);

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.source.sortsdk;
+
+import com.google.common.base.Preconditions;
+import org.apache.flume.channel.ChannelProcessor;
+import org.apache.inlong.sdk.sort.api.ReadCallback;
+import org.apache.inlong.sdk.sort.entity.MessageRecord;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Implementation of {@link ReadCallback}.
+ *
+ * TODO: Sort sdk should deliver one object which is held by {@link ProfileEvent} and used to ack upstream data store
+ * The code should be like :
+ *
+ *        public void onFinished(final MessageRecord messageRecord, ACKer acker) {
+ *            doSomething();
+ *            final ProfileEvent profileEvent = new ProfileEvent(result.getBody(), result.getHeaders(), acker);
+ *             channelProcessor.processEvent(profileEvent);
+ *        }
+ *
+ * The ACKer will be used to <b>ACK</b> upstream after that the downstream <b>ACKed</b> sort-standalone.
+ * This process seems like <b>transaction</b> of the whole sort-standalone, and which
+ * ensure <b>At Least One</b> semantics.
+ */
+public class FetchCallback implements ReadCallback {
+
+    /** Logger of {@link FetchCallback}.*/
+    private static final Logger LOG = LoggerFactory.getLogger(FetchCallback.class);
+
+    /** SortId of fetch message.*/
+    private final String sortId;
+
+    /** ChannelProcessor that put message in specific channel.*/
+    private final ChannelProcessor channelProcessor;
+
+    /**
+     * Private constructor of {@link FetchCallback}.
+     * <p> The construction of FetchCallback should be initiated by {@link FetchCallback.Factory}.</p>
+     *
+     * @param sortId SortId of fetch message.
+     * @param channelProcessor ChannelProcessor that message put in.
+     */
+    private FetchCallback(
+            final String sortId,
+            final ChannelProcessor channelProcessor) {
+        this.sortId = sortId;
+        this.channelProcessor = channelProcessor;
+    }
+
+    /**
+     * The callback function that SortSDK invoke when fetch messages.
+     *
+     * @param messageRecord message
+     */
+    @Override
+    public void onFinished(final MessageRecord messageRecord) {
+        try {
+            Preconditions.checkNotNull(messageRecord);
+            final SubscribeFetchResult result = SubscribeFetchResult.Factory.create(sortId, messageRecord);
+            final ProfileEvent profileEvent = new ProfileEvent(result.getBody(), result.getHeaders());
+            channelProcessor.processEvent(profileEvent);
+
+        } catch (NullPointerException npe) {
+            LOG.error("Fetch one NULL message from sortId {}.", sortId);
+        }
+    }
+
+    /**
+     * Factory of {@link FetchCallback}
+     */
+    public static class Factory {
+
+        /**
+         * Create one {@link FetchCallback}.
+         * <p> Validate sortId and channelProcessor before the construction of FetchCallback.</p>
+         *
+         * @param sortId The sortId of fetched message.
+         * @param channelProcessor The channelProcessor that put message in specific channel.
+         *
+         * @return One FetchCallback.
+         */
+        public static FetchCallback create(
+                @NotBlank(message = "sortId should not be null or empty.") final String sortId,
+                @NotNull(message = "channelProcessor should not be null.") final ChannelProcessor channelProcessor) {
+            return new FetchCallback(sortId, channelProcessor);
+        }
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
@@ -90,6 +90,10 @@ public class FetchCallback implements ReadCallback {
     /**
      * The callback function that SortSDK invoke when fetch messages.
      *
+     * <p> In order to ACK the fetched msg, {@link FetchCallback} has to hold the {@link SortClient} which results in
+     * <b>Cycle Reference</b>. The {@link SortClient} should deliver one object to ACK after invoke the callback method
+     * {@link ReadCallback#onFinished(MessageRecord)}. </p>
+     *
      * @param messageRecord message
      */
     @Override
@@ -102,10 +106,10 @@ public class FetchCallback implements ReadCallback {
             context.reportToMetric(profileEvent, sortId, "-", SortSdkSourceContext.FetchResult.SUCCESS);
             client.ack(messageRecord.getMsgKey(), messageRecord.getMsgKey());
         } catch (NullPointerException npe) {
-            LOG.error("Fetch one NULL message from sortId {}.", sortId);
+            LOG.error("Got a null pointer exception for sortId " + sortId, npe);
             context.reportToMetric(null, sortId, "-", SortSdkSourceContext.FetchResult.FAILURE);
         } catch (Exception e) {
-            LOG.error("Ack failed for sortId {}", sortId);
+            LOG.error("Ack failed for sortId " + sortId, e);
         }
     }
 

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
@@ -64,12 +64,12 @@ public class FetchCallback implements ReadCallback {
      *
      * @param sortId SortId of fetch message.
      * @param channelProcessor ChannelProcessor that message put in.
-     * @param contex The context to report fetch results.
+     * @param context The context to report fetch results.
      */
     private FetchCallback(
             final String sortId,
             final ChannelProcessor channelProcessor,
-            final SortSdkSourceContext contex) {
+            final SortSdkSourceContext context) {
         this.sortId = sortId;
         this.channelProcessor = channelProcessor;
         this.context = context;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
@@ -47,19 +47,19 @@ import javax.validation.constraints.NotNull;
  */
 public class FetchCallback implements ReadCallback {
 
-    /** Logger of {@link FetchCallback}. */
+    // Logger of {@link FetchCallback}.
     private static final Logger LOG = LoggerFactory.getLogger(FetchCallback.class);
 
-    /** SortId of fetch message. */
+    // SortId of fetch message.
     private final String sortId;
 
-    /** ChannelProcessor that put message in specific channel. */
+    // ChannelProcessor that put message in specific channel.
     private final ChannelProcessor channelProcessor;
 
-    /** Context of source, used to report fetch results. */
+    // Context of source, used to report fetch results.
     private final SortSdkSourceContext context;
 
-    /** Temporary usage for ACK. The {@link SortClient} and Callback should not circular reference each other. */
+    // Temporary usage for ACK. The {@link SortClient} and Callback should not circular reference each other.
     private SortClient client;
 
     /**

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
  * default constructor <b>WITHOUT</b> any arguments, and parameters will be configured by
  * {@link Configurable#configure(Context)}. </p>
  */
-final public class SortSdkSource extends AbstractSource implements Configurable, Runnable, EventDrivenSource {
+public final class SortSdkSource extends AbstractSource implements Configurable, Runnable, EventDrivenSource {
 
     /** Log of {@link SortSdkSource}. */
     private static final Logger LOG = LoggerFactory.getLogger(SortSdkSource.class);

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -1,0 +1,184 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.source.sortsdk;
+
+import com.google.common.base.Preconditions;
+import org.apache.flume.Context;
+import org.apache.flume.EventDrivenSource;
+import org.apache.flume.conf.Configurable;
+import org.apache.flume.source.AbstractSource;
+import org.apache.inlong.sdk.sort.api.SortClient;
+import org.apache.inlong.sdk.sort.api.SortClientConfig;
+import org.apache.inlong.sdk.sort.api.SortClientFactory;
+import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
+import org.apache.inlong.sort.standalone.config.pojo.SortTaskConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Default Source implementation of InLong.
+ *
+ * <p> SortSdkSource acquired msg from different upstream data store by register {@link SortClient} for each
+ * sort task. The only things SortSdkSource should do is to get one client by the sort task id, or remove one client
+ * when the task is finished or schedule to other source instance. </p>
+ *
+ * <p> The Default Manager of InLong will schedule the partition and topic automatically. </p>
+ *
+ * <p> Because all sources should implement {@link Configurable}, the SortSdkSource should have
+ * default constructor <b>WITHOUT</b> any arguments, and parameters will be configured by
+ * {@link Configurable#configure(Context)}. </p>
+ */
+final public class SortSdkSource extends AbstractSource implements Configurable, Runnable, EventDrivenSource {
+
+    /** Log of {@link SortSdkSource}. */
+    private static final Logger LOG = LoggerFactory.getLogger(SortSdkSource.class);
+
+    /** Default pool of {@link ScheduledExecutorService}. */
+    private static final int CORE_POOL_SIZE = 1;
+
+    /** Default consume strategy of {@link SortClient}. */
+    private static final  SortClientConfig.ConsumeStrategy defaultStrategy = SortClientConfig.ConsumeStrategy.lastest;
+
+    /** Map of {@link SortClient}. */
+    private ConcurrentHashMap<String, SortClient> clients;
+
+    /** The cluster name of sort. */
+    private String sortClusterName;
+
+    /** Reload config interval. */
+    private long reloadInterval;
+
+    /** Context of SortSdkSource. */
+    private SortSdkSourceContext context;
+
+    /** Executor for config reloading. */
+    private ScheduledExecutorService pool;
+
+    /**
+     * Start SortSdkSource.
+     */
+    @Override
+    public synchronized void start() {
+        this.reload();
+    }
+
+    /**
+     * Stop {@link #pool} and close all {@link SortClient}.
+     */
+    @Override
+    public void stop() {
+        pool.shutdownNow();
+        clients.forEach((sortId, client) -> client.close());
+    }
+
+    /**
+     * Entrance of {@link #pool} to reload clients with fix rate {@link #reloadInterval}.
+     */
+    @Override
+    public void run() {
+        this.reload();
+    }
+
+    /**
+     * Configure parameters.
+     *
+     * @param context Context of source.
+     */
+    @Override
+    public void configure(Context context) {
+        this.clients = new ConcurrentHashMap<>();
+        this.sortClusterName = SortClusterConfigHolder.getClusterConfig().getClusterName();
+        Preconditions.checkState(context != null, "No context, configure failed");
+        this.context = new SortSdkSourceContext(getName(), context);
+        this.reloadInterval = this.context.getReloadInterval();
+        this.initReloadExecutor();
+    }
+
+    /**
+     * Init ScheduledExecutorService with fix reload rate {@link #reloadInterval}.
+     */
+    private void initReloadExecutor() {
+        this.pool = Executors.newScheduledThreadPool(CORE_POOL_SIZE);
+        pool.scheduleAtFixedRate(this, reloadInterval, reloadInterval, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Reload clients by current {@link SortTaskConfig}.
+     *
+     * <p> Create new clients with new sort task id, and remove the finished or scheduled ones. </p>
+     */
+    private void reload() {
+
+        final List<SortTaskConfig> configs = SortClusterConfigHolder.getClusterConfig().getSortTasks();
+        LOG.info("start to reload SortSdkSource");
+
+        // Start new clients
+        for (SortTaskConfig taskConfig : configs) {
+
+            // If exits, skip.
+            final String sortId = taskConfig.getName();
+            SortClient client = this.clients.get(sortId);
+            if (client != null) {
+                continue;
+            }
+
+            // Otherwise, new one client.
+            client = this.newClient(sortId);
+            if (client != null) {
+                this.clients.put(sortId, client);
+            }
+        }
+
+    }
+
+    /**
+     * Create one {@link SortClient} with specific sort id.
+     * @param sortId Sort in of new client.
+     *
+     * @return New sort client.
+     */
+    private SortClient newClient(String sortId) {
+        LOG.info("Start to new sort client for id: {}", sortId);
+        try {
+            SortClientConfig clientConfig =
+                    new SortClientConfig(sortId, this.sortClusterName, new DefaultTopicChangeListener(),
+                            SortSdkSource.defaultStrategy, InetAddress.getLocalHost().getHostAddress());
+            FetchCallback callback = FetchCallback.Factory.create(sortId, getChannelProcessor(), context);
+            clientConfig.setCallback(callback);
+            SortClient client = SortClientFactory.createSortClient(clientConfig);
+            client.init();
+            return client;
+        } catch (UnknownHostException ex) {
+            LOG.error("Got one UnknownHostException when init client of id: " + sortId, ex);
+        } catch (Throwable th) {
+            LOG.error("Got one throwable when init client of id: " + sortId, th);
+        }
+        return null;
+    }
+
+
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -54,28 +55,28 @@ import java.util.concurrent.TimeUnit;
  */
 public final class SortSdkSource extends AbstractSource implements Configurable, Runnable, EventDrivenSource {
 
-    /** Log of {@link SortSdkSource}. */
+    // Log of {@link SortSdkSource}.
     private static final Logger LOG = LoggerFactory.getLogger(SortSdkSource.class);
 
-    /** Default pool of {@link ScheduledExecutorService}. */
+    // Default pool of {@link ScheduledExecutorService}.
     private static final int CORE_POOL_SIZE = 1;
 
-    /** Default consume strategy of {@link SortClient}. */
+    // Default consume strategy of {@link SortClient}.
     private static final  SortClientConfig.ConsumeStrategy defaultStrategy = SortClientConfig.ConsumeStrategy.lastest;
 
-    /** Map of {@link SortClient}. */
-    private ConcurrentHashMap<String, SortClient> clients;
+    // Map of {@link SortClient}.
+    private Map<String, SortClient> clients;
 
-    /** The cluster name of sort. */
+    // The cluster name of sort.
     private String sortClusterName;
 
-    /** Reload config interval. */
+    // Reload config interval.
     private long reloadInterval;
 
-    /** Context of SortSdkSource. */
+    // Context of SortSdkSource.
     private SortSdkSourceContext context;
 
-    /** Executor for config reloading. */
+    // Executor for config reloading.
     private ScheduledExecutorService pool;
 
     /**
@@ -168,7 +169,7 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
      *
      * @return New sort client.
      */
-    private SortClient newClient(String sortId) {
+    private SortClient newClient(final String sortId) {
         LOG.info("Start to new sort client for id: {}", sortId);
         try {
             final SortClientConfig clientConfig =

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -163,10 +163,10 @@ final public class SortSdkSource extends AbstractSource implements Configurable,
     private SortClient newClient(String sortId) {
         LOG.info("Start to new sort client for id: {}", sortId);
         try {
-            SortClientConfig clientConfig =
+            final SortClientConfig clientConfig =
                     new SortClientConfig(sortId, this.sortClusterName, new DefaultTopicChangeListener(),
                             SortSdkSource.defaultStrategy, InetAddress.getLocalHost().getHostAddress());
-            FetchCallback callback = FetchCallback.Factory.create(sortId, getChannelProcessor(), context);
+            final FetchCallback callback = FetchCallback.Factory.create(sortId, getChannelProcessor(), context);
             clientConfig.setCallback(callback);
             SortClient client = SortClientFactory.createSortClient(clientConfig);
             client.init();
@@ -178,7 +178,5 @@ final public class SortSdkSource extends AbstractSource implements Configurable,
         }
         return null;
     }
-
-
 
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -132,7 +132,7 @@ final public class SortSdkSource extends AbstractSource implements Configurable,
      * <p> Create new clients with new sort task id, and remove the finished or scheduled ones. </p>
      *
      * <p> Current version of SortSdk <b>DO NOT</b> support to get the corresponding sort id of {@link SortClient}.
-     *  Hence the maintenance of mapping of <SortId, SortClient> should be done by Source itself. Which is not elegant,
+     *  Hence, the maintenance of mapping of <SortId, SortClient> should be done by Source itself. Which is not elegant,
      *  the <b>REMOVE</b> of expire clients will <b>NOT</b> be supported right now. </p>
      */
     private void reload() {

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceContext.java
@@ -31,9 +31,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * Derived class of {@link SourceContext} which implements methods to report metrics.
+ */
 public final class SortSdkSourceContext extends SourceContext {
 
-    /** Metric item set of Sort to create and maintain specific metric group. */
+    // Metric item set of Sort to create and maintain specific metric group.
     private final SortMetricItemSet metricItemSet;
 
     /**

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceContext.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-final public class SortSdkSourceContext extends SourceContext {
+public final class SortSdkSourceContext extends SourceContext {
 
     /** Metric item set of Sort to create and maintain specific metric group. */
     private final SortMetricItemSet metricItemSet;
@@ -77,7 +77,7 @@ final public class SortSdkSourceContext extends SourceContext {
 
         final Map<String, String> dimensions = this.createSortSdkSourceDimensionMap(event, sortId, topic);
         final SortMetricItem metricItem = metricItemSet.findMetricItem(dimensions);
-        final int msgSize = event != null? event.getBody().length : -1;
+        final int msgSize = event != null ? event.getBody().length : -1;
         this.reportToMetric(metricItem, fetchResult, msgSize);
     }
 

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceContext.java
@@ -131,5 +131,5 @@ final public class SortSdkSourceContext extends SourceContext {
         }
         return dimensions;
     }
-    
+
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceContext.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.sort.standalone.source.sortsdk;
 
 import org.apache.flume.Context;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceContext.java
@@ -1,0 +1,135 @@
+package org.apache.inlong.sort.standalone.source.sortsdk;
+
+import org.apache.flume.Context;
+import org.apache.inlong.commons.config.metrics.MetricRegister;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItemSet;
+import org.apache.inlong.sort.standalone.source.SourceContext;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+final public class SortSdkSourceContext extends SourceContext {
+
+    /** Metric item set of Sort to create and maintain specific metric group. */
+    private final SortMetricItemSet metricItemSet;
+
+    /**
+     * Type of metrics to report.
+     *
+     * <p> For {@link SortSdkSource}, there are only two types of fetch results, success or failure.</p>
+     */
+    public enum FetchResult {
+        SUCCESS,
+        FAILURE
+    }
+
+    /**
+     * Constructor of {@link SourceContext}.
+     *
+     * @param sourceName Name of source. Usually the class name of source.
+     * @param context The configured source context.
+     */
+    public SortSdkSourceContext(
+            @NotBlank(message = "sourceName should not be empty or null") final String sourceName,
+            @NotNull(message = "context should not be null") final Context context) {
+
+        super(sourceName, context);
+        this.metricItemSet = new SortMetricItemSet(sourceName);
+        MetricRegister.register(metricItemSet);
+    }
+
+    /**
+     * Entrance to report fetch metrics.
+     *
+     * @param event The fetched event. May be <b>null</b> when fetch failed occurs.
+     * @param sortId Sort id of event.
+     * @param topic Topic that event fetched from. May be <b>null</b> when fetch failed occurs.
+     * @param fetchResult Result of fetching, SUCCESS or FAILURE.
+     */
+    public void reportToMetric(
+            @Nullable final ProfileEvent event,
+            @Nullable final String sortId,
+            @Nullable final String topic,
+            @NotNull(message = "Must specify fetch result") final SortSdkSourceContext.FetchResult fetchResult) {
+
+        final Map<String, String> dimensions = this.createSortSdkSourceDimensionMap(event, sortId, topic);
+        final SortMetricItem metricItem = metricItemSet.findMetricItem(dimensions);
+        final int msgSize = event != null? event.getBody().length : -1;
+        this.reportToMetric(metricItem, fetchResult, msgSize);
+    }
+
+    /**
+     * Selector of metric report flow.
+     *
+     * @param item MetricItem that report to.
+     * @param fetchResult Result of fetching, SUCCESS or FAILURE.
+     * @param size The fetch length. -1 means fetch failure.
+     */
+    private void reportToMetric(
+            @NotNull final SortMetricItem item,
+            final FetchResult fetchResult,
+            final int size) {
+
+        switch (fetchResult) {
+            case SUCCESS:
+                reportToMetric(item.readSuccessCount, item.readSuccessSize, size);
+                break;
+            case FAILURE:
+                reportToMetric(item.readFailCount, item.readFailSize, size);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Report to a specific metric group.
+     *
+     * @param countMetric Metric of event count.
+     * @param sizeMetric Metric of event size.
+     * @param size Size of event.
+     */
+    private void reportToMetric(
+            @NotNull final AtomicLong countMetric,
+            @NotNull final AtomicLong sizeMetric,
+            final int size) {
+        countMetric.incrementAndGet();
+        sizeMetric.addAndGet(size);
+    }
+
+    /**
+     * Generator of report dimensions.
+     *
+     * <p> For the case of fetch {@link FetchResult#FAILURE}, the event may be null,
+     * the {@link org.apache.inlong.sort.standalone.utils.Constants#INLONG_GROUP_ID}
+     * and the {@link org.apache.inlong.sort.standalone.utils.Constants#INLONG_STREAM_ID} will not be specified. </p>
+     *
+     * @param event Event to be reported.
+     * @param sortId Sort id of fetched event.
+     * @param topic Topic of event.
+     *
+     * @return The dimensions of reported event.
+     */
+    private Map<String, String> createSortSdkSourceDimensionMap(
+            final ProfileEvent event,
+            final String sortId,
+            final String topic) {
+
+        final Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        dimensions.put(SortMetricItem.KEY_SOURCE_ID, this.getSourceName());
+        dimensions.put(SortMetricItem.KEY_TASK_NAME, sortId);
+        dimensions.put(SortMetricItem.KEY_SOURCE_DATA_ID, topic);
+        if (event != null) {
+            SortMetricItem.fillInlongId(event, dimensions);
+        }
+        return dimensions;
+    }
+    
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SubscribeFetchResult.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SubscribeFetchResult.java
@@ -27,8 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * SubscribeFetchResult is the wrapper of {@link MessageRecord}.
- * <p> In current version <b>0.12.0</b>, the metrics that SortSdkSource
- *  cares about is {@link #sortId}, {@link #headers} and {@link #body}.</p>
+ * <p> SubscribeFetchResult integrate message key, offset and message time in to the header map.</p>
  */
 public class SubscribeFetchResult {
 
@@ -52,7 +51,9 @@ public class SubscribeFetchResult {
             final String sortId,
             final MessageRecord message) {
         this.sortId = sortId;
-        this.headers.put(Constants.MESSAGE_KEY, message.getMsgKey());
+        this.headers.put(Constants.HEADER_KEY_MESSAGE_KEY, message.getMsgKey());
+        this.headers.put(Constants.HEADER_KEY_MSG_OFFSET, message.getOffset());
+        this.headers.put(Constants.HEADER_KEY_MSG_TIME, String.valueOf(message.getRecTime()));
         this.headers.putAll(message.getMsgHeader());
         this.body = message.getMessage();
     }
@@ -88,7 +89,7 @@ public class SubscribeFetchResult {
 
         /**
          * Create one {@link SubscribeFetchResult}.
-         * <p> Validate sortId and message before construction of SubscribeFetchResult.</p>
+         * <p> Validate sortId and message before the construction of SubscribeFetchResult.</p>
          *
          * @param sortId The sortId of fetched message.
          * @param messageRecord Message that fetched from upstream data storage.

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SubscribeFetchResult.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SubscribeFetchResult.java
@@ -31,13 +31,13 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class SubscribeFetchResult {
 
-    /** The sortId of fetched message.*/
+    // The sortId of fetched message.
     private final String sortId;
 
-    /** Important metrics called headers of {@link MessageRecord}, including message key.*/
+    // Important metrics called headers of {@link MessageRecord}, including message key.
     private final Map<String, String> headers = new ConcurrentHashMap<>();
 
-    /** Row data in binary format.*/
+    // Row data in binary format.
     private final byte[] body;
 
     /**

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SubscribeFetchResult.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SubscribeFetchResult.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.source.sortsdk;
+
+import org.apache.inlong.sdk.sort.entity.MessageRecord;
+import org.apache.inlong.sort.standalone.utils.Constants;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * SubscribeFetchResult is the wrapper of {@link MessageRecord}.
+ * <p> In current version <b>0.12.0</b>, the metrics that SortSdkSource
+ *  cares about is {@link #sortId}, {@link #headers} and {@link #body}.</p>
+ */
+public class SubscribeFetchResult {
+
+    /** The sortId of fetched message.*/
+    private final String sortId;
+
+    /** Important metrics called headers of {@link MessageRecord}, including message key.*/
+    private final Map<String, String> headers = new ConcurrentHashMap<>();
+
+    /** Row data in binary format.*/
+    private final byte[] body;
+
+    /**
+     * Private constructor of SubscribeFetchResult.
+     * <p> The construction of SubscribeFetchResult should be initiated by {@link SubscribeFetchResult.Factory}.</p>
+     *
+     * @param sortId The sortId of fetched message.
+     * @param message Message that fetched from upstream data storage.
+     */
+    private SubscribeFetchResult(
+            final String sortId,
+            final MessageRecord message) {
+        this.sortId = sortId;
+        this.headers.put(Constants.MESSAGE_KEY, message.getMsgKey());
+        this.headers.putAll(message.getMsgHeader());
+        this.body = message.getMessage();
+    }
+
+    /**
+     * Get row data that in binary format.
+     * @return Row data.
+     */
+    public byte[] getBody() {
+        return body;
+    }
+
+    /**
+     * Get important metrics in Map format called headers.
+     * @return headers.
+     */
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * Get sortId of fetched message.
+     * @return SortId of message.
+     */
+    public String getSortId() {
+        return sortId;
+    }
+
+    /**
+     * The factory of {@link SubscribeFetchResult}.
+     */
+    public static class Factory {
+
+        /**
+         * Create one {@link SubscribeFetchResult}.
+         * <p> Validate sortId and message before construction of SubscribeFetchResult.</p>
+         *
+         * @param sortId The sortId of fetched message.
+         * @param messageRecord Message that fetched from upstream data storage.
+         *
+         * @return One SubscribeFetchResult.
+         */
+        public static SubscribeFetchResult create(
+                @NotBlank(message = "SortId should not be null or empty.") final String sortId,
+                @NotNull(message = "MessageRecord should not be null.") final MessageRecord messageRecord) {
+            return new SubscribeFetchResult(sortId, messageRecord);
+        }
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/test/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceTest.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/test/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceTest.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.sort.standalone.source.sortsdk;
 
 import org.apache.flume.Context;
@@ -5,7 +22,6 @@ import org.apache.inlong.commons.config.metrics.MetricRegister;
 import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
 import org.apache.inlong.sort.standalone.config.pojo.SortClusterConfig;
 import org.apache.inlong.sort.standalone.config.pojo.SortTaskConfig;
-import org.apache.inlong.sort.standalone.source.SourceContext;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/test/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceTest.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/test/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSourceTest.java
@@ -1,0 +1,69 @@
+package org.apache.inlong.sort.standalone.source.sortsdk;
+
+import org.apache.flume.Context;
+import org.apache.inlong.commons.config.metrics.MetricRegister;
+import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
+import org.apache.inlong.sort.standalone.config.pojo.SortClusterConfig;
+import org.apache.inlong.sort.standalone.config.pojo.SortTaskConfig;
+import org.apache.inlong.sort.standalone.source.SourceContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SortClusterConfigHolder.class, LoggerFactory.class, Logger.class, MetricRegister.class})
+public class SortSdkSourceTest {
+
+    private Context mockContext;
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(LoggerFactory.class);
+        Logger LOG = PowerMockito.mock(Logger.class);
+        PowerMockito.when(LoggerFactory.getLogger(Mockito.any(Class.class))).thenReturn(LOG);
+        PowerMockito.mockStatic(MetricRegister.class);
+
+        PowerMockito.mockStatic(SortClusterConfigHolder.class);
+        SortClusterConfig config = prepareSortClusterConfig(2);
+        PowerMockito.when(SortClusterConfigHolder.getClusterConfig()).thenReturn(config);
+        mockContext = PowerMockito.spy(new Context());
+    }
+
+    @Test
+    public void testRun() {
+        SortSdkSource testSource = new SortSdkSource();
+        testSource.configure(mockContext);
+        testSource.run();
+        testSource.stop();
+    }
+
+    private SortClusterConfig prepareSortClusterConfig(final int size) {
+        final SortClusterConfig testConfig = new SortClusterConfig();
+        testConfig.setClusterName("testConfig");
+        testConfig.setSortTasks(prepareSortTaskConfig(size));
+        return testConfig;
+    }
+
+    private List<SortTaskConfig> prepareSortTaskConfig(final int size) {
+        List<SortTaskConfig> configs = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            SortTaskConfig config = new SortTaskConfig();
+            config.setName("testConfig" + i);
+            configs.add(config);
+        }
+        Assert.assertEquals(size, configs.size());
+        return configs;
+    }
+
+}


### PR DESCRIPTION
### Title Name: [INLONG-1892][Inlong-sort-standalone] Sort-standalone support consume events from Pulsar.

Fixes #1892

### Motivation

Integrate SortSdk into SortSdkSource, and support to consume events from Pulsar cache cluster.

### Modifications

Same as the motivation.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
