### PR TITLE
[INLONG-2028][CI] Add support for docker build on GitHub Actions

### DIFF
--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -48,3 +48,5 @@ jobs:
 
       - name: Build docker image
         run: mvn --batch-mode --update-snapshots -e -V clean verify -DskipTests -Pdocker
+        env:
+          CI: false

--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: InLong Docker Build
+
+on:
+  push:
+    branches: [ master, 'INLONG-*' ]
+  pull_request:
+    branches: [ master, 'INLONG-*' ]
+
+jobs:
+  build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: adopt
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/inlong
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build docker
+        run: mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker

--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -46,5 +46,8 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -pl !inlong-website
+
       - name: Build docker
-        run: mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker
+        run: mvn --batch-mode --update-snapshots -e -V package -DskipTests -Pdocker

--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -46,8 +46,5 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -pl !inlong-website
-
-      - name: Build docker
-        run: mvn --batch-mode --update-snapshots -e -V package -DskipTests -Pdocker
+      - name: Build docker image
+        run: mvn --batch-mode --update-snapshots -e -V clean verify -DskipTests -Pdocker


### PR DESCRIPTION
Fixes: #2028 

### Motivation

Add support for docker build on GitHub Actions.

### Modifications

- `.github/workflows/ci_build_docker.yml`

### Verifying this change

Execute the following command.

```shell
mvn --batch-mode --update-snapshots -e -V clean verify -DskipTests -Pdocker
```
