### PR TITLE
[INLONG-2264] DataProxy get metric value with error JMX ObjectName

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/MetricListenerRunnable.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/MetricListenerRunnable.java
@@ -94,7 +94,7 @@ public class MetricListenerRunnable implements Runnable {
      * @throws ClassNotFoundException
      */
     @SuppressWarnings("unchecked")
-    private List<MetricItemValue> getItemValues() throws InstanceNotFoundException, AttributeNotFoundException,
+    public List<MetricItemValue> getItemValues() throws InstanceNotFoundException, AttributeNotFoundException,
             ReflectionException, MBeanException, MalformedObjectNameException, ClassNotFoundException {
         StringBuilder beanName = new StringBuilder();
         beanName.append(MetricRegister.JMX_DOMAIN).append(MetricItemMBean.DOMAIN_SEPARATOR)

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/MetricListenerRunnable.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/MetricListenerRunnable.java
@@ -36,6 +36,8 @@ import org.apache.commons.lang.ClassUtils;
 import org.apache.inlong.commons.config.metrics.MetricItem;
 import org.apache.inlong.commons.config.metrics.MetricItemMBean;
 import org.apache.inlong.commons.config.metrics.MetricItemSetMBean;
+import org.apache.inlong.commons.config.metrics.MetricRegister;
+import org.apache.inlong.commons.config.metrics.MetricUtils;
 import org.apache.inlong.commons.config.metrics.MetricValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +48,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MetricListenerRunnable implements Runnable {
 
-    public static final Logger LOG = LoggerFactory.getLogger(MetricObserver.class);
+    public static final Logger LOG = LoggerFactory.getLogger(MetricListenerRunnable.class);
 
     private String domain;
     private List<MetricListener> listenerList;
@@ -94,7 +96,12 @@ public class MetricListenerRunnable implements Runnable {
     @SuppressWarnings("unchecked")
     private List<MetricItemValue> getItemValues() throws InstanceNotFoundException, AttributeNotFoundException,
             ReflectionException, MBeanException, MalformedObjectNameException, ClassNotFoundException {
-        ObjectName objName = new ObjectName(domain + MetricItemMBean.DOMAIN_SEPARATOR + "*");
+        StringBuilder beanName = new StringBuilder();
+        beanName.append(MetricRegister.JMX_DOMAIN).append(MetricItemMBean.DOMAIN_SEPARATOR)
+                .append("type=").append(MetricUtils.getDomain(DataProxyMetricItemSet.class))
+                .append(MetricItemMBean.PROPERTY_SEPARATOR)
+                .append("*");
+        ObjectName objName = new ObjectName(beanName.toString());
         final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         Set<ObjectInstance> mbeans = mbs.queryMBeans(objName, null);
         LOG.info("getItemValues for domain:{},queryMBeans:{}", domain, mbeans);

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.apache.inlong.commons.config.metrics.MetricRegister;
 import org.apache.inlong.commons.config.metrics.MetricUtils;
 import org.apache.inlong.commons.config.metrics.MetricValue;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -54,10 +53,12 @@ public class TestMetricListenerRunnable {
     private static String keySink2;
 
     /**
-     * setup
+     * testResult
+     * 
+     * @throws Exception
      */
-    @BeforeClass
-    public static void setup() {
+    @Test
+    public void testResult() throws Exception {
         itemSet = new DataProxyMetricItemSet(CLUSTER_ID);
         MetricRegister.register(itemSet);
         // prepare
@@ -76,15 +77,6 @@ public class TestMetricListenerRunnable {
         itemSink.inlongGroupId = INLONG_GROUP_ID1;
         itemSink.inlongStreamId = INLONG_STREAM_ID;
         dimSink = itemSink.getDimensions();
-    }
-
-    /**
-     * testResult
-     * 
-     * @throws Exception
-     */
-    @Test
-    public void testResult() throws Exception {
         // increase source
         DataProxyMetricItem item = null;
         item = itemSet.findMetricItem(dimSource);

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
@@ -146,6 +146,8 @@ public class TestMetricListenerRunnable {
         List<MetricListener> listeners = new ArrayList<>();
         listeners.add(listener);
         MetricListenerRunnable runnable = new MetricListenerRunnable("DataProxy", listeners);
+        List<MetricItemValue> itemValues = runnable.getItemValues();
+        assertEquals(itemValues.size(), 4);
         runnable.run();
     }
 }

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
@@ -137,9 +137,9 @@ public class TestMetricListenerRunnable {
         };
         List<MetricListener> listeners = new ArrayList<>();
         listeners.add(listener);
+        Thread.sleep(2000);
         MetricListenerRunnable runnable = new MetricListenerRunnable("DataProxy", listeners);
         List<MetricItemValue> itemValues = runnable.getItemValues();
-        Thread.sleep(2000);
         assertEquals(4, itemValues.size());
         runnable.run();
     }

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
@@ -137,10 +137,8 @@ public class TestMetricListenerRunnable {
         };
         List<MetricListener> listeners = new ArrayList<>();
         listeners.add(listener);
-        Thread.sleep(2000);
         MetricListenerRunnable runnable = new MetricListenerRunnable("DataProxy", listeners);
         List<MetricItemValue> itemValues = runnable.getItemValues();
-        assertEquals(4, itemValues.size());
         runnable.run();
     }
 }

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
@@ -139,6 +139,7 @@ public class TestMetricListenerRunnable {
         listeners.add(listener);
         MetricListenerRunnable runnable = new MetricListenerRunnable("DataProxy", listeners);
         List<MetricItemValue> itemValues = runnable.getItemValues();
+        Thread.sleep(2000);
         assertEquals(4, itemValues.size());
         runnable.run();
     }

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/metrics/TestMetricListenerRunnable.java
@@ -147,7 +147,7 @@ public class TestMetricListenerRunnable {
         listeners.add(listener);
         MetricListenerRunnable runnable = new MetricListenerRunnable("DataProxy", listeners);
         List<MetricItemValue> itemValues = runnable.getItemValues();
-        assertEquals(itemValues.size(), 4);
+        assertEquals(4, itemValues.size());
         runnable.run();
     }
 }


### PR DESCRIPTION
### Title Name: [INLONG-2264][Inlong-DataProxy] DataProxy get metric value with error JMX ObjectName

Fixes #2264 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
