### PR TITLE
[INLONG-2068][Bug] the class name in dataproxy stop.sh is wrong

### DIFF
--- a/inlong-dataproxy/bin/dataproxy-stop.sh
+++ b/inlong-dataproxy/bin/dataproxy-stop.sh
@@ -20,4 +20,4 @@
 #
 
 # this program kills the dataProxy
-ps -ef |grep "org.apache.flume.node.Application"|grep "apache-inlong-dataproxy"|grep -v grep|awk '{print $2}'|xargs kill -9
+ps -ef |grep "org.apache.inlong.dataproxy.node.Application"|grep "apache-inlong-dataproxy"|grep -v grep|awk '{print $2}'|xargs kill -9


### PR DESCRIPTION
### Title Name: [INLONG-2068][Bug] the class name in dataproxy stop.sh is wrong

Fixes #2068 

### Motivation

see  #2068 

### Modifications

change from org.apache.flume.node.Application to org.apache.inlong.dataproxy.node.Application

### Documentation

  - Does this pull request introduce a new feature? (no)
