### PR TITLE
[INLONG-2038][Bug]inlong-sort abandon data from pulsar due to an ClassCastException

### DIFF
--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/TDMsgMixedSerializedRecord.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/TDMsgMixedSerializedRecord.java
@@ -22,7 +22,7 @@ import static org.apache.inlong.sort.configuration.Constants.UNKNOWN_DATAFLOW_ID
 /**
  * Data flow id might not been got from mixed TDMsg data stream.
  */
-public class TDMsgSerializedRecord extends SerializedRecord {
+public class TDMsgMixedSerializedRecord extends SerializedRecord {
 
     private static final long serialVersionUID = 4075321919886376829L;
 
@@ -31,11 +31,11 @@ public class TDMsgSerializedRecord extends SerializedRecord {
     /**
      * Just satisfy requirement of Flink Pojo definition.
      */
-    public TDMsgSerializedRecord() {
+    public TDMsgMixedSerializedRecord() {
         super();
     }
 
-    public TDMsgSerializedRecord(String topic, long timestampMillis, byte[] data) {
+    public TDMsgMixedSerializedRecord(String topic, long timestampMillis, byte[] data) {
         super(UNKNOWN_DATAFLOW_ID, timestampMillis, data);
         this.topic = topic;
     }

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/deserialization/MultiTenancyDeserializer.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/deserialization/MultiTenancyDeserializer.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.flink.deserialization;
+
+import static org.apache.inlong.sort.formats.tdmsg.TDMsgUtils.DEFAULT_ATTRIBUTES_FIELD_NAME;
+import static org.apache.inlong.sort.formats.tdmsg.TDMsgUtils.DEFAULT_TIME_FIELD_NAME;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.util.Collector;
+import org.apache.inlong.sort.flink.Record;
+import org.apache.inlong.sort.flink.SerializedRecord;
+import org.apache.inlong.sort.formats.base.TableFormatConstants;
+import org.apache.inlong.sort.formats.common.RowFormatInfo;
+import org.apache.inlong.sort.formats.tdmsgcsv.TDMsgCsvFormatDeserializer;
+import org.apache.inlong.sort.meta.MetaManager.DataFlowInfoListener;
+import org.apache.inlong.sort.protocol.DataFlowInfo;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.deserialization.DeserializationInfo;
+import org.apache.inlong.sort.protocol.deserialization.TDMsgCsvDeserializationInfo;
+import org.apache.inlong.sort.util.CommonUtils;
+
+public class MultiTenancyDeserializer implements DataFlowInfoListener, Deserializer<SerializedRecord, Record> {
+    /**
+     * Date flow id -> Deserializer.
+     */
+    private final Map<Long, Deserializer<SerializedRecord, Record>> deserializers = new HashMap<>();
+
+    @Override
+    public void addDataFlow(DataFlowInfo dataFlowInfo) throws Exception {
+        updateDataFlow(dataFlowInfo);
+    }
+
+    @Override
+    public void updateDataFlow(DataFlowInfo dataFlowInfo) {
+        final DeserializationInfo deserializationInfo = dataFlowInfo.getSourceInfo().getDeserializationInfo();
+
+        final Deserializer<SerializedRecord, Record> deserializer = generateDeserializer(
+                dataFlowInfo.getSourceInfo().getFields(), deserializationInfo);
+
+        deserializers.put(dataFlowInfo.getId(), deserializer);
+    }
+
+    @Override
+    public void removeDataFlow(DataFlowInfo dataFlowInfo) {
+        deserializers.remove(dataFlowInfo.getId());
+    }
+
+    @Override
+    public void deserialize(SerializedRecord record, Collector<Record> collector) throws Exception {
+        final Deserializer<SerializedRecord, Record> deserializer = deserializers.get(record.getDataFlowId());
+        if (deserializer == null) {
+            throw new Exception("No schema found for data flow:" + record.getDataFlowId());
+        }
+        deserializer.deserialize(record, collector);
+    }
+
+    @VisibleForTesting
+    Deserializer<SerializedRecord, Record> generateDeserializer(
+            FieldInfo[] fields,
+            DeserializationInfo deserializationInfo) {
+
+        final RowFormatInfo rowFormatInfo = CommonUtils.generateRowFormatInfo(fields);
+
+        final Deserializer<SerializedRecord, Record> deserializer;
+        if (deserializationInfo instanceof TDMsgCsvDeserializationInfo) {
+            TDMsgCsvDeserializationInfo tdMsgCsvDeserializationInfo = (TDMsgCsvDeserializationInfo) deserializationInfo;
+            TDMsgCsvFormatDeserializer tdMsgCsvFormatDeserializer = new TDMsgCsvFormatDeserializer(
+                    rowFormatInfo,
+                    DEFAULT_TIME_FIELD_NAME,
+                    DEFAULT_ATTRIBUTES_FIELD_NAME,
+                    TableFormatConstants.DEFAULT_CHARSET,
+                    tdMsgCsvDeserializationInfo.getDelimiter(),
+                    null,
+                    null,
+                    null,
+                    tdMsgCsvDeserializationInfo.isDeleteHeadDelimiter(),
+                    TableFormatConstants.DEFAULT_IGNORE_ERRORS);
+            deserializer = new TDMsgDeserializer(tdMsgCsvFormatDeserializer);
+        } else {
+            // TODO, support more formats here
+            throw new UnsupportedOperationException(
+                    "Not supported yet " + deserializationInfo.getClass().getSimpleName());
+        }
+
+        return deserializer;
+    }
+}

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/deserialization/TDMsgDeserializer.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/deserialization/TDMsgDeserializer.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.flink.deserialization;
+
+import org.apache.flink.util.Collector;
+import org.apache.inlong.sort.flink.Record;
+import org.apache.inlong.sort.flink.SerializedRecord;
+import org.apache.inlong.sort.formats.tdmsg.AbstractTDMsgFormatDeserializer;
+
+public class TDMsgDeserializer implements Deserializer<SerializedRecord, Record> {
+    private final AbstractTDMsgFormatDeserializer innerDeserializer;
+
+    public TDMsgDeserializer(AbstractTDMsgFormatDeserializer innerDeserializer) {
+        this.innerDeserializer = innerDeserializer;
+    }
+
+    @Override
+    public void deserialize(SerializedRecord input, Collector<Record> collector) throws Exception {
+        innerDeserializer.flatMap(input.getData(),  new CallbackCollector<>(
+                row -> collector.collect(new Record(
+                        input.getDataFlowId(),
+                        input.getTimestampMillis(),
+                        row))));
+    }
+}

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/deserialization/TDMsgMixedDeserializer.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/deserialization/TDMsgMixedDeserializer.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.flink.util.Collector;
 import org.apache.inlong.sort.flink.Record;
-import org.apache.inlong.sort.flink.TDMsgSerializedRecord;
+import org.apache.inlong.sort.flink.TDMsgMixedSerializedRecord;
 import org.apache.inlong.sort.formats.tdmsg.AbstractTDMsgFormatDeserializer;
 import org.apache.inlong.sort.formats.tdmsg.TDMsgMixedFormatConverter;
 import org.apache.inlong.sort.formats.tdmsg.TDMsgUtils;
@@ -32,7 +32,7 @@ import org.apache.inlong.sort.formats.tdmsg.TDMsgUtils;
 /**
  * A deserializer to handle mixed TDMsg records of one topic.
  */
-public class TDMsgMixedDeserializer implements Deserializer<TDMsgSerializedRecord, Record> {
+public class TDMsgMixedDeserializer implements Deserializer<TDMsgMixedSerializedRecord, Record> {
 
     /**
      * Each topic should have same preDeserializer, so just keep one.
@@ -76,7 +76,7 @@ public class TDMsgMixedDeserializer implements Deserializer<TDMsgSerializedRecor
     }
 
     @Override
-    public void deserialize(TDMsgSerializedRecord tdMsgRecord, Collector<Record> collector) throws Exception {
+    public void deserialize(TDMsgMixedSerializedRecord tdMsgRecord, Collector<Record> collector) throws Exception {
         preDeserializer.flatMap(tdMsgRecord.getData(), new CallbackCollector<>(mixedRow -> {
             final String tid = TDMsgUtils.getTidFromMixedRow(mixedRow);
             final Set<Long> dataFlowIds = interface2DataFlowsMap.get(tid);

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/tubemq/MultiTenancyTubeConsumer.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/tubemq/MultiTenancyTubeConsumer.java
@@ -42,7 +42,7 @@ import org.apache.flink.util.TimeUtils;
 import org.apache.inlong.sort.configuration.Configuration;
 import org.apache.inlong.sort.configuration.Constants;
 import org.apache.inlong.sort.flink.SerializedRecord;
-import org.apache.inlong.sort.flink.TDMsgSerializedRecord;
+import org.apache.inlong.sort.flink.TDMsgMixedSerializedRecord;
 import org.apache.inlong.sort.meta.MetaManager;
 import org.apache.inlong.sort.util.CommonUtils;
 import org.apache.inlong.tubemq.client.config.ConsumerConfig;
@@ -396,7 +396,7 @@ public class MultiTenancyTubeConsumer {
                 synchronized (context.getCheckpointLock()) {
                     for (Message message : consumeResult.getMessageList()) {
                         // TODO, optimize for single tid or no tid topic
-                        context.collect(new TDMsgSerializedRecord(
+                        context.collect(new TDMsgMixedSerializedRecord(
                                 topic, System.currentTimeMillis(), message.getData()));
                     }
                     final String partitionKey = consumeResult.getPartitionKey();

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/flink/deserialization/MultiTenancyTDMsgMixedDeserializerTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/flink/deserialization/MultiTenancyTDMsgMixedDeserializerTest.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.inlong.commons.msg.TDMsg1;
 import org.apache.inlong.sort.flink.Record;
-import org.apache.inlong.sort.flink.TDMsgSerializedRecord;
+import org.apache.inlong.sort.flink.TDMsgMixedSerializedRecord;
 import org.apache.inlong.sort.formats.common.LongFormatInfo;
 import org.apache.inlong.sort.formats.common.StringFormatInfo;
 import org.apache.inlong.sort.protocol.DataFlowInfo;
@@ -84,7 +84,7 @@ public class MultiTenancyTDMsgMixedDeserializerTest extends TestLogger {
         tdMsg1.addMsg(attrs, body1.getBytes());
 
         final TestingCollector<Record> collector = new TestingCollector<>();
-        deserializer.deserialize(new TDMsgSerializedRecord("topic", 0, tdMsg1.buildArray()), collector);
+        deserializer.deserialize(new TDMsgMixedSerializedRecord("topic", 0, tdMsg1.buildArray()), collector);
 
         assertEquals(1, collector.results.size());
         assertEquals(1L, collector.results.get(0).getDataflowId());

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/flink/deserialization/TDMsgMixedDeserializerTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/flink/deserialization/TDMsgMixedDeserializerTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Collector;
 import org.apache.inlong.sort.flink.Record;
-import org.apache.inlong.sort.flink.TDMsgSerializedRecord;
+import org.apache.inlong.sort.flink.TDMsgMixedSerializedRecord;
 import org.apache.inlong.sort.formats.tdmsg.AbstractTDMsgFormatDeserializer;
 import org.apache.inlong.sort.formats.tdmsg.TDMsgBody;
 import org.apache.inlong.sort.formats.tdmsg.TDMsgHead;
@@ -93,7 +93,7 @@ public class TDMsgMixedDeserializerTest extends TestLogger {
         row.setField(2, tid);
         preDeserializer.records.add(row);
 
-        mixedDeserializer.deserialize(new TDMsgSerializedRecord(), collector);
+        mixedDeserializer.deserialize(new TDMsgMixedSerializedRecord(), collector);
         assertEquals(2, collector.results.size());
         assertEquals(dataFlowId1, collector.results.get(0).getDataflowId());
         assertEquals(tid, collector.results.get(0).getRow().getField(2));


### PR DESCRIPTION

### Title Name:  [INLONG-2038][Bug]inlong-sort abandon data from pulsar due to an ClassCastException

where *XYZ* should be replaced by the actual issue number.

Fixes #2038 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
