### PR TITLE
[INLONG-2161][Feature][Manager] add the sort_cluster_config table for getClusterConfig interface

### DIFF
--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/entity/SortClusterConfgiEntity.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/entity/SortClusterConfgiEntity.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.dao.entity;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class SortClusterConfgiEntity implements Serializable {
+    private Integer id;
+    private String clusterName;
+    private String taskName;
+    private String sinkType;
+    private static final long serialVersionUID = 1L;
+}

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/SortClusterConfgiEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/SortClusterConfgiEntityMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.dao.mapper;
+
+import org.apache.inlong.manager.dao.entity.SortClusterConfgiEntity;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SortClusterConfgiEntityMapper {
+    int deleteByPrimaryKey(Integer id);
+
+    int insert(SortClusterConfgiEntity record);
+
+    int insertSelective(SortClusterConfgiEntity record);
+
+    SortClusterConfgiEntity selectByPrimaryKey(Integer id);
+
+    int updateByPrimaryKeySelective(SortClusterConfgiEntity record);
+
+    int updateByPrimaryKey(SortClusterConfgiEntity record);
+
+    List<SortClusterConfgiEntity> selectTasksByClusterName(String clusterName);
+
+}

--- a/inlong-manager/manager-dao/src/main/resources/generatorConfig.xml
+++ b/inlong-manager/manager-dao/src/main/resources/generatorConfig.xml
@@ -210,7 +210,14 @@
                 enableUpdateByPrimaryKey="true"
                 enableDeleteByPrimaryKey="true" enableInsert="true"
                 enableCountByExample="false" enableDeleteByExample="false"
-                enableSelectByExample="false" enableUpdateByExample="false"/>-->
+                enableSelectByExample="false" enableUpdateByExample="false"/>
+
+        <table tableName="sort_cluster_config" domainObjectName="SortClusterConfgiEntity"
+               enableSelectByPrimaryKey="true"
+               enableUpdateByPrimaryKey="true"
+               enableDeleteByPrimaryKey="true" enableInsert="true"
+               enableCountByExample="false" enableDeleteByExample="false"
+               enableSelectByExample="false" enableUpdateByExample="false"/>-->
 
     </context>
 </generatorConfiguration>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/SortClusterConfgiEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/SortClusterConfgiEntityMapper.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.inlong.manager.dao.mapper.SortClusterConfgiEntityMapper">
+  <resultMap id="BaseResultMap" type="org.apache.inlong.manager.dao.entity.SortClusterConfgiEntity">
+    <id column="id" jdbcType="INTEGER" property="id" />
+    <result column="cluster_name" jdbcType="VARCHAR" property="clusterName" />
+    <result column="task_name" jdbcType="VARCHAR" property="taskName" />
+    <result column="sink_type" jdbcType="VARCHAR" property="sinkType" />
+  </resultMap>
+  <sql id="Base_Column_List">
+    id, cluster_name, task_name, sink_type
+  </sql>
+  <select id="selectByPrimaryKey" parameterType="java.lang.Integer" resultMap="BaseResultMap">
+    select 
+    <include refid="Base_Column_List" />
+    from sort_cluster_config
+    where id = #{id,jdbcType=INTEGER}
+  </select>
+  <delete id="deleteByPrimaryKey" parameterType="java.lang.Integer">
+    delete from sort_cluster_config
+    where id = #{id,jdbcType=INTEGER}
+  </delete>
+  <insert id="insert" parameterType="org.apache.inlong.manager.dao.entity.SortClusterConfgiEntity">
+    insert into sort_cluster_config (id, cluster_name, task_name, 
+      sink_type)
+    values (#{id,jdbcType=INTEGER}, #{clusterName,jdbcType=VARCHAR}, #{taskName,jdbcType=VARCHAR}, 
+      #{sinkType,jdbcType=VARCHAR})
+  </insert>
+  <insert id="insertSelective" parameterType="org.apache.inlong.manager.dao.entity.SortClusterConfgiEntity">
+    insert into sort_cluster_config
+    <trim prefix="(" suffix=")" suffixOverrides=",">
+      <if test="id != null">
+        id,
+      </if>
+      <if test="clusterName != null">
+        cluster_name,
+      </if>
+      <if test="taskName != null">
+        task_name,
+      </if>
+      <if test="sinkType != null">
+        sink_type,
+      </if>
+    </trim>
+    <trim prefix="values (" suffix=")" suffixOverrides=",">
+      <if test="id != null">
+        #{id,jdbcType=INTEGER},
+      </if>
+      <if test="clusterName != null">
+        #{clusterName,jdbcType=VARCHAR},
+      </if>
+      <if test="taskName != null">
+        #{taskName,jdbcType=VARCHAR},
+      </if>
+      <if test="sinkType != null">
+        #{sinkType,jdbcType=VARCHAR},
+      </if>
+    </trim>
+  </insert>
+  <update id="updateByPrimaryKeySelective" parameterType="org.apache.inlong.manager.dao.entity.SortClusterConfgiEntity">
+    update sort_cluster_config
+    <set>
+      <if test="clusterName != null">
+        cluster_name = #{clusterName,jdbcType=VARCHAR},
+      </if>
+      <if test="taskName != null">
+        task_name = #{taskName,jdbcType=VARCHAR},
+      </if>
+      <if test="sinkType != null">
+        sink_type = #{sinkType,jdbcType=VARCHAR},
+      </if>
+    </set>
+    where id = #{id,jdbcType=INTEGER}
+  </update>
+  <update id="updateByPrimaryKey" parameterType="org.apache.inlong.manager.dao.entity.SortClusterConfgiEntity">
+    update sort_cluster_config
+    set cluster_name = #{clusterName,jdbcType=VARCHAR},
+      task_name = #{taskName,jdbcType=VARCHAR},
+      sink_type = #{sinkType,jdbcType=VARCHAR}
+    where id = #{id,jdbcType=INTEGER}
+  </update>
+  <select id="selectTasksByClusterName" parameterType="java.lang.String" resultMap="BaseResultMap">
+    select
+    <include refid="Base_Column_List" />
+    from sort_cluster_config
+    where cluster_name = #{clusterName, jdbcType=VARCHAR}
+  </select>
+</mapper>

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/SortClusterConfigService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/SortClusterConfigService.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.core;
+
+import org.apache.inlong.manager.dao.entity.SortClusterConfgiEntity;
+
+import java.util.List;
+
+/**
+ * Sort cluster config service.
+ */
+public interface SortClusterConfigService {
+
+    /**
+     * Select list of task by cluster name.
+     * @param clusterName Name of sort cluster.
+     * @return List of tasks, including task name and sink type.
+     */
+    List<SortClusterConfgiEntity> selectTasksByClusterName(String clusterName);
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterConfigServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterConfigServiceImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.core.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.inlong.manager.dao.entity.SortClusterConfgiEntity;
+import org.apache.inlong.manager.dao.mapper.SortClusterConfgiEntityMapper;
+import org.apache.inlong.manager.service.core.SortClusterConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Sort service implementation.
+ */
+@Slf4j
+@Service
+public class SortClusterConfigServiceImpl implements SortClusterConfigService {
+
+    @Autowired
+    private SortClusterConfgiEntityMapper sortClusterConfgiEntityMapper;
+
+    @Override
+    public List<SortClusterConfgiEntity> selectTasksByClusterName(String clusterName) {
+        return sortClusterConfgiEntityMapper.selectTasksByClusterName(clusterName);
+    }
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
@@ -18,11 +18,17 @@
 package org.apache.inlong.manager.service.core.impl;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.pojo.sort.SortClusterConfigResponse;
+import org.apache.inlong.manager.dao.entity.SortClusterConfgiEntity;
+import org.apache.inlong.manager.service.core.SortClusterConfigService;
 import org.apache.inlong.manager.service.core.SortService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
  * Sort service implementation.
@@ -33,9 +39,30 @@ public class SortServiceImpl implements SortService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SortServiceImpl.class);
 
+    @Autowired
+    private SortClusterConfigService sortClusterConfigService;
+
     @Override
     public SortClusterConfigResponse getClusterConfig(String clusterName, String md5) {
         LOGGER.info("start getClusterConfig");
-        return SortClusterConfigResponse.builder().build();
+
+        if (StringUtils.isBlank(clusterName)) {
+            String errMsg = "Blank cluster name";
+            LOGGER.info(errMsg);
+            return SortClusterConfigResponse.builder()
+                    .msg(errMsg).build();
+        }
+
+        List<SortClusterConfgiEntity> tasks = sortClusterConfigService.selectTasksByClusterName(clusterName);
+        if (tasks == null || tasks.isEmpty()) {
+            String errMsg = "There is not any task for cluster" + clusterName;
+            LOGGER.info(errMsg);
+            return SortClusterConfigResponse.builder()
+                    .msg(errMsg).build();
+        }
+
+        return SortClusterConfigResponse.builder()
+                .msg("success").build();
     }
+
 }

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -1132,5 +1132,18 @@ CREATE TABLE `db_collector_detail_task`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='db collector detail task table';
 
+-- ----------------------------
+-- Table structure for sort_cluster_config
+-- ----------------------------
+DROP TABLE IF EXISTS `sort_cluster_config`;
+CREATE TABLE `sort_cluster_config`
+(
+    `id`            int(11)       NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
+    `cluster_name`  varchar(128)  NOT NULL COMMENT 'Cluster name',
+    `task_name`     varchar(128)  NOT NULL COMMENT 'Task name',
+    `sink_type`     varchar(128)  NOT NULL COMMENT 'Type of sink',
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='Sort cluster config table';
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/controller/openapi/SortControllerTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/controller/openapi/SortControllerTest.java
@@ -60,4 +60,15 @@ public class SortControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
     }
+
+    @Test
+    public void testEmptyClusterNameWhenGet() throws Exception {
+        RequestBuilder request =
+                get("/openapi/sort/getClusterConfig")
+                        .param("clusterName", "  ")
+                        .param("md5", "testMd5");
+        mockMvc.perform(request)
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
 }


### PR DESCRIPTION
### Title Name: [INLONG-2161][component] Define the sort_cluster_config table


Fixes #2161

### Motivation

Define sort_cluster_config table. 
Use cluster name to select the corresponding tasks and the sink type of each task.

### Modifications

Add mappers of sort_cluster_config
Add invalid cluster name check.
Add UT of blank cluster name

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
