### PR TITLE
[INLONG-2160][tubemq] Time format conversion using DateTimeFormatter

### DIFF
--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TBaseConstants.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TBaseConstants.java
@@ -47,7 +47,6 @@ public class TBaseConstants {
     public static final String META_TMP_GROUP_VALUE = "^[a-zA-Z][\\w-]+$";
     public static final String META_TMP_CONSUMERID_VALUE = "^[_A-Za-z0-9\\.\\-]+$";
     public static final String META_TMP_CALLBACK_STRING_VALUE = "^[_A-Za-z0-9]+$";
-    public static final String META_TMP_DATE_VALUE = "yyyyMMddHHmmss";
     public static final String META_TMP_IP_ADDRESS_VALUE =
             "((?:(?:25[0-5]|2[0-4]\\d|((1\\d{2})|([1-9]?\\d)))\\.){3}(?:25[0-5]|2[0-4]\\d|((1\\d{2})|([1-9]?\\d))))";
     public static final String META_TMP_PORT_REGEX = "[\\d]+";

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/DateTimeConvertUtils.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/DateTimeConvertUtils.java
@@ -1,0 +1,205 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.tubemq.corebase.utils;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+/**
+ * Datetime, string and timestamp conversion tools
+ *
+ * This class includes the date and time-related methods, for unified use and management.
+ *
+ */
+public class DateTimeConvertUtils {
+
+    private static final ZoneId defZoneId = ZoneId.systemDefault();
+    public static final String PAT_YYYYMMDDHHMM = "yyyyMMddHHmm";
+    private static final DateTimeFormatter sdf4yyyyMMddHHmm
+            = DateTimeFormatter.ofPattern(PAT_YYYYMMDDHHMM);
+    public static final String PAT_YYYYMMDDHHMMSS = "yyyyMMddHHmmss";
+    private static final DateTimeFormatter sdf4yyyyMMddHHmmss
+            = DateTimeFormatter.ofPattern(PAT_YYYYMMDDHHMMSS);
+
+    /**
+     * Converts the specified timestamp value to a string
+     * in the format yyyyMMddHHmm under the current system default time zone
+     *
+     * @param timestamp The millisecond value of the specified time
+     * @return the time string in yyyyMMddHHmm format
+     */
+    public static String ms2yyyyMMddHHmm(long timestamp) {
+        return ms2yyyyMMddHHmm(timestamp, defZoneId);
+    }
+
+    /**
+     * Converts the specified timestamp value to a string
+     * in the format yyyyMMddHHmm under the specified time zone
+     *
+     * @param timestamp The millisecond value of the specified time
+     * @param zoneId the specified time zone
+     * @return the time string in yyyyMMddHHmm format
+     */
+    public static String ms2yyyyMMddHHmm(long timestamp, ZoneId zoneId) {
+        LocalDateTime  localDateTime =
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), zoneId);
+        return sdf4yyyyMMddHHmm.format(localDateTime);
+    }
+
+    /**
+     * Converts the time string in yyyyMMddHHmm format to timestamp value
+     * under the current system default time zone
+     *
+     * @param yyyyMMddHHmm the time string in yyyyMMddHHmm format
+     * @return the timestamp value
+     */
+    public static long yyyyMMddHHmm2ms(String yyyyMMddHHmm) {
+        return yyyyMMddHHmm2ms(yyyyMMddHHmm, defZoneId);
+    }
+
+    /**
+     * Converts the time string in yyyyMMddHHmm format to timestamp value
+     * under the specified time zone
+     *
+     * @param yyyyMMddHHmm the time string in yyyyMMddHHmm format
+     * @param zoneId the specified time zone
+     * @return the timestamp value
+     */
+    public static long yyyyMMddHHmm2ms(String yyyyMMddHHmm, ZoneId zoneId) {
+        LocalDateTime localDateTime =
+                LocalDateTime.parse(yyyyMMddHHmm, sdf4yyyyMMddHHmm);
+        return LocalDateTime.from(localDateTime).atZone(zoneId).toInstant().toEpochMilli();
+    }
+
+    /**
+     * Converts the specified timestamp value to a string
+     * in the format yyyyMMddHHmmss under the current system default time zone
+     *
+     * @param timestamp The millisecond value of the specified time
+     * @return the time string in yyyyMMddHHmmss format
+     */
+    public static String ms2yyyyMMddHHmmss(long timestamp) {
+        return ms2yyyyMMddHHmmss(timestamp, defZoneId);
+    }
+
+    /**
+     * Converts the specified timestamp value to a string
+     * in the format yyyyMMddHHmmss under the specified time zone
+     *
+     * @param timestamp The millisecond value of the specified time
+     * @param zoneId the specified time zone
+     * @return the time string in yyyyMMddHHmmss format
+     */
+    public static String ms2yyyyMMddHHmmss(long timestamp, ZoneId zoneId) {
+        LocalDateTime  localDateTime =
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), zoneId);
+        return sdf4yyyyMMddHHmmss.format(localDateTime);
+    }
+
+    /**
+     * Converts the specified timestamp value to a string
+     * in the format yyyyMMddHHmmss under the current system default time zone
+     *
+     * @param date the date time
+     * @return the string in yyyyMMddHHmmss format
+     */
+    public static String date2yyyyMMddHHmmss(Date date) {
+        return date2yyyyMMddHHmmss(date, defZoneId);
+    }
+
+    /**
+     * Converts the specified timestamp value to a string
+     * in the format yyyyMMddHHmmss under the specified time zone
+     *
+     * @param date the date time
+     * @param zoneId the specified time zone
+     * @return the string in yyyyMMddHHmmss format
+     */
+    public static String date2yyyyMMddHHmmss(Date date, ZoneId zoneId) {
+        if (date == null) {
+            return TStringUtils.EMPTY;
+        }
+        try {
+            LocalDateTime  localDateTime =
+                    LocalDateTime.ofInstant(date.toInstant(), zoneId);
+            return sdf4yyyyMMddHHmmss.format(localDateTime);
+        } catch (Throwable ex) {
+            return TStringUtils.EMPTY;
+        }
+    }
+
+    /**
+     * Converts the time string in yyyyMMddHHmmss format to timestamp value
+     * under the current system default time zone
+     *
+     * @param yyyyMMddHHmmss the time string in yyyyMMddHHmmss format
+     * @return the timestamp value
+     */
+    public static long yyyyMMddHHmmss2ms(String yyyyMMddHHmmss) {
+        return yyyyMMddHHmmss2ms(yyyyMMddHHmmss, defZoneId);
+    }
+
+    /**
+     * Converts the time string in yyyyMMddHHmmss format to timestamp value
+     * under the specified time zone
+     *
+     * @param yyyyMMddHHmmss the time string in yyyyMMddHHmmss format
+     * @param zoneId the specified time zone
+     * @return the timestamp value
+     */
+    public static long yyyyMMddHHmmss2ms(String yyyyMMddHHmmss, ZoneId zoneId) {
+        LocalDateTime localDateTime =
+                LocalDateTime.parse(yyyyMMddHHmmss, sdf4yyyyMMddHHmmss);
+        return LocalDateTime.from(localDateTime).atZone(zoneId).toInstant().toEpochMilli();
+    }
+
+    /**
+     * Converts the time string in yyyyMMddHHmmss format to date value
+     * under the specified time zone
+     *
+     * @param yyyyMMddHHmmss the time string in yyyyMMddHHmmss format
+     * @return the Date value
+     */
+    public static Date yyyyMMddHHmmss2date(String yyyyMMddHHmmss) {
+        return yyyyMMddHHmmss2date(yyyyMMddHHmmss, defZoneId);
+    }
+
+    /**
+     * Converts the time string in yyyyMMddHHmmss format to date value
+     * under the specified time zone
+     *
+     * @param yyyyMMddHHmmss the time string in yyyyMMddHHmmss format
+     * @param zoneId the specified time zone
+     * @return the Date value
+     */
+    public static Date yyyyMMddHHmmss2date(String yyyyMMddHHmmss, ZoneId zoneId) {
+        if (yyyyMMddHHmmss == null) {
+            return null;
+        }
+        try {
+            LocalDateTime localDateTime =
+                    LocalDateTime.parse(yyyyMMddHHmmss, sdf4yyyyMMddHHmmss);
+            return Date.from(localDateTime.atZone(zoneId).toInstant());
+        } catch (Throwable ex) {
+            return null;
+        }
+    }
+}

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/MixedUtils.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/MixedUtils.java
@@ -18,9 +18,7 @@
 package org.apache.inlong.tubemq.corebase.utils;
 
 import java.nio.ByteBuffer;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -117,8 +115,7 @@ public class MixedUtils {
     // build message to be sent
     // only for demo
     public static Message buildMessage(String topicName, String filterItem,
-                                       byte[] bodyData, long serialId,
-                                       SimpleDateFormat sdf) {
+                                       byte[] bodyData, long serialId) {
         // build message to be sent
         Message message = new Message(topicName, bodyData);
         long currTimeMillis = System.currentTimeMillis();
@@ -126,8 +123,9 @@ public class MixedUtils {
         message.setAttrKeyVal("serialId", String.valueOf(serialId));
         message.setAttrKeyVal("dataTime", String.valueOf(currTimeMillis));
         if (filterItem != null) {
-            // add filter attribute information
-            message.putSystemHeader(filterItem, sdf.format(new Date(currTimeMillis)));
+            // add filter attribute information, time require yyyyMMddHHmm format
+            message.putSystemHeader(filterItem,
+                    DateTimeConvertUtils.ms2yyyyMMddHHmm(currTimeMillis));
         }
         return message;
     }

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/TStringUtils.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/utils/TStringUtils.java
@@ -30,6 +30,9 @@ import org.apache.inlong.tubemq.corebase.TokenConstants;
  */
 public class TStringUtils {
 
+    // empty string
+    public static final String EMPTY = "";
+
     public static boolean isEmpty(String str) {
         return StringUtils.isEmpty(str);
     }

--- a/inlong-tubemq/tubemq-core/src/test/java/org/apache/inlong/tubemq/corebase/MessagesTest.java
+++ b/inlong-tubemq/tubemq-core/src/test/java/org/apache/inlong/tubemq/corebase/MessagesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.tubemq.corebase;
+
+import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MessagesTest {
+
+    @Test
+    public void testPutSystemHeader() {
+        // case 1
+        Throwable exVal = null;
+        Message message1 = new Message("test", "test case".getBytes());
+        try {
+            message1.putSystemHeader("streamId1", "12345667");
+        } catch (Throwable ex) {
+            exVal = ex;
+        }
+        Assert.assertNotNull(exVal);
+        Assert.assertEquals(exVal.getClass(), IllegalArgumentException.class);
+        Assert.assertTrue(exVal.getMessage().contains("format and length must equal"));
+        // case 2
+        exVal = null;
+        try {
+            message1.putSystemHeader("streamId1", "20220115170022");
+        } catch (Throwable ex) {
+            exVal = ex;
+        }
+        Assert.assertNotNull(exVal);
+        Assert.assertEquals(exVal.getClass(), IllegalArgumentException.class);
+        Assert.assertTrue(exVal.getMessage().contains("format and length must equal"));
+        // case 3
+        exVal = null;
+        try {
+            message1.putSystemHeader("streamId1", "202201151799");
+        } catch (Throwable ex) {
+            exVal = ex;
+        }
+        Assert.assertNotNull(exVal);
+        Assert.assertEquals(exVal.getClass(), IllegalArgumentException.class);
+        Assert.assertTrue(exVal.getMessage().contains("could not be parsed"));
+        // case 4
+        message1.putSystemHeader("streamId1", "202201151700");
+        message1.setAttrKeyVal("key","value");
+        System.out.println(message1.getAttribute());
+        Assert.assertTrue(message1.getAttribute().contains("202201151700"));
+        // case 5
+        message1.putSystemHeader("streamId2", "202201151300");
+        message1.setAttrKeyVal("key2","value2");
+        System.out.println(message1.getAttribute());
+        Assert.assertTrue(message1.getAttribute().contains("202201151300"));
+        // case 6
+        message1.putSystemHeader(null, null);
+        System.out.println(message1.getAttribute());
+        Assert.assertFalse(message1.getAttribute().contains("202201151300"));
+        // case 7
+        Message message2 = new Message("test", "test case".getBytes());
+        message2.setAttrKeyVal("key2","value2");
+        message2.putSystemHeader("streamId1", "202201151715");
+        System.out.println(message2.getAttribute());
+        Assert.assertTrue(message2.getAttribute().contains("202201151715"));
+        // case 8
+        Message message3 = new Message("test", "test case".getBytes());
+        message3.setAttrKeyVal("key2","value2");
+        message3.putSystemHeader(null, "202201151715");
+        System.out.println(message3.getAttribute());
+        Assert.assertTrue(message3.getAttribute().contains("202201151715"));
+        // case 8
+        Message message4 = new Message("test", "test case".getBytes());
+        message4.putSystemHeader("streamId1", null);
+        System.out.println(message4.getAttribute());
+        Assert.assertFalse(message4.getAttribute().contains("202201151715"));
+    }
+
+    @Test
+    public void testParseSystemHeader() {
+        // case 1
+        Throwable exVal = null;
+        String msgTime;
+        Message message1 = new MessageExt(0, "test", "test case".getBytes(),
+                "$msgType$=streamId1,$msgTime$=202201151799,key2=value2", 1);
+        msgTime = message1.getMsgTime();
+        Assert.assertEquals(msgTime, TStringUtils.EMPTY);
+
+    }
+}

--- a/inlong-tubemq/tubemq-core/src/test/java/org/apache/inlong/tubemq/corebase/utils/DateTimeConvertUtilsTest.java
+++ b/inlong-tubemq/tubemq-core/src/test/java/org/apache/inlong/tubemq/corebase/utils/DateTimeConvertUtilsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.tubemq.corebase.utils;
+
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DateTimeConvertUtilsTest {
+    @Test
+    public void testDateTimeFormatUtils() {
+
+        // test yyyyMMddHHmmss string to ms
+        String strDateTime11 = "20220114155900";
+        long timeStamp11 = DateTimeConvertUtils.yyyyMMddHHmmss2ms(strDateTime11);
+        String newDateTime11 = DateTimeConvertUtils.ms2yyyyMMddHHmmss(timeStamp11);
+        Assert.assertEquals(strDateTime11, newDateTime11);
+        // test yyyyMMddHHmm string to ms 2
+        String strDateTime12 = "202201141559";
+        long timeStamp12 = DateTimeConvertUtils.yyyyMMddHHmm2ms(strDateTime12);
+        String newDateTime12 = DateTimeConvertUtils.ms2yyyyMMddHHmm(timeStamp12);
+        Assert.assertEquals(strDateTime12, newDateTime12);
+        // test yyyyMMddHHmmss string to ms 3
+        long timeStamp13 = DateTimeConvertUtils.yyyyMMddHHmmss2ms(strDateTime11);
+        String newDateTime13 = DateTimeConvertUtils.ms2yyyyMMddHHmm(timeStamp13);
+        Assert.assertEquals(strDateTime12, newDateTime13);
+
+        // test date to string
+        Date curDate21 = new Date();
+        String strTime21 = DateTimeConvertUtils.date2yyyyMMddHHmmss(curDate21);
+        long timeStamp21 = DateTimeConvertUtils.yyyyMMddHHmmss2ms(strTime21);
+        Date newDate21 = new Date(timeStamp21);
+        String strNewTime21 = DateTimeConvertUtils.date2yyyyMMddHHmmss(newDate21);
+        Assert.assertEquals(strTime21, strNewTime21);
+
+        String orig31 = "20220115152055";
+        Date date32 = DateTimeConvertUtils.yyyyMMddHHmmss2date(orig31);
+        String strNew33 = DateTimeConvertUtils.date2yyyyMMddHHmmss(date32);
+        Assert.assertEquals(orig31, strNew33);
+
+        // test null cases
+        String curDate41 = DateTimeConvertUtils.date2yyyyMMddHHmmss(null);
+        Assert.assertEquals(curDate41, TStringUtils.EMPTY);
+        Date curDate42 = DateTimeConvertUtils.yyyyMMddHHmmss2date(null);
+        Assert.assertEquals(curDate42, null);
+        Date curDate43 = DateTimeConvertUtils.yyyyMMddHHmmss2date("202201152536");
+        Assert.assertEquals(curDate43, null);
+        Throwable exVal = null;
+        try {
+            DateTimeConvertUtils.yyyyMMddHHmm2ms(null);
+        } catch (Throwable ex) {
+            exVal = ex;
+        }
+        Assert.assertNotNull(exVal);
+        Assert.assertEquals(exVal.getClass(), NullPointerException.class);
+        //
+        exVal = null;
+        try {
+            DateTimeConvertUtils.yyyyMMddHHmm2ms("20220115172722");
+        } catch (Throwable ex) {
+            exVal = ex;
+        }
+        Assert.assertNotNull(exVal);
+        Assert.assertEquals(exVal.getClass(), DateTimeParseException.class);
+        Assert.assertTrue(exVal.getMessage().contains("could not be parsed"));
+        //
+        exVal = null;
+        try {
+            DateTimeConvertUtils.yyyyMMddHHmm2ms("202201158827");
+        } catch (Throwable ex) {
+            exVal = ex;
+        }
+        Assert.assertNotNull(exVal);
+        Assert.assertEquals(exVal.getClass(), DateTimeParseException.class);
+        Assert.assertTrue(exVal.getMessage().contains("could not be parsed"));
+    }
+}

--- a/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MAMessageProducerExample.java
+++ b/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MAMessageProducerExample.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.example;
 
-import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -172,7 +171,6 @@ public class MAMessageProducerExample {
             long sentCount = 0;
             int roundIndex = 0;
             int targetCnt = topicFilterTuples.size();
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmm");
             while (msgCount < 0 || sentCount < msgCount) {
                 // 1 Rotate to get the attribute information to be sent
                 roundIndex = (int) (sentCount++ % targetCnt);
@@ -182,7 +180,7 @@ public class MAMessageProducerExample {
                 try {
                     // 2.1 Send data asynchronously, recommended
                     producer.sendMessage(MixedUtils.buildMessage(target.getF0(),
-                            target.getF1(), bodyData, sentCount, sdf), new DefaultSendCallback());
+                            target.getF1(), bodyData, sentCount), new DefaultSendCallback());
                     // Or
                     // 2.2 Send message synchronous, not recommended
                     // MessageSentResult result = producer.sendMessage(message);

--- a/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MessageProducerExample.java
+++ b/inlong-tubemq/tubemq-example/src/main/java/org/apache/inlong/tubemq/example/MessageProducerExample.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.example;
 
-import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,7 +85,6 @@ public final class MessageProducerExample {
                 MixedUtils.buildTestData(pkgSize);
         List<Tuple2<String, String>> buildTopicFilterTuples =
                 MixedUtils.buildTopicFilterTupleList(topicAndFiltersMap);
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmm");
 
         // 5. send message to server
         long sentCount = 0;
@@ -101,7 +99,7 @@ public final class MessageProducerExample {
             try {
                 // 5.2.1 Send data asynchronously, recommended
                 messageProducer.sendMessage(MixedUtils.buildMessage(target.getF0(),
-                        target.getF1(), bodyData, sentCount, sdf), new DefaultSendCallback());
+                        target.getF1(), bodyData, sentCount), new DefaultSendCallback());
                 // Or
                 // 5.2.2 Send message synchronous, not recommended
                 // MessageSentResult result = messageProducer.sendMessage(message);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metrics/BrokerMetrics.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metrics/BrokerMetrics.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.broker.metrics;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -27,7 +26,7 @@ import org.apache.inlong.tubemq.corebase.metric.GaugeMaxMetricItem;
 import org.apache.inlong.tubemq.corebase.metric.GaugeMinMetricItem;
 import org.apache.inlong.tubemq.corebase.metric.GaugeNormMetricItem;
 import org.apache.inlong.tubemq.corebase.metric.MetricValues;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 
 public class BrokerMetrics implements BrokerMetricMXBean {
 
@@ -73,8 +72,8 @@ public class BrokerMetrics implements BrokerMetricMXBean {
         metricValues.put(ioExceptionCnt.getName(), ioExceptionCnt.getValue());
         metricValues.put(consumerOnlineCnt.getName(), consumerOnlineCnt.getValue());
         metricValues.put(consumerTmoTotCnt.getName(), consumerTmoTotCnt.getValue());
-        return new MetricValues(WebParameterUtils.date2yyyyMMddHHmmss(
-                new Date(lastResetTime.get())), metricValues);
+        return new MetricValues(
+                DateTimeConvertUtils.ms2yyyyMMddHHmmss(lastResetTime.get()), metricValues);
     }
 
     @Override
@@ -92,7 +91,7 @@ public class BrokerMetrics implements BrokerMetricMXBean {
         metricValues.put(consumerTmoTotCnt.getName(), consumerTmoTotCnt.getAndSet());
         long befTime = lastResetTime.getAndSet(System.currentTimeMillis());
         return new MetricValues(
-                WebParameterUtils.date2yyyyMMddHHmmss(new Date(befTime)), metricValues);
+                DateTimeConvertUtils.ms2yyyyMMddHHmmss(befTime), metricValues);
     }
 
     public long getLastResetTime() {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/WebParameterUtils.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/WebParameterUtils.java
@@ -21,8 +21,6 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
@@ -36,6 +34,7 @@ import org.apache.inlong.tubemq.corebase.TokenConstants;
 import org.apache.inlong.tubemq.corebase.policies.FlowCtrlItem;
 import org.apache.inlong.tubemq.corebase.policies.FlowCtrlRuleHandler;
 import org.apache.inlong.tubemq.corebase.rv.ProcessResult;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.corebase.utils.Tuple2;
 import org.apache.inlong.tubemq.server.broker.utils.DataStoreUtils;
@@ -1113,16 +1112,15 @@ public class WebParameterUtils {
             result.setSuccResult(defValue);
             return result.isSuccess();
         }
-        try {
-            DateFormat sdf = new SimpleDateFormat(TBaseConstants.META_TMP_DATE_VALUE);
-            Date date = sdf.parse(paramValue);
-            result.setSuccResult(date);
-        } catch (Throwable e) {
+        Date date = DateTimeConvertUtils.yyyyMMddHHmmss2date(paramValue);
+        if (date == null) {
             result.setFailResult(sBuffer.append("Parameter ").append(fieldDef.name)
                     .append("'s value ").append(paramValue)
                     .append(" parse error, required value format is ")
-                    .append(TBaseConstants.META_TMP_DATE_VALUE).toString());
+                    .append(DateTimeConvertUtils.PAT_YYYYMMDDHHMMSS).toString());
             sBuffer.delete(0, sBuffer.length());
+        } else {
+            result.setSuccResult(date);
         }
         return result.isSuccess();
     }
@@ -1646,43 +1644,12 @@ public class WebParameterUtils {
     }
 
     /**
-     * translate Date value from Date to yyyyMMddHHmmss format string
-     *
-     * @param date date
-     * @return the yyyyMMddHHmmss format string
-     */
-    public static String date2yyyyMMddHHmmss(Date date) {
-        SimpleDateFormat sdf =
-                new SimpleDateFormat(TBaseConstants.META_TMP_DATE_VALUE);
-        return sdf.format(date);
-    }
-
-    /**
-     * translate yyyyMMddHHmmss format string to Date value
-     *
-     * @param dateStr date string, format yyyyMMddHHmmss
-     * @return the Date value of string
-     */
-    public static Date yyyyMMddHHmmss2date(String dateStr) {
-        if (dateStr == null) {
-            return null;
-        }
-        SimpleDateFormat sdf =
-                new SimpleDateFormat(TBaseConstants.META_TMP_DATE_VALUE);
-        try {
-            return sdf.parse(dateStr);
-        } catch (Throwable e) {
-            return null;
-        }
-    }
-
-    /**
      * check parameter is required
      *
      * @param paramName   the parameter name
      * @param paramValue  the parameter value
-     * @param required
-     * @return the yyyyMMddHHmmss format string
+     * @param required    Whether the parameter is required
+     * @return the parameter value without quotes
      */
     public static String checkParamCommonRequires(String paramName, String paramValue,
                                                   boolean required) throws Exception {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbBlackGroupEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbBlackGroupEntity.java
@@ -24,8 +24,8 @@ import java.util.Date;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
 @Entity
@@ -146,7 +146,7 @@ public class BdbBlackGroupEntity implements Serializable {
                 .append("\",\"attributes\":\"").append(attributes)
                 .append("\",\"createUser\":\"").append(createUser)
                 .append("\",\"createDate\":\"")
-                .append(WebParameterUtils.date2yyyyMMddHHmmss(createDate))
+                .append(DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate))
                 .append("\"}");
     }
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbBrokerConfEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbBrokerConfEntity.java
@@ -24,9 +24,9 @@ import java.util.Date;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.TServerConstants;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
 @Entity
@@ -121,10 +121,10 @@ public class BdbBrokerConfEntity implements Serializable {
                 .append(",\"memCacheFlushIntvl\":").append(getDftMemCacheFlushIntvl())
                 .append(",\"createUser\":\"").append(createUser)
                 .append("\",\"createDate\":\"")
-                .append(WebParameterUtils.date2yyyyMMddHHmmss(createDate))
+                .append(DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate))
                 .append("\",\"modifyUser\":\"").append(modifyUser)
                 .append("\",\"modifyDate\":\"")
-                .append(WebParameterUtils.date2yyyyMMddHHmmss(modifyDate))
+                .append(DateTimeConvertUtils.date2yyyyMMddHHmmss(modifyDate))
                 .append("\"}");
     }
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbClusterSettingEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbClusterSettingEntity.java
@@ -23,8 +23,8 @@ import java.io.Serializable;
 import java.util.Date;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
 /*
@@ -347,7 +347,7 @@ public class BdbClusterSettingEntity implements Serializable {
                             TStoreConstants.TOKEN_CREATE_USER, creater);
         }
         if (createDate != null) {
-            String dataStr = WebParameterUtils.date2yyyyMMddHHmmss(createDate);
+            String dataStr = DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate);
             this.attributes =
                     TStringUtils.setAttrValToAttributes(this.attributes,
                             TStoreConstants.TOKEN_CREATE_DATE, dataStr);
@@ -362,7 +362,7 @@ public class BdbClusterSettingEntity implements Serializable {
     public Date getCreateDate() {
         String dateStr = TStringUtils.getAttrValFrmAttributes(
                 this.attributes, TStoreConstants.TOKEN_CREATE_DATE);
-        return WebParameterUtils.yyyyMMddHHmmss2date(dateStr);
+        return DateTimeConvertUtils.yyyyMMddHHmmss2date(dateStr);
     }
 
     public String getStrCreateDate() {
@@ -371,7 +371,7 @@ public class BdbClusterSettingEntity implements Serializable {
     }
 
     public String getStrModifyDate() {
-        return WebParameterUtils.date2yyyyMMddHHmmss(modifyDate);
+        return DateTimeConvertUtils.date2yyyyMMddHHmmss(modifyDate);
     }
 
     /**

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbConsumeGroupSettingEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbConsumeGroupSettingEntity.java
@@ -23,8 +23,8 @@ import java.io.Serializable;
 import java.util.Date;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
 @Entity
@@ -163,7 +163,7 @@ public class BdbConsumeGroupSettingEntity implements Serializable {
                 .append(",\"attributes\":\"").append(attributes)
                 .append("\",\"createUser\":\"").append(createUser)
                 .append("\",\"createDate\":\"")
-                .append(WebParameterUtils.date2yyyyMMddHHmmss(createDate))
+                .append(DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate))
                 .append("\"}");
     }
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbConsumerGroupEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbConsumerGroupEntity.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 import java.util.Date;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 
 @Entity
 public class BdbConsumerGroupEntity implements Serializable {
@@ -119,7 +119,7 @@ public class BdbConsumerGroupEntity implements Serializable {
                 .append("\",\"attributes\":\"").append(attributes)
                 .append("\",\"createUser\":\"").append(createUser)
                 .append("\",\"createDate\":\"")
-                .append(WebParameterUtils.date2yyyyMMddHHmmss(createDate))
+                .append(DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate))
                 .append("\"}");
     }
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbGroupFilterCondEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbGroupFilterCondEntity.java
@@ -24,9 +24,9 @@ import java.util.Date;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.statusdef.EnableStatus;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
 @Entity
@@ -212,7 +212,7 @@ public class BdbGroupFilterCondEntity implements Serializable {
                             TStoreConstants.TOKEN_CREATE_USER, createUser);
         }
         if (createDate != null) {
-            String dataStr = WebParameterUtils.date2yyyyMMddHHmmss(createDate);
+            String dataStr = DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate);
             this.attributes =
                     TStringUtils.setAttrValToAttributes(this.attributes,
                             TStoreConstants.TOKEN_CREATE_DATE, dataStr);
@@ -227,11 +227,11 @@ public class BdbGroupFilterCondEntity implements Serializable {
     public Date getCreateDate() {
         String dateStr = TStringUtils.getAttrValFrmAttributes(
                 this.attributes, TStoreConstants.TOKEN_CREATE_DATE);
-        return WebParameterUtils.yyyyMMddHHmmss2date(dateStr);
+        return DateTimeConvertUtils.yyyyMMddHHmmss2date(dateStr);
     }
 
     public String getStrModifyDate() {
-        return WebParameterUtils.date2yyyyMMddHHmmss(createDate);
+        return DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate);
     }
 
     public String getStrCreateDate() {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbGroupFlowCtrlEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbGroupFlowCtrlEntity.java
@@ -23,10 +23,10 @@ import java.io.Serializable;
 import java.util.Date;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.TServerConstants;
 import org.apache.inlong.tubemq.server.common.statusdef.EnableStatus;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
 @Entity
@@ -254,7 +254,7 @@ public class BdbGroupFlowCtrlEntity implements Serializable {
                             TStoreConstants.TOKEN_CREATE_USER, createUser);
         }
         if (createDate != null) {
-            String dataStr = WebParameterUtils.date2yyyyMMddHHmmss(createDate);
+            String dataStr = DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate);
             this.attributes =
                     TStringUtils.setAttrValToAttributes(this.attributes,
                             TStoreConstants.TOKEN_CREATE_DATE, dataStr);
@@ -269,11 +269,11 @@ public class BdbGroupFlowCtrlEntity implements Serializable {
     public Date getCreateDate() {
         String dateStr = TStringUtils.getAttrValFrmAttributes(
                 this.attributes, TStoreConstants.TOKEN_CREATE_DATE);
-        return WebParameterUtils.yyyyMMddHHmmss2date(dateStr);
+        return DateTimeConvertUtils.yyyyMMddHHmmss2date(dateStr);
     }
 
     public String getStrModifyDate() {
-        return WebParameterUtils.date2yyyyMMddHHmmss(createDate);
+        return DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate);
     }
 
     public String getStrCreateDate() {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbTopicAuthControlEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbTopicAuthControlEntity.java
@@ -23,8 +23,8 @@ import java.io.Serializable;
 import java.util.Date;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
 @Entity
@@ -168,7 +168,7 @@ public class BdbTopicAuthControlEntity implements Serializable {
                             TStoreConstants.TOKEN_CREATE_USER, createUser);
         }
         if (createDate != null) {
-            String dataStr = WebParameterUtils.date2yyyyMMddHHmmss(createDate);
+            String dataStr = DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate);
             this.attributes =
                     TStringUtils.setAttrValToAttributes(this.attributes,
                             TStoreConstants.TOKEN_CREATE_DATE, dataStr);
@@ -183,11 +183,11 @@ public class BdbTopicAuthControlEntity implements Serializable {
     public Date getCreateDate() {
         String dateStr = TStringUtils.getAttrValFrmAttributes(
                 this.attributes, TStoreConstants.TOKEN_CREATE_DATE);
-        return WebParameterUtils.yyyyMMddHHmmss2date(dateStr);
+        return DateTimeConvertUtils.yyyyMMddHHmmss2date(dateStr);
     }
 
     public String getStrModifyDate() {
-        return WebParameterUtils.date2yyyyMMddHHmmss(createDate);
+        return DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate);
     }
 
     public String getStrCreateDate() {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbTopicConfEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/bdbstore/bdbentitys/BdbTopicConfEntity.java
@@ -24,9 +24,9 @@ import java.util.Date;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.TServerConstants;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.apache.inlong.tubemq.server.master.metamanage.metastore.TStoreConstants;
 
 @Entity
@@ -428,10 +428,10 @@ public class BdbTopicConfEntity implements Serializable {
                 .append(",\"dataPath\":\"").append(dataPath)
                 .append("\",\"createUser\":\"").append(createUser)
                 .append("\",\"createDate\":\"")
-                .append(WebParameterUtils.date2yyyyMMddHHmmss(createDate))
+                .append(DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate))
                 .append("\",\"modifyUser\":\"").append(modifyUser)
                 .append("\",\"modifyDate\":\"")
-                .append(WebParameterUtils.date2yyyyMMddHHmmss(modifyDate))
+                .append(DateTimeConvertUtils.date2yyyyMMddHHmmss(modifyDate))
                 .append("\"}");
     }
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BaseEntity.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BaseEntity.java
@@ -24,10 +24,10 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.TServerConstants;
 import org.apache.inlong.tubemq.server.common.utils.SerialIdUtils;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 
 // AbstractEntity: entity's abstract class
 public class BaseEntity implements Serializable, Cloneable {
@@ -274,7 +274,7 @@ public class BaseEntity implements Serializable, Cloneable {
             return;
         }
         this.modifyDate = date;
-        this.modifyDateStr = WebParameterUtils.date2yyyyMMddHHmmss(date);
+        this.modifyDateStr = DateTimeConvertUtils.date2yyyyMMddHHmmss(date);
     }
 
     private void setCreateDate(Date date) {
@@ -282,7 +282,7 @@ public class BaseEntity implements Serializable, Cloneable {
             return;
         }
         this.createDate = date;
-        this.createDateStr = WebParameterUtils.date2yyyyMMddHHmmss(date);
+        this.createDateStr = DateTimeConvertUtils.date2yyyyMMddHHmmss(date);
     }
 
     @Override

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metrics/MasterMetrics.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/metrics/MasterMetrics.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.master.metrics;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -27,7 +26,7 @@ import org.apache.inlong.tubemq.corebase.metric.GaugeMaxMetricItem;
 import org.apache.inlong.tubemq.corebase.metric.GaugeMinMetricItem;
 import org.apache.inlong.tubemq.corebase.metric.GaugeNormMetricItem;
 import org.apache.inlong.tubemq.corebase.metric.MetricValues;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 
 public class MasterMetrics implements MasterMetricMXBean {
 
@@ -111,8 +110,8 @@ public class MasterMetrics implements MasterMetricMXBean {
                 svrBalConEventConsumerCnt.getValue());
         metricValues.put(svrBalDisConEventConsumerCnt.getName(),
                 svrBalDisConEventConsumerCnt.getValue());
-        return new MetricValues(WebParameterUtils.date2yyyyMMddHHmmss(
-                new Date(lastResetTime.get())), metricValues);
+        return new MetricValues(
+                DateTimeConvertUtils.ms2yyyyMMddHHmmss(lastResetTime.get()), metricValues);
     }
 
     @Override
@@ -145,8 +144,8 @@ public class MasterMetrics implements MasterMetricMXBean {
         alignBrokerFbdMetrics();
         alignBrokerAbnMetrics();
         long befTime = lastResetTime.getAndSet(System.currentTimeMillis());
-        return new MetricValues(WebParameterUtils.date2yyyyMMddHHmmss(
-                new Date(befTime)), metricValues);
+        return new MetricValues(
+                DateTimeConvertUtils.ms2yyyyMMddHHmmss(befTime), metricValues);
     }
 
     public long getLastResetTime() {

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/cli/CliProducer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/cli/CliProducer.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.tubemq.server.tools.cli;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -253,7 +252,6 @@ public class CliProducer extends CliAbstractBase {
         @Override
         public void run() {
             int topicAndCondCnt = topicSendRounds.size();
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmm");
             long sentCount = 0;
             int roundIndex = 0;
             while (msgCount < 0 || sentCount < msgCount) {
@@ -261,7 +259,7 @@ public class CliProducer extends CliAbstractBase {
                 try {
                     Tuple2<String, String> target = topicSendRounds.get(roundIndex);
                     Message message = MixedUtils.buildMessage(
-                            target.getF0(), target.getF1(), sentData, sentCount, sdf);
+                            target.getF0(), target.getF1(), sentData, sentCount);
                     // use sync or async process
                     if (syncProduction) {
                         MessageSentResult procResult =
@@ -353,5 +351,4 @@ public class CliProducer extends CliAbstractBase {
         }
 
     }
-
 }

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/common/WebParameterUtilsTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/common/WebParameterUtilsTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import org.apache.inlong.tubemq.corebase.rv.ProcessResult;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.corebase.utils.TStringUtils;
 import org.apache.inlong.tubemq.server.common.fielddef.WebFieldDef;
 import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
@@ -196,11 +197,11 @@ public class WebParameterUtilsTest {
                 paramCntrMap.get(WebFieldDef.DATAVERSIONID.name));
         Assert.assertEquals(retEntry.getCreateUser(),
                 paramCntrMap.get(WebFieldDef.CREATEUSER.name));
-        Assert.assertEquals(WebParameterUtils.date2yyyyMMddHHmmss(retEntry.getCreateDate()),
+        Assert.assertEquals(DateTimeConvertUtils.date2yyyyMMddHHmmss(retEntry.getCreateDate()),
                 paramCntrMap.get(WebFieldDef.CREATEDATE.name));
         Assert.assertEquals(retEntry.getModifyUser(),
                 paramCntrMap.get(WebFieldDef.CREATEUSER.name));
-        Assert.assertEquals(WebParameterUtils.date2yyyyMMddHHmmss(retEntry.getModifyDate()),
+        Assert.assertEquals(DateTimeConvertUtils.date2yyyyMMddHHmmss(retEntry.getModifyDate()),
                 paramCntrMap.get(WebFieldDef.CREATEDATE.name));
         // case 5
         paramCntrMap.clear();
@@ -237,7 +238,7 @@ public class WebParameterUtilsTest {
         Assert.assertTrue(TStringUtils.isBlank(retEntry.getCreateUser()));
         Assert.assertEquals(retEntry.getModifyUser(),
                 paramCntrMap.get(WebFieldDef.MODIFYUSER.name));
-        Assert.assertEquals(WebParameterUtils.date2yyyyMMddHHmmss(retEntry.getModifyDate()),
+        Assert.assertEquals(DateTimeConvertUtils.date2yyyyMMddHHmmss(retEntry.getModifyDate()),
                 paramCntrMap.get(WebFieldDef.MODIFYDATE.name));
     }
 

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BaseEntityTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/master/metamanage/metastore/dao/entity/BaseEntityTest.java
@@ -19,8 +19,8 @@ package org.apache.inlong.tubemq.server.master.metamanage.metastore.dao.entity;
 
 import java.util.Date;
 import org.apache.inlong.tubemq.corebase.TBaseConstants;
+import org.apache.inlong.tubemq.corebase.utils.DateTimeConvertUtils;
 import org.apache.inlong.tubemq.server.common.TServerConstants;
-import org.apache.inlong.tubemq.server.common.utils.WebParameterUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,7 +42,7 @@ public class BaseEntityTest {
         // case 2
         String createUser = "test";
         Date createDate = new Date();
-        String createDataStr = WebParameterUtils.date2yyyyMMddHHmmss(createDate);
+        String createDataStr = DateTimeConvertUtils.date2yyyyMMddHHmmss(createDate);
         BaseEntity baseEntity2 = new BaseEntity(createUser, createDate);
         Assert.assertEquals(baseEntity2.getDataVerId(), TServerConstants.DEFAULT_DATA_VERSION);
         Assert.assertNotEquals(baseEntity2.getSerialId(), TBaseConstants.META_VALUE_UNDEFINED);
@@ -68,7 +68,7 @@ public class BaseEntityTest {
         // case 4
         String modifyUser = "modifyUser";
         Date modifyDate = new Date();
-        String modifyDateStr = WebParameterUtils.date2yyyyMMddHHmmss(modifyDate);
+        String modifyDateStr = DateTimeConvertUtils.date2yyyyMMddHHmmss(modifyDate);
         BaseEntity baseEntity4 =
                 new BaseEntity(createUser, createDate, modifyUser, modifyDate);
         Assert.assertEquals(baseEntity4.getDataVerId(), TServerConstants.DEFAULT_DATA_VERSION);


### PR DESCRIPTION
Fixes #2160

This PR revision mainly makes the following changes, and the changes are carried out in the form of equivalent replacement:
1. Construct a DateTimeConvertUtils class, which is responsible for data format conversion operations;
2. Remove the time conversion functions date2yyyyMMddHHmmss and yyyyMMddHHmmss2date in WebParameterUtils, and replace them with the corresponding functions of the DateTimeConvertUtils class;
3. Update other processing logic for time conversion
