### PR TITLE
[INLONG-2192] Audit data supports auditId batch query

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/audit/AuditInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/audit/AuditInfo.java
@@ -18,22 +18,21 @@
 package org.apache.inlong.manager.common.pojo.audit;
 
 import io.swagger.annotations.ApiModelProperty;
-import java.util.List;
 import lombok.Data;
 
 @Data
-public class AuditVO {
+public class AuditInfo {
 
-    @ApiModelProperty(value = "Audit id")
-    private String auditId;
-    @ApiModelProperty(value = "Audit set")
-    private List<AuditInfo> auditSet;
+    @ApiModelProperty(value = "Audit log timestamp")
+    private String logTs;
+    @ApiModelProperty(value = "Audit count")
+    private Long count;
 
-    public AuditVO() {
+    public AuditInfo() {
     }
 
-    public AuditVO(String auditId, List<AuditInfo> auditSet) {
-        this.auditId = auditId;
-        this.auditSet = auditSet;
+    public AuditInfo(String logTs, Long count) {
+        this.logTs = logTs;
+        this.count = count;
     }
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/audit/AuditRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/audit/AuditRequest.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.common.pojo.audit;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
 import javax.validation.constraints.NotBlank;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -35,9 +36,9 @@ public class AuditRequest {
     @NotBlank(message = "inlongStreamId not be blank")
     @ApiModelProperty(value = "inlong stream id", required = true)
     private String inlongStreamId;
-    @NotBlank(message = "auditId not be blank")
-    @ApiModelProperty(value = "audit id", required = true)
-    private String auditId;
+    @NotBlank(message = "auditIds not be empty")
+    @ApiModelProperty(value = "audit id list", required = true)
+    private List<String> auditIds;
 
     @ApiModelProperty(value = "query date, format by 'yyyy-MM-dd'", required = true, example = "2022-01-01")
     @NotBlank(message = "dt not be blank")

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/service/core/AuditServiceTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/service/core/AuditServiceTest.java
@@ -19,7 +19,9 @@ package org.apache.inlong.manager.service.core;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import org.apache.inlong.manager.common.pojo.audit.AuditInfo;
 import org.apache.inlong.manager.common.pojo.audit.AuditRequest;
 import org.apache.inlong.manager.common.pojo.audit.AuditVO;
 import org.apache.inlong.manager.web.ServiceBaseTest;
@@ -37,14 +39,15 @@ public class AuditServiceTest extends ServiceBaseTest {
     @Test
     public void testQueryFromMySQL() throws IOException {
         AuditRequest request = new AuditRequest();
-        request.setAuditId("3");
+        request.setAuditIds(Arrays.asList("3", "4"));
         request.setInlongGroupId("g1");
         request.setInlongStreamId("s1");
         request.setDt("2022-01-01");
         List<AuditVO> result = new ArrayList<>();
         AuditVO auditVO = new AuditVO();
-        auditVO.setCount(123L);
-        auditVO.setLogTs("2022-01-01 00:00:00");
+        auditVO.setAuditId("3");
+        auditVO.setAuditSet(Arrays.asList(new AuditInfo("2022-01-01 00:00:00", 123L),
+                new AuditInfo("2022-01-01 00:01:00", 124L)));
         result.add(auditVO);
         Assert.assertNotNull(result);
         // close real test for testQueryFromMySQL due to date_format function not support in h2
@@ -60,7 +63,7 @@ public class AuditServiceTest extends ServiceBaseTest {
 //    @Test
     public void testQueryFromElasticsearch() throws IOException {
         AuditRequest request = new AuditRequest();
-        request.setAuditId("3");
+        request.setAuditIds(Arrays.asList("3", "4"));
         request.setInlongGroupId("g1");
         request.setInlongStreamId("s1");
         request.setDt("2022-01-01");


### PR DESCRIPTION
### Title Name: [INLONG-2192] Audit data supports auditId batch query

Audit data supports auditId batch query

Fixes #2192 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
