### PR TITLE
[INLONG-2119][Website][CI] Add support for building inlong website when building and testing project

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -47,7 +47,9 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -pl !inlong-website
+        run: mvn --batch-mode --update-snapshots -e -V clean install -DskipTests
+        env:
+          CI: false
 
       - name: Upload unit test results
         if: ${{ failure() }}

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -47,7 +47,9 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Unit test with Maven
-        run: mvn --batch-mode --update-snapshots -e -V clean verify -pl !inlong-website
+        run: mvn --batch-mode --update-snapshots -e -V clean verify
+        env:
+          CI: false
 
       - name: Upload unit test results
         if: ${{ failure() }}


### PR DESCRIPTION
Fixes: #2119

Now, the website component has been excluded when building or testing project on GitHub Actions.

https://github.com/apache/incubator-inlong/blob/7b5c1ede854bda35cd13a8340dd615137bad1190/.github/workflows/ci_build.yml#L49-L50

https://github.com/apache/incubator-inlong/blob/7b5c1ede854bda35cd13a8340dd615137bad1190/.github/workflows/ci_ut.yml#L49-L50

But, according to https://stackoverflow.com/questions/63445967/githubs-action-is-not-building-react-application, we can set the `CI` environment variable to false to build node project on GitHub Actions.

### Motivation

Make the website component included and set the `CI` environment variable to false to build and test it.

Same solution as #2112

https://github.com/apache/incubator-inlong/blob/6fb2d928f58221c933a5d49e319f693ea94077bd/.github/workflows/ci_build_docker.yml#L49-L52

### Modifications

- `.github/workflows/ci_build.yml`
- `.github/workflows/ci_ut.yml`
