### PR TITLE
[INLONG-2232][tubemq] Add start and end timestamp of segment

### DIFF
--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerServiceServer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerServiceServer.java
@@ -466,7 +466,7 @@ public class BrokerServiceServer implements BrokerReadService, BrokerWriteServic
             sb.delete(0, sb.length());
             GetMessageResult msgQueryResult =
                     msgStore.getMessages(reqSwitch, requestOffset,
-                            partitionId, consumerNodeInfo, baseKey, msgDataSizeLimit);
+                            partitionId, consumerNodeInfo, baseKey, msgDataSizeLimit, 0);
             offsetManager.bookOffset(group, topic, partitionId,
                     msgQueryResult.lastReadOffset, isManualCommitOffset,
                     msgQueryResult.transferedMessageList.isEmpty(), sb);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/MessageStoreManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/MessageStoreManager.java
@@ -79,9 +79,9 @@ public class MessageStoreManager implements StoreService {
     // message on memory sink to disk operation scheduler.
     private final ScheduledExecutorService unFlushMemScheduler;
     // max transfer size.
-    private int maxMsgTransferSize;
+    private final int maxMsgTransferSize;
     // the status that is deleting topic.
-    private AtomicBoolean isRemovingTopic = new AtomicBoolean(false);
+    private final AtomicBoolean isRemovingTopic = new AtomicBoolean(false);
 
     public MessageStoreManager(final TubeBroker tubeBroker,
                                final BrokerConfig tubeConfig) throws IOException {
@@ -366,7 +366,7 @@ public class MessageStoreManager implements StoreService {
             }
             requestOffset = maxOffset - maxIndexReadSize < 0 ? 0L : maxOffset - maxIndexReadSize;
             return msgStore.getMessages(303, requestOffset, partitionId,
-                    consumerNodeInfo, topic, this.maxMsgTransferSize);
+                    consumerNodeInfo, topic, this.maxMsgTransferSize, 0);
         } catch (Throwable e1) {
             return new GetMessageResult(false, TErrCodeConstants.INTERNAL_SERVER_ERROR,
                     requestOffset, 0, "Get message failure, errMsg=" + e1.getMessage());

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/Segment.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/Segment.java
@@ -28,7 +28,17 @@ public interface Segment {
 
     void close();
 
-    long append(ByteBuffer buf) throws IOException;
+    /***
+     * Messages can only be appended to the last FileSegment.
+     * The last FileSegment is writable, the others are mutable.
+     *
+     * @param buf            data buffer
+     * @param leftTime       the first record timestamp
+     * @param rightTime      the latest record timestamp
+     * @return               latest writable position
+     * @throws IOException   exception while force data to disk
+     */
+    long append(ByteBuffer buf, long leftTime, long rightTime) throws IOException;
 
     long flush(boolean force) throws IOException;
 
@@ -62,6 +72,27 @@ public interface Segment {
 
     void relViewRef();
 
-    void read(ByteBuffer bf, long offset) throws IOException;
+    /***
+     * Read data to buffer from absolute position.
+     *
+     * @param bf          buffer to store data
+     * @param absOffset   absolute read position
+     */
+    void read(ByteBuffer bf, long absOffset) throws IOException;
 
+    /***
+     * Read data to buffer from relative position.
+     *
+     * @param bf          buffer to store data
+     * @param relOffset   relative read position
+     */
+    void relRead(ByteBuffer bf, long relOffset) throws IOException;
+
+    long getLeftAppendTime();
+
+    long getRightAppendTime();
+
+    boolean containTime(long timestamp);
+
+    long getRecordTime(long reqOffset) throws IOException;
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/SegmentList.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/SegmentList.java
@@ -36,6 +36,8 @@ public interface SegmentList {
 
     long getMaxOffset();
 
+    long getMaxAppendTime();
+
     boolean checkExpiredSegments(long checkTimestamp, long fileValidTimeMs);
 
     void delExpiredSegments(StringBuilder sb);
@@ -52,4 +54,5 @@ public interface SegmentList {
 
     Segment getRecordSeg(long offset) throws IOException;
 
+    Segment findSegmentByTimeStamp(long timestamp);
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/StoreRepairAdmin.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/tools/StoreRepairAdmin.java
@@ -379,7 +379,7 @@ public class StoreRepairAdmin {
                                 curPartSeg =
                                         new FileSegment(queueOffset, newFile, SegmentType.INDEX);
                             }
-                            curPartSeg.append(indexBuffer);
+                            curPartSeg.append(indexBuffer, timeRecv, timeRecv);
                             gQueueOffset += DataStoreUtils.STORE_INDEX_HEAD_LEN;
                             if (curPartSeg.getCachedSize() >= maxIndexSegmentSize) {
                                 curPartSeg.flush(true);

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/FileSegmentListTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/FileSegmentListTest.java
@@ -43,7 +43,8 @@ public class FileSegmentListTest {
             Segment fileSegment = fileSegmentList.last();
             String data = "abc";
             // append data to last FileSegment.
-            fileSegment.append(ByteBuffer.wrap(data.getBytes()));
+            long appendTime = System.currentTimeMillis();
+            fileSegment.append(ByteBuffer.wrap(data.getBytes()), appendTime, appendTime);
             fileSegment.flush(true);
             // get view
             Segment[] segmentList = fileSegmentList.getView();
@@ -70,7 +71,8 @@ public class FileSegmentListTest {
             Segment fileSegment = new FileSegment(100L, file, true, SegmentType.DATA);
             String data = "abc";
             // append data to last FileSegment.
-            fileSegment.append(ByteBuffer.wrap(data.getBytes()));
+            long appendTime = System.currentTimeMillis();
+            fileSegment.append(ByteBuffer.wrap(data.getBytes()), appendTime, appendTime);
             fileSegment.flush(true);
             fileSegmentList.append(fileSegment);
             Segment[] segmentList = fileSegmentList.getView();

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/FileSegmentTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/broker/msgstore/disk/FileSegmentTest.java
@@ -40,8 +40,9 @@ public class FileSegmentTest {
             byte[] bytes = data.getBytes();
             ByteBuffer buf = ByteBuffer.wrap(bytes);
             // append data to FileSegment.
-            fileSegment.append(buf);
-            fileSegment.append(buf);
+            long appendTime = System.currentTimeMillis();
+            fileSegment.append(buf, appendTime, appendTime);
+            fileSegment.append(buf, appendTime, appendTime);
         } catch (IOException e) {
             e.printStackTrace();
         } finally {
@@ -64,7 +65,8 @@ public class FileSegmentTest {
             byte[] bytes = data.getBytes();
             ByteBuffer buf = ByteBuffer.wrap(bytes);
             // append data to fileSegment.
-            long offset = fileSegment.append(buf);
+            long appendTime = System.currentTimeMillis();
+            long offset = fileSegment.append(buf, appendTime, appendTime);
             int limit = 1000;
             // get view of fileSegment.
             ByteBuffer readBuffer = ByteBuffer.allocate(limit);

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/broker/msgstore/mem/MsgMemStoreTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/broker/msgstore/mem/MsgMemStoreTest.java
@@ -53,6 +53,6 @@ public class MsgMemStoreTest {
         msgMemStore.appendMsg(msgMemStatisInfo, 0, 0,
                 System.currentTimeMillis(), 3, bf, appendResult);
         // get messages
-        GetCacheMsgResult getCacheMsgResult = msgMemStore.getMessages(0, 2, 1024, 1000, 0, false, false, null);
+        GetCacheMsgResult getCacheMsgResult = msgMemStore.getMessages(0, 2, 1024, 1000, 0, false, false, null, 0);
     }
 }


### PR DESCRIPTION
Fixes #2232

1. Add the write and read processing of start and end timestamp information for Segment;
2. Based on point 1, modify the corresponding API calling logic, increase the incoming time information, and find the corresponding segment according to the specified timestamp
3. Add comments to improve code readability