### PR TITLE
[INLONG-2148] Fix the problem that the pattern used for extracting clickhouse metadata is not compatible with some versions of clickhouse

### DIFF
--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/clickhouse/output/ClickHouseShardOutputFormat.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/flink/clickhouse/output/ClickHouseShardOutputFormat.java
@@ -46,8 +46,8 @@ public class ClickHouseShardOutputFormat extends AbstractClickHouseOutputFormat 
 
     private static final Logger LOG = LoggerFactory.getLogger(ClickHouseShardOutputFormat.class);
 
-    private static final Pattern PATTERN = Pattern.compile("Distributed\\((?<cluster>[a-zA-Z_][0-9a-zA-Z_]*),"
-            + "\\s*(?<database>[a-zA-Z_][0-9a-zA-Z_]*),\\s*(?<table>[a-zA-Z_][0-9a-zA-Z_]*)");
+    private static final Pattern PATTERN = Pattern.compile("Distributed\\('?(?<cluster>[a-zA-Z_][0-9a-zA-Z_]*)'?,"
+            + "\\s*'?(?<database>[a-zA-Z_][0-9a-zA-Z_]*)'?,\\s*'?(?<table>[a-zA-Z_][0-9a-zA-Z_]*)'?");
 
     private final ClickHouseConnectionProvider connectionProvider;
 


### PR DESCRIPTION
### Title Name: [INLONG-XYZ][component] Title of the pull request

where *XYZ* should be replaced by the actual issue number.

Fixes #2148 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
