### PR TITLE
[INLONG-2035][Bug] Agent use wrong tid __ to generate message

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constants/CommonConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constants/CommonConstants.java
@@ -80,8 +80,8 @@ public class CommonConstants {
     public static final String FIELD_SPLITTER = "proxy.field.splitter";
     public static final String DEFAULT_FIELD_SPLITTER = "|";
 
-    public static final String PROXY_KEY_GROUP_ID = "groupId";
-    public static final String PROXY_KEY_STREAM_ID = "streamId";
+    public static final String PROXY_KEY_GROUP_ID = "inlongGroupId";
+    public static final String PROXY_KEY_STREAM_ID = "inlongStreamId";
     public static final String PROXY_KEY_ID = "id";
     public static final String PROXY_KEY_AGENT_IP = "agentip";
     public static final String PROXY_OCEANUS_F = "f";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/ProxyMessage.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/ProxyMessage.java
@@ -17,6 +17,9 @@
 
 package org.apache.inlong.agent.message;
 
+import static org.apache.inlong.agent.constants.CommonConstants.PROXY_KEY_GROUP_ID;
+import static org.apache.inlong.agent.constants.CommonConstants.PROXY_KEY_STREAM_ID;
+
 import java.util.Map;
 import org.apache.inlong.agent.plugin.Message;
 
@@ -35,8 +38,8 @@ public class ProxyMessage implements Message {
     public ProxyMessage(byte[] body, Map<String, String> header) {
         this.body = body;
         this.header = header;
-        this.inlongGroupId = header.get("inlongGroupId");
-        this.inlongStreamId = header.getOrDefault("inlongStreamId", DEFAULT_INLONG_STREAM_ID);
+        this.inlongGroupId = header.get(PROXY_KEY_GROUP_ID);
+        this.inlongStreamId = header.getOrDefault(PROXY_KEY_STREAM_ID, DEFAULT_INLONG_STREAM_ID);
     }
 
     /**


### PR DESCRIPTION
### [INLONG-2035][Bug] Agent use wrong tid __ to generate message

Fixes #2035 

### Motivation

Agent use wrong tid __ to generate message

### Modifications

Agent use right tid  to generate message


### Documentation

  - Does this pull request introduce a new feature? (no)

