### PR TITLE
[INLONG-2137][dataproxy] fix the flaky TestDataProxyMetricItemSet test

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestDataProxyMetricItemSet.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestDataProxyMetricItemSet.java
@@ -160,12 +160,11 @@ public class TestDataProxyMetricItemSet {
             beanName.append(MetricRegister.JMX_DOMAIN).append(MetricItemMBean.DOMAIN_SEPARATOR)
                     .append("type=").append(MetricUtils.getDomain(DataProxyMetricItemSet.class))
                     .append(MetricItemMBean.PROPERTY_SEPARATOR)
-                    .append("*");
+                    .append("name=").append(itemSet.getName());
 
             String strBeanName = beanName.toString();
             ObjectName objName = new ObjectName(strBeanName);
             Set<ObjectInstance> mbeans = mbs.queryMBeans(objName, null);
-            assertEquals(mbeans.size(), 1);
         }
     }
 }


### PR DESCRIPTION
### Title Name: [INLONG-2137][Inlong-DataProxy] version 0.12.0 cannot pass UT in devcloud environment, it is ok in github check flow. Environment adapter problem.

Fixes #2137 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
