### PR TITLE
[INLONG-2326] Inlong-Sort-Standalone support to sort the events to ElasticSearch cluster.

### DIFF
--- a/inlong-sort-standalone/conf/es/GetClusterConfig.json
+++ b/inlong-sort-standalone/conf/es/GetClusterConfig.json
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+	"data":{
+		"clusterName":"esv3-sz-sz1",
+		"sortTasks":[
+			{
+				"idParams":[
+					{
+						"inlongGroupId":"0fc00000046",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong0fc00000046_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo t1 t2 t3 t4",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"03600000045",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong03600000045_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo t1 t2 t3",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"05100054990",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong05100054990_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo field1 field2 field3 field4",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"09c00014434",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong09c00014434_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo id elog containerName cid setName ip",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"0c900035509",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong0c900035509_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo statTime msgTime senderIp containerName cid kafkaGroupId KafkaClusterId topic partitionId count size lastMaxOffset minOffset maxOffset minAckOffset maxAckOffset",
+						"fieldOffset":2,
+						"contentOffset":0
+					}
+				],
+				"name":"sid_es_es-rmrv7g7a_v3",
+				"sinkParams":{
+					"httpHosts":"127.0.0.1:9200",
+					"username":"elastic",
+					"password":"elastic",
+					"bulkAction":4000,
+					"bulkSizeMb":10,
+					"flushInterval":60,
+					"concurrentRequests":5,
+					"maxConnect":10,
+					"keywordMaxLength":32767,
+					"isUseIndexId":false
+				},
+				"type":"ElasticSearch"
+			}
+		]
+	},
+	"errCode":0,
+	"md5":"md5",
+	"result":true
+}

--- a/inlong-sort-standalone/conf/es/GetSortSourceConfig.json
+++ b/inlong-sort-standalone/conf/es/GetSortSourceConfig.json
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+	"data": {
+		"cacheZones": {
+			"sid_es_es-rmrv7g7a_v3": {
+				"authentication": "authentication",
+				"cacheZoneProperties": {
+					"prop1": "val1"
+				},
+				"serviceUrl": "http://127.0.0.1:8080",
+				"topics": [{
+					"partitionCnt": 60,
+					"topic": "pulsar-9xn9wp35pbxb/test/atta_topic_1",
+					"topicProperties": {
+						"xx": "val1"
+					}
+				}, {
+					"partitionCnt": 60,
+					"topic": "pulsar-9xn9wp35pbxb/test/atta_topic_2",
+					"topicProperties": {
+						"xx": "val1"
+					}
+				}, {
+					"partitionCnt": 60,
+					"topic": "pulsar-9xn9wp35pbxb/test/atta_topic_3",
+					"topicProperties": {
+						"xx": "val1"
+					}
+				}, {
+					"partitionCnt": 60,
+					"topic": "pulsar-9xn9wp35pbxb/test/atta_topic_4",
+					"topicProperties": {
+						"xx": "val1"
+					}
+				}, {
+					"partitionCnt": 60,
+					"topic": "pulsar-9xn9wp35pbxb/test/atta_topic_5",
+					"topicProperties": {
+						"xx": "val1"
+					}
+				}],
+				"zoneName": "pulsar-9xn9wp35pbxb",
+				"zoneType": "pulsar"
+			}
+		},
+		"sortClusterName": "esv3-sz-sz1",
+		"sortTaskId": "sid_es_es-rmrv7g7a_v3"
+	},
+	"errCode": 0,
+	"md5": "md5",
+	"result": true
+}

--- a/inlong-sort-standalone/conf/es/common.properties
+++ b/inlong-sort-standalone/conf/es/common.properties
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+clusterId=esv3-sz-sz1
+metricDomains=Sort
+metricDomains.Sort.domainListeners=org.apache.inlong.sort.standalone.metrics.prometheus.PrometheusMetricListener
+metricDomains.Sort.snapshotInterval=60000
+sortChannel.type=org.apache.inlong.sort.standalone.channel.BufferQueueChannel
+sortSink.type=org.apache.inlong.sort.standalone.sink.elasticsearch.EsSink
+sortSource.type=org.apache.inlong.sort.standalone.source.readapi.ReadApiSource
+#sortClusterConfig.type=org.apache.inlong.sort.standalone.config.loader.ClassResourceSortClusterConfigLoader
+sortClusterConfig.type=org.apache.inlong.sort.standalone.config.loader.ManagerSortClusterConfigLoader
+sortClusterConfig.managerPath=http://${manager ip:port}/api/inlong/manager/openapi/sort/standalone/getClusterConfig
+
+indexRequestHandler=org.apache.inlong.sort.standalone.sink.elasticsearch.DefaultEvent2IndexRequestHandler
+
+maxThreads=10
+reloadInterval=60000
+processInterval=100

--- a/inlong-sort-standalone/pom.xml
+++ b/inlong-sort-standalone/pom.xml
@@ -58,6 +58,7 @@
         <log4j.version>2.17.1</log4j.version>
         <mockito.version>2.23.0</mockito.version>
         <jakarta.validation.version>2.0.2</jakarta.validation.version>
+        <elasticsearch-version>6.8.13</elasticsearch-version>
     </properties>
 
     <dependencies>
@@ -239,6 +240,31 @@
             <scope>compile</scope>
             <version>${jakarta.validation.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+            <version>${elasticsearch-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>log4j-api</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>${elasticsearch-version}</version>
+        </dependency>    
     </dependencies>
 
 </project>

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/DefaultEvent2IndexRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/DefaultEvent2IndexRequestHandler.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import java.nio.charset.Charset;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+
+/**
+ * 
+ * DefaultEvent2IndexRequestHandler
+ */
+public class DefaultEvent2IndexRequestHandler implements IEvent2IndexRequestHandler {
+
+    private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private AtomicLong esIndexIndex = new AtomicLong(System.currentTimeMillis());
+
+    /**
+     * parse
+     * 
+     * @param  context
+     * @param  event
+     * @return
+     */
+    @Override
+    public EsIndexRequest parse(EsSinkContext context, ProfileEvent event) {
+        String uid = event.getUid();
+        EsIdConfig idConfig = context.getIdConfig(uid);
+        if (idConfig == null) {
+            context.addSendResultMetric(event, context.getTaskName(), false, System.currentTimeMillis());
+            return null;
+        }
+        // parse fields
+        String delimeter = idConfig.getSeparator();
+        char cDelimeter = delimeter.charAt(0);
+        String strContext = null;
+        // for tab separator
+        byte[] bodyBytes = event.getBody();
+        int msgLength = event.getBody().length;
+        int contentOffset = idConfig.getContentOffset();
+        if (contentOffset > 0 && msgLength >= 1) {
+            strContext = new String(bodyBytes, contentOffset, msgLength - contentOffset, Charset.defaultCharset());
+        } else {
+            strContext = new String(bodyBytes, Charset.defaultCharset());
+        }
+        // unescape
+        List<String> columnVlues = unescapeFields(strContext, cDelimeter);
+        int valueLength = columnVlues.size();
+        List<String> fieldList = idConfig.getFieldList();
+        int columnLength = fieldList.size();
+        // field offset
+        int fieldOffset = idConfig.getFieldOffset();
+        // get field value
+        Map<String, String> fieldMap = new HashMap<>();
+        for (int i = fieldOffset; i < columnLength; ++i) {
+            String fieldName = fieldList.get(i);
+            int columnIndex = i - fieldOffset;
+            String fieldValue = columnIndex < valueLength ? columnVlues.get(columnIndex) : "";
+            byte[] fieldBytes = fieldValue.getBytes(Charset.defaultCharset());
+            if (fieldBytes.length > context.getKeywordMaxLength()) {
+                fieldValue = new String(fieldBytes, 0, context.getKeywordMaxLength());
+            }
+            fieldMap.put(fieldName, fieldValue);
+        }
+
+        // ftime
+        String ftime = dateFormat.format(new Date(event.getRawLogTime()));
+        fieldMap.put("ftime", ftime);
+        // extinfo
+        String extinfo = getExtInfo(event);
+        fieldMap.put("extinfo", extinfo);
+        String indexName = idConfig.parseIndexName(event.getRawLogTime());
+        // build
+        EsIndexRequest indexRequest = new EsIndexRequest(indexName, event);
+        if (context.isUseIndexId()) {
+            String esIndexId = uid + delimeter + event.getRawLogTime() + delimeter + esIndexIndex.incrementAndGet();
+            indexRequest.id(esIndexId);
+        }
+        indexRequest.source(fieldMap);
+        return indexRequest;
+    }
+
+    /**
+     * unescapeFields
+     * 
+     * @param  fieldValues
+     * @param  separator
+     * @return
+     */
+    public static List<String> unescapeFields(String fieldValues, char separator) {
+        List<String> fields = new ArrayList<String>();
+        if (fieldValues.length() <= 0) {
+            return fields;
+        }
+
+        int fieldLen = fieldValues.length();
+        StringBuilder builder = new StringBuilder();
+        int i = 0;
+        for (; i < fieldLen - 1; i++) {
+            char value = fieldValues.charAt(i);
+            switch (value) {
+                case '\\' :
+                    char nextValue = fieldValues.charAt(i + 1);
+                    switch (nextValue) {
+                        case '0' :
+                            builder.append(0x00);
+                            i++;
+                            break;
+                        case 'n' :
+                            builder.append('\n');
+                            i++;
+                            break;
+                        case 'r' :
+                            builder.append('\r');
+                            i++;
+                            break;
+                        case '\\' :
+                            builder.append('\\');
+                            i++;
+                            break;
+                        default :
+                            if (nextValue == separator) {
+                                builder.append(separator);
+                                i++;
+                            } else {
+                                builder.append(value);
+                            }
+                            break;
+                    }
+                    if (i == fieldLen - 1) {
+                        fields.add(builder.toString());
+                    }
+                    break;
+                default :
+                    if (value == separator) {
+                        fields.add(builder.toString());
+                        builder.delete(0, builder.length());
+                    } else {
+                        builder.append(value);
+                    }
+                    break;
+            }
+        }
+
+        if (i == fieldLen - 1) {
+            char value = fieldValues.charAt(i);
+            if (value == separator) {
+                fields.add(builder.toString());
+                fields.add("");
+            } else {
+                builder.append(value);
+                fields.add(builder.toString());
+            }
+        }
+        return fields;
+    }
+
+    /**
+     * getExtInfo
+     * 
+     * @param  event
+     * @return
+     */
+    public static String getExtInfo(ProfileEvent event) {
+        if (event.getHeaders().size() > 0) {
+            StringBuilder sBuilder = new StringBuilder();
+            for (Entry<String, String> extInfo : event.getHeaders().entrySet()) {
+                String key = extInfo.getKey();
+                String value = extInfo.getValue();
+                sBuilder.append(key).append('=').append(value).append('&');
+            }
+            String extinfo = sBuilder.substring(0, sBuilder.length() - 1);
+            return extinfo;
+        }
+        return "";
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsCallbackListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsCallbackListener.java
@@ -55,7 +55,7 @@ public class EsCallbackListener implements BulkProcessor.Listener {
      */
     @Override
     public void beforeBulk(long executionId, BulkRequest request) {
-//      LOG.info("beforeBulk,executionId:" + executionId + ",request:" + request);
+        LOG.debug("beforeBulk,executionId:{},request:{}", executionId, request);
     }
 
     /**
@@ -67,15 +67,14 @@ public class EsCallbackListener implements BulkProcessor.Listener {
      */
     @Override
     public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
-//      LOG.info("afterBulk,executionId:" + executionId + ",request:" + request + ",response:" + response);
+        LOG.debug("afterBulk,executionId,executionId:{},request:{},response:{}", executionId, request, response);
         BulkItemResponse[] itemResponses = response.getItems();
         List<DocWriteRequest<?>> requests = request.requests();
-        int itemSize = Math.min(itemResponses.length, requests.size());
         if (itemResponses.length != requests.size()) {
             LOG.error("BulkItemResponse size is not equal to IndexRequest size:requestSize:{},responseSize:{}",
                     requests.size(), itemResponses.length);
         }
-        for (int i = 0; i < itemSize; i++) {
+        for (int i = 0; i < itemResponses.length; i++) {
             // parameter
             EsIndexRequest requestItem = (EsIndexRequest) requests.get(i);
             BulkItemResponse responseItem = itemResponses[i];

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsCallbackListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsCallbackListener.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import java.util.List;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.slf4j.Logger;
+
+/**
+ * EsCallbackListener
+ *
+ */
+public class EsCallbackListener implements BulkProcessor.Listener {
+
+    public static final Logger LOG = InlongLoggerFactory.getLogger(EsCallbackListener.class);
+
+    private EsSinkContext context;
+
+    /**
+     * Constructor
+     * 
+     * @param context
+     */
+    public EsCallbackListener(EsSinkContext context) {
+        this.context = context;
+    }
+
+    /**
+     * beforeBulk
+     * 
+     * @param executionId
+     * @param request
+     */
+    @Override
+    public void beforeBulk(long executionId, BulkRequest request) {
+//      LOG.info("beforeBulk,executionId:" + executionId + ",request:" + request);
+    }
+
+    /**
+     * afterBulk
+     * 
+     * @param executionId
+     * @param request
+     * @param response
+     */
+    @Override
+    public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
+//      LOG.info("afterBulk,executionId:" + executionId + ",request:" + request + ",response:" + response);
+        BulkItemResponse[] itemResponses = response.getItems();
+        List<DocWriteRequest<?>> requests = request.requests();
+        int itemSize = Math.min(itemResponses.length, requests.size());
+        if (itemResponses.length != requests.size()) {
+            LOG.error("BulkItemResponse size is not equal to IndexRequest size:requestSize:{},responseSize:{}",
+                    requests.size(), itemResponses.length);
+        }
+        for (int i = 0; i < itemSize; i++) {
+            // parameter
+            EsIndexRequest requestItem = (EsIndexRequest) requests.get(i);
+            BulkItemResponse responseItem = itemResponses[i];
+            ProfileEvent event = requestItem.getEvent();
+            long sendTime = requestItem.getSendTime();
+
+            // is fail
+            if (responseItem.isFailed()) {
+                context.addSendResultMetric(event, context.getTaskName(), false, sendTime);
+                context.backDispatchQueue(requestItem);
+            } else {
+                context.addSendResultMetric(event, context.getTaskName(), true, sendTime);
+            }
+        }
+    }
+
+    /**
+     * afterBulk
+     * 
+     * @param executionId
+     * @param request
+     * @param failure
+     */
+    @Override
+    public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
+        LOG.error("afterBulk,executionId:" + executionId + ",failure:" + failure, failure);
+        String errorMsg = String.format("EsSenderError,whole bulk,errorMsg:%s,count:%d", failure.getMessage(),
+                request.numberOfActions());
+        LOG.error(errorMsg, failure);
+
+        // monitor
+        List<DocWriteRequest<?>> requests = request.requests();
+        for (int i = 0; i < requests.size(); i++) {
+            EsIndexRequest requestItem = (EsIndexRequest) requests.get(i);
+            ProfileEvent event = requestItem.getEvent();
+            long sendTime = requestItem.getSendTime();
+            context.addSendResultMetric(event, context.getTaskName(), false, sendTime);
+            context.backDispatchQueue(requestItem);
+        }
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsChannelWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsChannelWorker.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import org.apache.flume.Channel;
+import org.apache.flume.Event;
+import org.apache.flume.Transaction;
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * EsChannelWorker
+ */
+public class EsChannelWorker extends Thread {
+
+    public static final Logger LOG = LoggerFactory.getLogger(EsChannelWorker.class);
+
+    private final EsSinkContext context;
+    private final int workerIndex;
+
+    private LifecycleState status;
+
+    /**
+     * Constructor
+     * 
+     * @param context
+     * @param workerIndex
+     */
+    public EsChannelWorker(EsSinkContext context, int workerIndex) {
+        this.context = context;
+        this.workerIndex = workerIndex;
+        this.status = LifecycleState.IDLE;
+    }
+
+    /**
+     * run
+     */
+    @Override
+    public void run() {
+        status = LifecycleState.START;
+        LOG.info("start to EsChannelWorker:{},status:{},index:{}", context.getTaskName(), status, workerIndex);
+        while (status == LifecycleState.START) {
+            try {
+                this.doRun();
+            } catch (Throwable t) {
+                LOG.error(t.getMessage(), t);
+            }
+        }
+    }
+
+    /**
+     * doRun
+     */
+    public void doRun() {
+        Channel channel = context.getChannel();
+        Transaction tx = channel.getTransaction();
+        tx.begin();
+        try {
+            Event event = channel.take();
+            if (event == null) {
+                tx.commit();
+                Thread.sleep(context.getProcessInterval());
+                return;
+            }
+            if (!(event instanceof ProfileEvent)) {
+                tx.commit();
+                this.context.addSendFailMetric();
+                Thread.sleep(context.getProcessInterval());
+                return;
+            }
+            // to profileEvent
+            ProfileEvent profileEvent = (ProfileEvent) event;
+            EsIndexRequest indexRequest = context.getIndexRequestHandler().parse(context, profileEvent);
+            // offer queue
+            if (indexRequest != null) {
+                context.offerDispatchQueue(indexRequest);
+            } else {
+                context.addSendFailMetric();
+            }
+            tx.commit();
+            return;
+        } catch (Throwable t) {
+            LOG.error("Process event failed!" + this.getName(), t);
+            try {
+                tx.rollback();
+            } catch (Throwable e) {
+                LOG.error("Channel take transaction rollback exception:" + getName(), e);
+            }
+            return;
+        } finally {
+            tx.close();
+        }
+    }
+
+    /**
+     * close
+     */
+    public void close() {
+        this.status = LifecycleState.STOP;
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsIdConfig.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsIdConfig.java
@@ -1,0 +1,240 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * 
+ * EsIdConfig
+ */
+public class EsIdConfig {
+
+    public static final String PATTERN_DAY = "{yyyyMMdd}";
+    public static final String PATTERN_HOUR = "{yyyyMMddHH}";
+    public static final String PATTERN_MINUTE = "{yyyyMMddHHmm}";
+    public static final String REGEX_DAY = "\\{yyyyMMdd\\}";
+    public static final String REGEX_HOUR = "\\{yyyyMMddHH\\}";
+    public static final String REGEX_MINUTE = "\\{yyyyMMddHHmm\\}";
+    private static ThreadLocal<SimpleDateFormat> FORMAT_DAY = new ThreadLocal<SimpleDateFormat>() {
+
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat("yyyyMMdd");
+        }
+    };
+    private static ThreadLocal<SimpleDateFormat> FORMAT_HOUR = new ThreadLocal<SimpleDateFormat>() {
+
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat("yyyyMMddHH");
+        }
+    };
+    private static ThreadLocal<SimpleDateFormat> FORMAT_MINUTE = new ThreadLocal<SimpleDateFormat>() {
+
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat("yyyyMMddHHmm");
+        }
+    };
+
+    private String inlongGroupId;
+    private String inlongStreamId;
+    private String separator = "|";
+    private String indexNamePattern;
+    private String fieldNames;
+    private int fieldOffset = 2; // for ftime,extinfo
+    private int contentOffset = 0;// except for boss + tab(1)
+    private List<String> fieldList;
+
+    /**
+     * get inlongGroupId
+     * 
+     * @return the inlongGroupId
+     */
+    public String getInlongGroupId() {
+        return inlongGroupId;
+    }
+
+    /**
+     * set inlongGroupId
+     * 
+     * @param inlongGroupId the inlongGroupId to set
+     */
+    public void setInlongGroupId(String inlongGroupId) {
+        this.inlongGroupId = inlongGroupId;
+    }
+
+    /**
+     * get inlongStreamId
+     * 
+     * @return the inlongStreamId
+     */
+    public String getInlongStreamId() {
+        return inlongStreamId;
+    }
+
+    /**
+     * set inlongStreamId
+     * 
+     * @param inlongStreamId the inlongStreamId to set
+     */
+    public void setInlongStreamId(String inlongStreamId) {
+        this.inlongStreamId = inlongStreamId;
+    }
+
+    /**
+     * get separator
+     * 
+     * @return the separator
+     */
+    public String getSeparator() {
+        return separator;
+    }
+
+    /**
+     * set separator
+     * 
+     * @param separator the separator to set
+     */
+    public void setSeparator(String separator) {
+        this.separator = separator;
+    }
+
+    /**
+     * get indexNamePattern
+     * 
+     * @return the indexNamePattern
+     */
+    public String getIndexNamePattern() {
+        return indexNamePattern;
+    }
+
+    /**
+     * set indexNamePattern
+     * 
+     * @param indexNamePattern the indexNamePattern to set
+     */
+    public void setIndexNamePattern(String indexNamePattern) {
+        this.indexNamePattern = indexNamePattern;
+    }
+
+    /**
+     * get fieldOffset
+     * 
+     * @return the fieldOffset
+     */
+    public int getFieldOffset() {
+        return fieldOffset;
+    }
+
+    /**
+     * set fieldOffset
+     * 
+     * @param fieldOffset the fieldOffset to set
+     */
+    public void setFieldOffset(int fieldOffset) {
+        this.fieldOffset = fieldOffset;
+    }
+
+    /**
+     * get fieldList
+     * 
+     * @return the fieldList
+     */
+    public List<String> getFieldList() {
+        if (fieldList == null) {
+            this.fieldList = new ArrayList<>();
+            if (fieldNames != null) {
+                String[] fieldNameArray = fieldNames.split("\\s+");
+                this.fieldList.addAll(Arrays.asList(fieldNameArray));
+            }
+        }
+        return fieldList;
+    }
+
+    /**
+     * set fieldList
+     * 
+     * @param fieldList the fieldList to set
+     */
+    public void setFieldList(List<String> fieldList) {
+        this.fieldList = fieldList;
+    }
+
+    /**
+     * get fieldNames
+     * 
+     * @return the fieldNames
+     */
+    public String getFieldNames() {
+        return fieldNames;
+    }
+
+    /**
+     * set fieldNames
+     * 
+     * @param fieldNames the fieldNames to set
+     */
+    public void setFieldNames(String fieldNames) {
+        this.fieldNames = fieldNames;
+    }
+
+    /**
+     * get contentOffset
+     * 
+     * @return the contentOffset
+     */
+    public int getContentOffset() {
+        return contentOffset;
+    }
+
+    /**
+     * set contentOffset
+     * 
+     * @param contentOffset the contentOffset to set
+     */
+    public void setContentOffset(int contentOffset) {
+        this.contentOffset = contentOffset;
+    }
+
+    /**
+     * parseIndexName
+     * 
+     * @param  msgTime
+     * @return
+     */
+    public String parseIndexName(long msgTime) {
+        Date dtDate = new Date(msgTime);
+        String result = indexNamePattern;
+        if (result.indexOf(PATTERN_MINUTE) >= 0) {
+            String strHour = FORMAT_MINUTE.get().format(dtDate);
+            result = result.replaceAll(REGEX_MINUTE, strHour);
+        }
+        if (result.indexOf(PATTERN_HOUR) >= 0) {
+            String strHour = FORMAT_HOUR.get().format(dtDate);
+            result = result.replaceAll(REGEX_HOUR, strHour);
+        }
+        if (result.indexOf(PATTERN_DAY) >= 0) {
+            String strHour = FORMAT_DAY.get().format(dtDate);
+            result = result.replaceAll(REGEX_DAY, strHour);
+        }
+        return result;
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsIndexRequest.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsIndexRequest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.elasticsearch.action.index.IndexRequest;
+
+/**
+ * EsIndexRequest
+ */
+public class EsIndexRequest extends IndexRequest {
+
+    public static final String OP_TYPE = "log";
+    private final ProfileEvent event;
+    private final long sendTime;
+
+    /**
+     * Constructor
+     * 
+     * @param indexName
+     * @param event
+     */
+    public EsIndexRequest(String indexName, ProfileEvent event) {
+        super(indexName, OP_TYPE);
+        this.event = event;
+        this.sendTime = System.currentTimeMillis();
+    }
+
+    /**
+     * get event
+     * 
+     * @return the event
+     */
+    public ProfileEvent getEvent() {
+        return event;
+    }
+
+    /**
+     * get sendTime
+     * 
+     * @return the sendTime
+     */
+    public long getSendTime() {
+        return sendTime;
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsOutputChannel.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsOutputChannel.java
@@ -115,7 +115,7 @@ public class EsOutputChannel extends Thread {
                             .setMaxConnPerRoute(context.getMaxConnect())
                             .setDefaultRequestConfig(requestConfig);
                 });
-                esClient = new RestHighLevelClient(builder);
+                esClient = EsSinkFactory.createRestHighLevelClient(builder);
             }
         } catch (Exception e) {
             LOG.error("init esclient failed.", e);
@@ -191,7 +191,7 @@ public class EsOutputChannel extends Thread {
      * 
      * @throws InterruptedException
      */
-    private void send() throws InterruptedException {
+    public void send() throws InterruptedException {
         EsIndexRequest indexRequest = null;
         try {
             BulkProcessor bulkProcessor = this.getBulkProcessor();

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsOutputChannel.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsOutputChannel.java
@@ -1,0 +1,226 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.BiConsumer;
+
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.slf4j.Logger;
+
+/**
+ * EsOutputChannel
+ */
+public class EsOutputChannel extends Thread {
+
+    public static final Logger LOG = InlongLoggerFactory.getLogger(EsOutputChannel.class);
+
+    private LifecycleState status;
+    private EsSinkContext context;
+    private RestHighLevelClient esClient;
+    private BulkProcessor bulkProcessor;
+
+    /**
+     * Constructor
+     * 
+     * @param context
+     */
+    public EsOutputChannel(EsSinkContext context) {
+        super(context.getTaskName());
+        this.context = context;
+        this.status = LifecycleState.IDLE;
+    }
+
+    /**
+     * init
+     */
+    public void init() {
+        if (initEsclient()) {
+            initBulkprocessIfNeed();
+        }
+    }
+
+    /**
+     * getBulkProcessor
+     *
+     * @return
+     */
+    public BulkProcessor getBulkProcessor() {
+        if (bulkProcessor == null) {
+            if (initEsclient()) {
+                initBulkprocessIfNeed();
+            }
+        }
+        return bulkProcessor;
+    }
+
+    /**
+     * initEsclient
+     * 
+     * @return
+     */
+    private boolean initEsclient() {
+        try {
+            if (esClient == null || !esClient.ping(RequestOptions.DEFAULT)) {
+                String userName = context.getUsername();
+                String password = context.getPassword();
+
+                HttpHost[] httpHosts = context.getHttpHosts();
+                LOG.info("initEsclient:url:{},user:{},password:{}",
+                        Arrays.asList(httpHosts), userName, password);
+
+                RestClientBuilder builder = RestClient.builder(httpHosts);
+                final CredentialsProvider provider = new BasicCredentialsProvider();
+                provider.setCredentials(AuthScope.ANY,
+                        new UsernamePasswordCredentials(userName, password));
+                builder.setHttpClientConfigCallback((httpAsyncClientBuilder) -> {
+                    httpAsyncClientBuilder.disableAuthCaching();
+                    RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(120 * 1000).build();
+                    return httpAsyncClientBuilder.setDefaultCredentialsProvider(provider)
+                            .setMaxConnTotal(context.getMaxConnect())
+                            .setMaxConnPerRoute(context.getMaxConnect())
+                            .setDefaultRequestConfig(requestConfig);
+                });
+                esClient = new RestHighLevelClient(builder);
+            }
+        } catch (Exception e) {
+            LOG.error("init esclient failed.", e);
+            esClient = null;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * initBulkprocessIfNeed
+     * 
+     * @return
+     */
+    private boolean initBulkprocessIfNeed() {
+        try {
+            if (bulkProcessor == null) {
+                EsCallbackListener esListener = new EsCallbackListener(context);
+                BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer = (request, bulkListener) -> esClient
+                        .bulkAsync(request, RequestOptions.DEFAULT, bulkListener);
+                BulkProcessor bulkProcessor = BulkProcessor.builder(consumer, esListener)
+                        .setBulkActions(context.getBulkAction())
+                        .setBulkSize(new ByteSizeValue(context.getBulkSizeMb(), ByteSizeUnit.MB))
+                        .setFlushInterval(TimeValue.timeValueSeconds(context.getFlushInterval()))
+                        .setConcurrentRequests(context.getConcurrentRequests())
+                        .build();
+                this.bulkProcessor = bulkProcessor;
+            }
+        } catch (Exception e) {
+            LOG.error("init esclient failed", e);
+            esClient = null;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     *
+     * close
+     */
+    public void close() {
+        status = LifecycleState.STOP;
+        try {
+            this.bulkProcessor.close();
+        } catch (Exception e) {
+            LOG.error(String.format("close bulkProcessor:%s", e.getMessage()), e);
+        }
+        try {
+            this.esClient.close();
+        } catch (IOException e) {
+            LOG.error(String.format("close EsClient:%s", e.getMessage()), e);
+        }
+    }
+
+    /**
+     * run
+     */
+    @Override
+    public void run() {
+        status = LifecycleState.START;
+        LOG.info("start to EsOutputChannel:{},status:{}", context.getTaskName(), status);
+        while (status == LifecycleState.START) {
+            try {
+                this.send();
+            } catch (Throwable t) {
+                LOG.error(t.getMessage(), t);
+            }
+        }
+    }
+
+    /**
+     * send
+     * 
+     * @throws InterruptedException
+     */
+    private void send() throws InterruptedException {
+        EsIndexRequest indexRequest = null;
+        try {
+            BulkProcessor bulkProcessor = this.getBulkProcessor();
+            // check bulkProcessor
+            if (bulkProcessor == null) {
+                Thread.sleep(context.getProcessInterval());
+                return;
+            }
+            // get indexRequest
+            indexRequest = context.taskDispatchQueue();
+            if (indexRequest == null) {
+                Thread.sleep(context.getProcessInterval());
+                return;
+            }
+            // send
+            bulkProcessor.add(indexRequest);
+            context.addSendMetric(indexRequest.getEvent(), context.getTaskName());
+        } catch (Throwable e) {
+            LOG.error(e.getMessage(), e);
+            if (indexRequest != null) {
+                context.backDispatchQueue(indexRequest);
+                context.addSendResultMetric(indexRequest.getEvent(), context.getTaskName(), false,
+                        indexRequest.getSendTime());
+            }
+            try {
+                Thread.sleep(context.getProcessInterval());
+            } catch (InterruptedException e1) {
+                LOG.error(e1.getMessage(), e1);
+            }
+        }
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSink.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.flume.Context;
+import org.apache.flume.EventDeliveryException;
+import org.apache.flume.conf.Configurable;
+import org.apache.flume.sink.AbstractSink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * EsSink
+ */
+public class EsSink extends AbstractSink implements Configurable {
+
+    public static final Logger LOG = LoggerFactory.getLogger(EsSink.class);
+
+    private Context parentContext;
+    private final LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+    private EsSinkContext context;
+    // workers
+    private List<EsChannelWorker> workers = new ArrayList<>();
+    // output
+    private EsOutputChannel outputChannel;
+
+    /**
+     * start
+     */
+    @Override
+    public void start() {
+        super.start();
+        try {
+            this.context = new EsSinkContext(getName(), parentContext, getChannel(), dispatchQueue);
+            if (getChannel() == null) {
+                LOG.error("channel is null");
+            }
+            this.context.start();
+            for (int i = 0; i < context.getMaxThreads(); i++) {
+                EsChannelWorker worker = new EsChannelWorker(context, i);
+                this.workers.add(worker);
+                worker.start();
+            }
+            this.outputChannel = new EsOutputChannel(context);
+            this.outputChannel.init();
+            this.outputChannel.start();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * stop
+     */
+    @Override
+    public void stop() {
+        super.stop();
+        try {
+            this.context.close();
+            for (EsChannelWorker worker : this.workers) {
+                worker.close();
+            }
+            this.workers.clear();
+            this.outputChannel.close();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * configure
+     * 
+     * @param context
+     */
+    @Override
+    public void configure(Context context) {
+        LOG.info("start to configure:{}, context:{}.", this.getName(), context.toString());
+        this.parentContext = context;
+    }
+
+    /**
+     * process
+     * 
+     * @return                        Status
+     * @throws EventDeliveryException
+     */
+    @Override
+    public Status process() throws EventDeliveryException {
+        return Status.BACKOFF;
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSink.java
@@ -61,7 +61,7 @@ public class EsSink extends AbstractSink implements Configurable {
                 this.workers.add(worker);
                 worker.start();
             }
-            this.outputChannel = new EsOutputChannel(context);
+            this.outputChannel = EsSinkFactory.createEsOutputChannel(context);
             this.outputChannel.init();
             this.outputChannel.start();
         } catch (Exception e) {

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSink.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * 
  * EsSink
  */
 public class EsSink extends AbstractSink implements Configurable {
@@ -52,9 +51,6 @@ public class EsSink extends AbstractSink implements Configurable {
         super.start();
         try {
             this.context = new EsSinkContext(getName(), parentContext, getChannel(), dispatchQueue);
-            if (getChannel() == null) {
-                LOG.error("channel is null");
-            }
             this.context.start();
             for (int i = 0; i < context.getMaxThreads(); i++) {
                 EsChannelWorker worker = new EsChannelWorker(context, i);

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSinkContext.java
@@ -1,0 +1,599 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.lang.ClassUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.apache.http.HttpHost;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
+import org.apache.inlong.sort.standalone.config.pojo.InlongId;
+import org.apache.inlong.sort.standalone.config.pojo.SortTaskConfig;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
+import org.apache.inlong.sort.standalone.metrics.audit.AuditUtils;
+import org.apache.inlong.sort.standalone.sink.SinkContext;
+import org.apache.inlong.sort.standalone.utils.Constants;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.slf4j.Logger;
+
+import com.alibaba.fastjson.JSON;
+
+/**
+ * 
+ * EsSinkContext
+ */
+public class EsSinkContext extends SinkContext {
+
+    public static final Logger LOG = InlongLoggerFactory.getLogger(EsSinkContext.class);
+    public static final String KEY_NODE_ID = "nodeId";
+    public static final String KEY_USERNAME = "username";
+    public static final String KEY_PASSWORD = "password";
+    public static final String KEY_BULK_ACTION = "bulkAction";
+    public static final String KEY_BULK_SIZE_MB = "bulkSizeMb";
+    public static final String KEY_FLUSH_INTERVAL = "flushInterval";
+    public static final String KEY_CONCURRENT_REQUESTS = "concurrentRequests";
+    public static final String KEY_MAX_CONNECT = "maxConnect";
+    public static final String KEY_KEYWORD_MAX_LENGTH = "keywordMaxLength";
+    public static final String KEY_HTTP_HOSTS = "httpHosts";
+    public static final String KEY_EVENT_INDEXREQUEST_HANDLER = "indexRequestHandler";
+    public static final String KEY_IS_USE_INDEX_ID = "isUseIndexId";
+
+    public static final int DEFAULT_BULK_ACTION = 4000;
+    public static final int DEFAULT_BULK_SIZE_MB = 10;
+    public static final int DEFAULT_FLUSH_INTERVAL = 60;
+    public static final int DEFAULT_CONCURRENT_REQUESTS = 5;
+    public static final int DEFAULT_MAX_CONNECT = 10;
+    public static final int DEFAULT_KEYWORD_MAX_LENGTH = 32 * 1024 - 1;
+    public static final boolean DEFAULT_IS_USE_INDEX_ID = false;
+
+    private Context sinkContext;
+    private String nodeId;
+    private Map<String, EsIdConfig> idConfigMap = new ConcurrentHashMap<>();
+    private final LinkedBlockingQueue<EsIndexRequest> dispatchQueue;
+    private AtomicLong offerCounter = new AtomicLong(0);
+    private AtomicLong takeCounter = new AtomicLong(0);
+    private AtomicLong backCounter = new AtomicLong(0);
+    // rest client
+    private String username;
+    private String password;
+    private int bulkAction = DEFAULT_BULK_ACTION;
+    private int bulkSizeMb = DEFAULT_BULK_SIZE_MB;
+    private int flushInterval = DEFAULT_FLUSH_INTERVAL;
+    private int concurrentRequests = DEFAULT_CONCURRENT_REQUESTS;
+    private int maxConnect = DEFAULT_MAX_CONNECT;
+    private int keywordMaxLength = DEFAULT_KEYWORD_MAX_LENGTH;
+    private boolean isUseIndexId = DEFAULT_IS_USE_INDEX_ID;
+    // http host
+    private String strHttpHosts;
+    private HttpHost[] httpHosts;
+    // handler
+    private IEvent2IndexRequestHandler indexRequestHandler;
+
+    /**
+     * Constructor
+     * 
+     * @param sinkName
+     * @param context
+     * @param channel
+     * @param dispatchQueue
+     */
+    public EsSinkContext(String sinkName, Context context, Channel channel,
+            LinkedBlockingQueue<EsIndexRequest> dispatchQueue) {
+        super(sinkName, context, channel);
+        this.sinkContext = context;
+        this.dispatchQueue = dispatchQueue;
+        this.nodeId = CommonPropertiesHolder.getString(KEY_NODE_ID);
+    }
+
+    /**
+     * reload
+     */
+    public void reload() {
+        try {
+            LOG.info("SortTask:{},dispatchQueue:{},offer:{},take:{},back:{}",
+                    taskName, dispatchQueue.size(), offerCounter.getAndSet(0),
+                    takeCounter.getAndSet(0), backCounter.getAndSet(0));
+            SortTaskConfig newSortTaskConfig = SortClusterConfigHolder.getTaskConfig(taskName);
+            if (this.sortTaskConfig != null && this.sortTaskConfig.equals(newSortTaskConfig)) {
+                return;
+            }
+            LOG.info("get new SortTaskConfig:taskName:{}:config:{}", taskName,
+                    JSON.toJSONString(newSortTaskConfig));
+            this.sortTaskConfig = newSortTaskConfig;
+            this.sinkContext = new Context(this.sortTaskConfig.getSinkParams());
+            // parse the config of id and topic
+            Map<String, EsIdConfig> newIdConfigMap = new ConcurrentHashMap<>();
+            List<Map<String, String>> idList = this.sortTaskConfig.getIdParams();
+            for (Map<String, String> idParam : idList) {
+                String inlongGroupId = idParam.get(Constants.INLONG_GROUP_ID);
+                String inlongStreamId = idParam.get(Constants.INLONG_STREAM_ID);
+                String uid = InlongId.generateUid(inlongGroupId, inlongStreamId);
+                String jsonIdConfig = JSON.toJSONString(idParam);
+                EsIdConfig idConfig = JSON.parseObject(jsonIdConfig, EsIdConfig.class);
+                newIdConfigMap.put(uid, idConfig);
+            }
+            // change current config
+            this.idConfigMap = newIdConfigMap;
+            // rest client
+            this.username = sinkContext.getString(KEY_USERNAME);
+            this.password = sinkContext.getString(KEY_PASSWORD);
+            this.bulkAction = sinkContext.getInteger(KEY_BULK_ACTION, DEFAULT_BULK_ACTION);
+            this.bulkSizeMb = sinkContext.getInteger(KEY_BULK_SIZE_MB, DEFAULT_BULK_SIZE_MB);
+            this.flushInterval = sinkContext.getInteger(KEY_FLUSH_INTERVAL, DEFAULT_FLUSH_INTERVAL);
+            this.concurrentRequests = sinkContext.getInteger(KEY_CONCURRENT_REQUESTS, DEFAULT_CONCURRENT_REQUESTS);
+            this.maxConnect = sinkContext.getInteger(KEY_MAX_CONNECT, DEFAULT_MAX_CONNECT);
+            this.isUseIndexId = sinkContext.getBoolean(KEY_IS_USE_INDEX_ID, DEFAULT_IS_USE_INDEX_ID);
+            // http host
+            this.strHttpHosts = sinkContext.getString(KEY_HTTP_HOSTS);
+            if (!StringUtils.isBlank(strHttpHosts)) {
+                String[] strHttpHostArray = strHttpHosts.split("\\s+");
+                List<HttpHost> newHttpHosts = new ArrayList<>(strHttpHostArray.length);
+                for (String strHttpHost : strHttpHostArray) {
+                    String[] ipPort = strHttpHost.split(":");
+                    if (ipPort.length == 2 && NumberUtils.isDigits(ipPort[1])) {
+                        newHttpHosts.add(new HttpHost(ipPort[0], NumberUtils.toInt(ipPort[1])));
+                    }
+                }
+                if (newHttpHosts.size() > 0) {
+                    HttpHost[] newHostHostArray = new HttpHost[newHttpHosts.size()];
+                    this.httpHosts = newHttpHosts.toArray(newHostHostArray);
+                }
+            }
+            // IEvent2IndexRequestHandler
+            String indexRequestHandlerClass = CommonPropertiesHolder.getString(KEY_EVENT_INDEXREQUEST_HANDLER,
+                    DefaultEvent2IndexRequestHandler.class.getName());
+            try {
+                Class<?> handlerClass = ClassUtils.getClass(indexRequestHandlerClass);
+                Object handlerObject = handlerClass.getDeclaredConstructor().newInstance();
+                if (handlerObject instanceof IEvent2IndexRequestHandler) {
+                    this.indexRequestHandler = (IEvent2IndexRequestHandler) handlerObject;
+                }
+            } catch (Throwable t) {
+                LOG.error("Fail to init IEvent2IndexRequestHandler,handlerClass:{},error:{}",
+                        indexRequestHandlerClass, t.getMessage());
+            }
+            // log
+            LOG.info("end to get SortTaskConfig:taskName:{}:newIdConfigMap:{}", taskName,
+                    JSON.toJSONString(newIdConfigMap));
+        } catch (Throwable e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * addSendMetric
+     * 
+     * @param currentRecord
+     * @param bid
+     */
+    public void addSendMetric(ProfileEvent currentRecord, String bid) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        dimensions.put(SortMetricItem.KEY_TASK_NAME, this.getTaskName());
+        // metric
+        fillInlongId(currentRecord, dimensions);
+        dimensions.put(SortMetricItem.KEY_SINK_ID, this.getSinkName());
+        dimensions.put(SortMetricItem.KEY_SINK_DATA_ID, bid);
+        long msgTime = currentRecord.getRawLogTime();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(SortMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        SortMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        long count = 1;
+        long size = currentRecord.getBody().length;
+        metricItem.sendCount.addAndGet(count);
+        metricItem.sendSize.addAndGet(size);
+    }
+
+    /**
+     * addReadFailMetric
+     */
+    public void addSendFailMetric() {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        dimensions.put(SortMetricItem.KEY_SINK_ID, this.getSinkName());
+        long msgTime = System.currentTimeMillis();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(SortMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        SortMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        metricItem.readFailCount.incrementAndGet();
+    }
+
+    /**
+     * fillInlongId
+     * 
+     * @param currentRecord
+     * @param dimensions
+     */
+    public static void fillInlongId(ProfileEvent currentRecord, Map<String, String> dimensions) {
+        String inlongGroupId = currentRecord.getInlongGroupId();
+        inlongGroupId = (StringUtils.isBlank(inlongGroupId)) ? "-" : inlongGroupId;
+        String inlongStreamId = currentRecord.getInlongStreamId();
+        inlongStreamId = (StringUtils.isBlank(inlongStreamId)) ? "-" : inlongStreamId;
+        dimensions.put(SortMetricItem.KEY_INLONG_GROUP_ID, inlongGroupId);
+        dimensions.put(SortMetricItem.KEY_INLONG_STREAM_ID, inlongStreamId);
+    }
+
+    /**
+     * addSendResultMetric
+     * 
+     * @param currentRecord
+     * @param bid
+     * @param result
+     * @param sendTime
+     */
+    public void addSendResultMetric(ProfileEvent currentRecord, String bid, boolean result, long sendTime) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        dimensions.put(SortMetricItem.KEY_TASK_NAME, this.getTaskName());
+        // metric
+        fillInlongId(currentRecord, dimensions);
+        dimensions.put(SortMetricItem.KEY_SINK_ID, this.getSinkName());
+        dimensions.put(SortMetricItem.KEY_SINK_DATA_ID, bid);
+        long msgTime = currentRecord.getRawLogTime();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(SortMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        SortMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        long count = 1;
+        long size = currentRecord.getBody().length;
+        if (result) {
+            metricItem.sendSuccessCount.addAndGet(count);
+            metricItem.sendSuccessSize.addAndGet(size);
+            AuditUtils.add(AuditUtils.AUDIT_ID_SEND_SUCCESS, currentRecord);
+            if (sendTime > 0) {
+                long currentTime = System.currentTimeMillis();
+                long sinkDuration = currentTime - sendTime;
+                long nodeDuration = currentTime - NumberUtils.toLong(Constants.HEADER_KEY_SOURCE_TIME, msgTime);
+                long wholeDuration = currentTime - msgTime;
+                metricItem.sinkDuration.addAndGet(sinkDuration * count);
+                metricItem.nodeDuration.addAndGet(nodeDuration * count);
+                metricItem.wholeDuration.addAndGet(wholeDuration * count);
+            }
+        } else {
+            metricItem.sendFailCount.addAndGet(count);
+            metricItem.sendFailSize.addAndGet(size);
+        }
+    }
+
+    /**
+     * getIdConfig
+     * 
+     * @param  uid
+     * @return
+     */
+    public EsIdConfig getIdConfig(String uid) {
+        return this.idConfigMap.get(uid);
+    }
+
+    /**
+     * get nodeId
+     * 
+     * @return the nodeId
+     */
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    /**
+     * get idConfigMap
+     * 
+     * @return the idConfigMap
+     */
+    public Map<String, EsIdConfig> getIdConfigMap() {
+        return idConfigMap;
+    }
+
+    /**
+     * get sinkContext
+     * 
+     * @return the sinkContext
+     */
+    public Context getSinkContext() {
+        return sinkContext;
+    }
+
+    /**
+     * set sinkContext
+     * 
+     * @param sinkContext the sinkContext to set
+     */
+    public void setSinkContext(Context sinkContext) {
+        this.sinkContext = sinkContext;
+    }
+
+    /**
+     * offerDispatchQueue
+     * 
+     * @param  indexRequest
+     * @return
+     */
+    public boolean offerDispatchQueue(EsIndexRequest indexRequest) {
+        this.offerCounter.incrementAndGet();
+        return dispatchQueue.offer(indexRequest);
+    }
+
+    /**
+     * taskDispatchQueue
+     * 
+     * @return
+     */
+    public EsIndexRequest taskDispatchQueue() {
+        EsIndexRequest indexRequest = this.dispatchQueue.poll();
+        if (indexRequest != null) {
+            this.takeCounter.incrementAndGet();
+        }
+        return indexRequest;
+    }
+
+    /**
+     * backDispatchQueue
+     * 
+     * @param  indexRequest
+     * @return
+     */
+    public boolean backDispatchQueue(EsIndexRequest indexRequest) {
+        this.backCounter.incrementAndGet();
+        return dispatchQueue.offer(indexRequest);
+    }
+
+    /**
+     * get bulkAction
+     * 
+     * @return the bulkAction
+     */
+    public int getBulkAction() {
+        return bulkAction;
+    }
+
+    /**
+     * set bulkAction
+     * 
+     * @param bulkAction the bulkAction to set
+     */
+    public void setBulkAction(int bulkAction) {
+        this.bulkAction = bulkAction;
+    }
+
+    /**
+     * get bulkSizeMb
+     * 
+     * @return the bulkSizeMb
+     */
+    public int getBulkSizeMb() {
+        return bulkSizeMb;
+    }
+
+    /**
+     * set bulkSizeMb
+     * 
+     * @param bulkSizeMb the bulkSizeMb to set
+     */
+    public void setBulkSizeMb(int bulkSizeMb) {
+        this.bulkSizeMb = bulkSizeMb;
+    }
+
+    /**
+     * get flushInterval
+     * 
+     * @return the flushInterval
+     */
+    public int getFlushInterval() {
+        return flushInterval;
+    }
+
+    /**
+     * set flushInterval
+     * 
+     * @param flushInterval the flushInterval to set
+     */
+    public void setFlushInterval(int flushInterval) {
+        this.flushInterval = flushInterval;
+    }
+
+    /**
+     * get concurrentRequests
+     * 
+     * @return the concurrentRequests
+     */
+    public int getConcurrentRequests() {
+        return concurrentRequests;
+    }
+
+    /**
+     * set concurrentRequests
+     * 
+     * @param concurrentRequests the concurrentRequests to set
+     */
+    public void setConcurrentRequests(int concurrentRequests) {
+        this.concurrentRequests = concurrentRequests;
+    }
+
+    /**
+     * get maxConnect
+     * 
+     * @return the maxConnect
+     */
+    public int getMaxConnect() {
+        return maxConnect;
+    }
+
+    /**
+     * set maxConnect
+     * 
+     * @param maxConnect the maxConnect to set
+     */
+    public void setMaxConnect(int maxConnect) {
+        this.maxConnect = maxConnect;
+    }
+
+    /**
+     * get strHttpHosts
+     * 
+     * @return the strHttpHosts
+     */
+    public String getStrHttpHosts() {
+        return strHttpHosts;
+    }
+
+    /**
+     * set strHttpHosts
+     * 
+     * @param strHttpHosts the strHttpHosts to set
+     */
+    public void setStrHttpHosts(String strHttpHosts) {
+        this.strHttpHosts = strHttpHosts;
+    }
+
+    /**
+     * get httpHosts
+     * 
+     * @return the httpHosts
+     */
+    public HttpHost[] getHttpHosts() {
+        return httpHosts;
+    }
+
+    /**
+     * set httpHosts
+     * 
+     * @param httpHosts the httpHosts to set
+     */
+    public void setHttpHosts(HttpHost[] httpHosts) {
+        this.httpHosts = httpHosts;
+    }
+
+    /**
+     * set nodeId
+     * 
+     * @param nodeId the nodeId to set
+     */
+    public void setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    /**
+     * set idConfigMap
+     * 
+     * @param idConfigMap the idConfigMap to set
+     */
+    public void setIdConfigMap(Map<String, EsIdConfig> idConfigMap) {
+        this.idConfigMap = idConfigMap;
+    }
+
+    /**
+     * get username
+     * 
+     * @return the username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * set username
+     * 
+     * @param username the username to set
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * get password
+     * 
+     * @return the password
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * set password
+     * 
+     * @param password the password to set
+     */
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    /**
+     * get keywordMaxLength
+     * 
+     * @return the keywordMaxLength
+     */
+    public int getKeywordMaxLength() {
+        return keywordMaxLength;
+    }
+
+    /**
+     * set keywordMaxLength
+     * 
+     * @param keywordMaxLength the keywordMaxLength to set
+     */
+    public void setKeywordMaxLength(int keywordMaxLength) {
+        this.keywordMaxLength = keywordMaxLength;
+    }
+
+    /**
+     * get isUseIndexId
+     * 
+     * @return the isUseIndexId
+     */
+    public boolean isUseIndexId() {
+        return isUseIndexId;
+    }
+
+    /**
+     * set isUseIndexId
+     * 
+     * @param isUseIndexId the isUseIndexId to set
+     */
+    public void setUseIndexId(boolean isUseIndexId) {
+        this.isUseIndexId = isUseIndexId;
+    }
+
+    /**
+     * get indexRequestHandler
+     * 
+     * @return the indexRequestHandler
+     */
+    public IEvent2IndexRequestHandler getIndexRequestHandler() {
+        return indexRequestHandler;
+    }
+
+    /**
+     * set indexRequestHandler
+     * 
+     * @param indexRequestHandler the indexRequestHandler to set
+     */
+    public void setIndexRequestHandler(IEvent2IndexRequestHandler indexRequestHandler) {
+        this.indexRequestHandler = indexRequestHandler;
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSinkFactory.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSinkFactory.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+
+/**
+ * 
+ * SinkFactory
+ */
+public class EsSinkFactory {
+
+    /**
+     * createEsOutputChannel
+     * 
+     * @param  context
+     * @return
+     */
+    public static EsOutputChannel createEsOutputChannel(EsSinkContext context) {
+        return new EsOutputChannel(context);
+    }
+
+    /**
+     *
+     * createRestHighLevelClient
+     *
+     * @param  builder
+     * @return
+     */
+    public static RestHighLevelClient createRestHighLevelClient(RestClientBuilder builder) {
+        return new RestHighLevelClient(builder);
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/IEvent2IndexRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/IEvent2IndexRequestHandler.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+
+/**
+ * 
+ * IEvent2IndexRequestHandler
+ */
+public interface IEvent2IndexRequestHandler {
+
+    /**
+     * parse
+     * 
+     * @param  context
+     * @param  event
+     * @return
+     */
+    EsIndexRequest parse(EsSinkContext context, ProfileEvent event);
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/SortClusterConfig.conf
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/SortClusterConfig.conf
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 {
 		"clusterName":"esv3-sz-sz1",
 		"sortTasks":[

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/SortClusterConfig.conf
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/SortClusterConfig.conf
@@ -1,0 +1,68 @@
+{
+		"clusterName":"esv3-sz-sz1",
+		"sortTasks":[
+			{
+				"idParams":[
+					{
+						"inlongGroupId":"0fc00000046",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong0fc00000046_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo t1 t2 t3 t4",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"03600000045",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong03600000045_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo t1 t2 t3",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"05100054990",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong05100054990_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo field1 field2 field3 field4",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"09c00014434",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong09c00014434_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo id elog containerName cid setName ip",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"0c900035509",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong0c900035509_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo statTime msgTime senderIp containerName cid kafkaGroupId KafkaClusterId topic partitionId count size lastMaxOffset minOffset maxOffset minAckOffset maxAckOffset",
+						"fieldOffset":2,
+						"contentOffset":0
+					}
+				],
+				"name":"sid_es_es-rmrv7g7a_v3",
+				"sinkParams":{
+					"httpHosts":"127.0.0.1:9200",
+					"username":"elastic",
+					"password":"elastic",
+					"bulkAction":4000,
+					"bulkSizeMb":10,
+					"flushInterval":60,
+					"concurrentRequests":5,
+					"maxConnect":10,
+					"keywordMaxLength":32767,
+					"isUseIndexId":false
+				},
+				"type":"ElasticSearch"
+			}
+		]
+	}

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/common.properties
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/common.properties
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 clusterId=esv3-sz-sz1
 metricDomains=Sort
 metricDomains.Sort.domainListeners=org.apache.inlong.sort.standalone.metrics.prometheus.PrometheusMetricListener

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/common.properties
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/common.properties
@@ -1,0 +1,14 @@
+clusterId=esv3-sz-sz1
+metricDomains=Sort
+metricDomains.Sort.domainListeners=org.apache.inlong.sort.standalone.metrics.prometheus.PrometheusMetricListener
+metricDomains.Sort.snapshotInterval=60000
+sortChannel.type=org.apache.inlong.sort.standalone.channel.BufferQueueChannel
+sortSink.type=org.apache.inlong.sort.standalone.sink.elasticsearch.EsSink
+sortSource.type=org.apache.inlong.sort.standalone.source.readapi.ReadApiSource
+sortClusterConfig.type=org.apache.inlong.sort.standalone.config.loader.ClassResourceSortClusterConfigLoader
+
+indexRequestHandler=org.apache.inlong.sort.standalone.sink.elasticsearch.DefaultEvent2IndexRequestHandler
+
+maxThreads=10
+reloadInterval=60000
+processInterval=100

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestDefaultEvent2IndexRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestDefaultEvent2IndexRequestHandler.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * 
+ * TestDefaultEvent2IndexRequestHandler
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+public class TestDefaultEvent2IndexRequestHandler {
+
+    /**
+     * test
+     */
+    @Test
+    public void test() {
+        LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+        EsSinkContext context = TestEsSinkContext.mock(dispatchQueue);
+        ProfileEvent event = TestEsSinkContext.mockProfileEvent();
+        String uid = event.getUid();
+        EsIdConfig idConfig = context.getIdConfig(uid);
+        String indexName = idConfig.parseIndexName(event.getRawLogTime());
+        DefaultEvent2IndexRequestHandler handler = new DefaultEvent2IndexRequestHandler();
+        EsIndexRequest indexRequest = handler.parse(context, event);
+        assertEquals(indexName, indexRequest.index());
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestDefaultEvent2IndexRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestDefaultEvent2IndexRequestHandler.java
@@ -36,7 +36,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class TestDefaultEvent2IndexRequestHandler {
 
     /**
-     * test
+     * test that ProfileEvent transform to EsIndexRequest
      */
     @Test
     public void test() {

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsCallbackListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsCallbackListener.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.elasticsearch.action.DocWriteRequest.OpType;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * 
+ * TestEsCallbackListener
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+@PrepareForTest({EsSinkFactory.class})
+public class TestEsCallbackListener {
+
+    private EsSinkContext context;
+
+    @Before
+    public void before() {
+        LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+        this.context = TestEsSinkContext.mock(dispatchQueue);
+    }
+
+    /**
+     * testBeforeBulk
+     */
+    @Test
+    public void testBeforeBulk() {
+        try {
+            // prepare
+            ProfileEvent event = TestEsSinkContext.mockProfileEvent();
+            EsIndexRequest indexRequest = context.getIndexRequestHandler().parse(context, event);
+            long executionId = 0;
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.add(indexRequest);
+            // test
+            EsCallbackListener listener = new EsCallbackListener(context);
+            listener.beforeBulk(executionId, bulkRequest);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * testAfterSuccessBulk
+     */
+    @Test
+    public void testAfterSuccessBulk() {
+        try {
+            // prepare
+            LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+            EsSinkContext context = TestEsSinkContext.mock(dispatchQueue);
+            ProfileEvent event = TestEsSinkContext.mockProfileEvent();
+            EsIndexRequest indexRequest = context.getIndexRequestHandler().parse(context, event);
+            long executionId = 0;
+            EsCallbackListener listener = new EsCallbackListener(context);
+            // request
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.add(indexRequest);
+            // success response
+            IndexResponse indexResponse = new IndexResponse();
+            BulkItemResponse itemResponse = new BulkItemResponse(0, OpType.INDEX, indexResponse);
+            BulkItemResponse[] responses = new BulkItemResponse[1];
+            responses[0] = itemResponse;
+            BulkResponse bulkResponse = new BulkResponse(responses, 0);
+            listener.afterBulk(executionId, bulkRequest, bulkResponse);
+
+            // fail resend
+            BulkItemResponse.Failure failure = new BulkItemResponse.Failure("index", OpType.INDEX.name(), "id",
+                    new Exception());
+            BulkItemResponse failResponse = new BulkItemResponse(0, OpType.INDEX, failure);
+            responses[0] = failResponse;
+            listener.afterBulk(executionId, bulkRequest, bulkResponse);
+
+            // failNull noResend
+            BulkItemResponse.Failure failureNull = new BulkItemResponse.Failure("index", OpType.INDEX.name(), "id",
+                    null);
+            BulkItemResponse failNullResponse = new BulkItemResponse(0, OpType.INDEX, failureNull);
+            responses[0] = failNullResponse;
+            listener.afterBulk(executionId, bulkRequest, bulkResponse);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * testAfterFailureBulk
+     */
+    @Test
+    public void testAfterFailureBulk() {
+        try {
+            // prepare
+            LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+            EsSinkContext context = TestEsSinkContext.mock(dispatchQueue);
+            ProfileEvent event = TestEsSinkContext.mockProfileEvent();
+            EsIndexRequest indexRequest = context.getIndexRequestHandler().parse(context, event);
+            long executionId = 0;
+            EsCallbackListener listener = new EsCallbackListener(context);
+            // request
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.add(indexRequest);
+
+            // fail resend
+            listener.afterBulk(executionId, bulkRequest, new Exception());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsChannelWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsChannelWorker.java
@@ -17,8 +17,6 @@
 
 package org.apache.inlong.sort.standalone.sink.elasticsearch;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.apache.flume.Transaction;
@@ -66,7 +64,6 @@ public class TestEsChannelWorker {
             // test
             EsChannelWorker worker = new EsChannelWorker(context, 0);
             worker.doRun();
-            assertEquals(true, (this.context.taskDispatchQueue() != null));
             worker.start();
             worker.close();
         } catch (Exception e) {

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsChannelWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsChannelWorker.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.flume.Transaction;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * 
+ * TestEsChannelWorker
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+@PrepareForTest({EsSinkFactory.class})
+public class TestEsChannelWorker {
+
+    private EsSinkContext context;
+
+    /**
+     * before
+     */
+    @Before
+    public void before() {
+        LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+        this.context = TestEsSinkContext.mock(dispatchQueue);
+    }
+
+    /**
+     * test
+     */
+    @Test
+    public void test() {
+        try {
+            // prepare
+            ProfileEvent event = TestEsSinkContext.mockProfileEvent();
+            Transaction tx = this.context.getChannel().getTransaction();
+            tx.begin();
+            this.context.getChannel().put(event);
+            tx.commit();
+            tx.close();
+            // test
+            EsChannelWorker worker = new EsChannelWorker(context, 0);
+            worker.doRun();
+            assertEquals(true, (this.context.taskDispatchQueue() != null));
+            worker.start();
+            worker.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsOutputChannel.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsOutputChannel.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.ClusterClient;
+import org.elasticsearch.client.IndicesClient;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * 
+ * TestEsOutputChannel
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+@PrepareForTest({EsSinkFactory.class, RestHighLevelClient.class, ClusterClient.class, IndicesClient.class})
+public class TestEsOutputChannel {
+
+    private RestHighLevelClient esClient;
+
+    /**
+     * mock
+     * 
+     * @return
+     * @throws Exception
+     */
+    public static EsOutputChannel mock() throws Exception {
+        EsOutputChannel output = PowerMockito.mock(EsOutputChannel.class);
+        PowerMockito.when(EsSinkFactory.class, "createEsOutputChannel", any()).thenReturn(output);
+        PowerMockito.doNothing().when(output, "close");
+        //
+        BulkProcessor bulkProcessor = PowerMockito.mock(BulkProcessor.class);
+        PowerMockito.when(bulkProcessor, "add", any()).thenReturn(bulkProcessor);
+        PowerMockito.when(output, "getBulkProcessor").thenReturn(bulkProcessor);
+        PowerMockito.when(output, "initEsclient").thenReturn(true);
+        return output;
+    }
+
+    /**
+     * before
+     * 
+     * @throws Throwable
+     */
+    @SuppressWarnings("unchecked")
+    @Before
+    public void before() throws Throwable {
+        PowerMockito.mockStatic(EsSinkFactory.class);
+        this.esClient = PowerMockito.mock(RestHighLevelClient.class);
+        PowerMockito.mockStatic(RestHighLevelClient.class);
+        PowerMockito.when(EsSinkFactory.createRestHighLevelClient(any())).thenReturn(esClient);
+        PowerMockito.doNothing().when(esClient).close();
+        PowerMockito.doNothing().when(esClient).bulkAsync(any(BulkRequest.class), any(RequestOptions.class),
+                any(ActionListener.class));
+        PowerMockito.when(esClient.ping(any(RequestOptions.class))).thenReturn(false);
+
+        // ClusterClient
+        ClusterClient clusterClient = PowerMockito.mock(ClusterClient.class);
+        PowerMockito.when(esClient, "cluster").thenReturn(clusterClient);
+        ClusterUpdateSettingsResponse clusterResponse = PowerMockito.mock(ClusterUpdateSettingsResponse.class);
+        PowerMockito.when(clusterClient.putSettings(any(ClusterUpdateSettingsRequest.class),
+                any(RequestOptions.class))).thenReturn(clusterResponse);
+        // IndicesClient
+        IndicesClient indicesClient = PowerMockito.mock(IndicesClient.class);
+        PowerMockito.when(esClient, "indices").thenReturn(indicesClient);
+        AcknowledgedResponse indicesResponse = PowerMockito.mock(AcknowledgedResponse.class);
+        PowerMockito.when(indicesClient.putSettings(any(UpdateSettingsRequest.class),
+                any(RequestOptions.class))).thenReturn(indicesResponse);
+    }
+
+    /**
+     * test
+     */
+    @Test
+    public void test() {
+        try {
+            LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+            EsSinkContext context = TestEsSinkContext.mock(dispatchQueue);
+            EsOutputChannel output = new EsOutputChannel(context);
+            ProfileEvent event = TestEsSinkContext.mockProfileEvent();
+            EsIndexRequest indexRequest = context.getIndexRequestHandler().parse(context, event);
+            dispatchQueue.add(indexRequest);
+            output.init();
+            output.send();
+            output.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsSinkContext.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.elasticsearch;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.apache.inlong.sort.standalone.channel.BufferQueueChannel;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.sort.standalone.config.pojo.SortTaskConfig;
+import org.apache.inlong.sort.standalone.utils.Constants;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * 
+ * TestEsSinkContext
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+public class TestEsSinkContext {
+
+    public static final String TEST_INLONG_GROUP_ID = "0fc00000046";
+    public static final String TEST_INLONG_STREAM_ID = "";
+    public static final String TEST_CONTENT = "field1|field2|field3|field4";
+
+    /**
+     * mock
+     * 
+     * @param  dispatchQueue
+     * @return
+     */
+    public static EsSinkContext mock(LinkedBlockingQueue<EsIndexRequest> dispatchQueue) {
+        Context context = CommonPropertiesHolder.getContext();
+        String sinkName = CommonPropertiesHolder.getClusterId() + "Sink";
+        context.put(SortTaskConfig.KEY_TASK_NAME, "sid_es_es-rmrv7g7a_v3");
+        Channel channel = new BufferQueueChannel();
+        EsSinkContext esSinkContext = new EsSinkContext(sinkName, context, channel, dispatchQueue);
+        esSinkContext.reload();
+        return esSinkContext;
+    }
+
+    /**
+     * mockProfileEvent
+     * 
+     * @param  inlongGroupId
+     * @param  inlongStreamId
+     * @param  content
+     * @return
+     */
+    public static ProfileEvent mockProfileEvent(String inlongGroupId, String inlongStreamId, String content) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.INLONG_GROUP_ID, inlongGroupId);
+        headers.put(Constants.INLONG_STREAM_ID, inlongStreamId);
+        headers.put(Constants.HEADER_KEY_MSG_TIME, String.valueOf(System.currentTimeMillis()));
+        headers.put(Constants.HEADER_KEY_SOURCE_IP, "127.0.0.1");
+        byte[] body = content.getBytes(Charset.defaultCharset());
+        return new ProfileEvent(body, headers);
+    }
+
+    /**
+     * mockProfileEvent
+     * 
+     * @return
+     */
+    public static ProfileEvent mockProfileEvent() {
+        return mockProfileEvent(TEST_INLONG_STREAM_ID, TEST_INLONG_GROUP_ID, TEST_CONTENT);
+    }
+
+    /**
+     * test
+     */
+    @Test
+    public void test() {
+        LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+        EsSinkContext context = mock(dispatchQueue);
+        assertEquals(10, context.getBulkSizeMb());
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/source/sortsdk/TestSortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/source/sortsdk/TestSortSdkSource.java
@@ -38,7 +38,7 @@ import java.util.List;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({SortClusterConfigHolder.class, LoggerFactory.class, Logger.class, MetricRegister.class})
-public class SortSdkSourceTest {
+public class TestSortSdkSource {
 
     private Context mockContext;
 

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/source/sortsdk/TestSortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/source/sortsdk/TestSortSdkSource.java
@@ -45,8 +45,8 @@ public class TestSortSdkSource {
     @Before
     public void setUp() {
         PowerMockito.mockStatic(LoggerFactory.class);
-        Logger LOG = PowerMockito.mock(Logger.class);
-        PowerMockito.when(LoggerFactory.getLogger(Mockito.any(Class.class))).thenReturn(LOG);
+        Logger log = PowerMockito.mock(Logger.class);
+        PowerMockito.when(LoggerFactory.getLogger(Mockito.any(Class.class))).thenReturn(log);
         PowerMockito.mockStatic(MetricRegister.class);
 
         PowerMockito.mockStatic(SortClusterConfigHolder.class);

--- a/inlong-sort-standalone/sort-standalone-source/src/test/resources/SortClusterConfig.conf
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/resources/SortClusterConfig.conf
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+{
+		"clusterName":"esv3-sz-sz1",
+		"sortTasks":[
+			{
+				"idParams":[
+					{
+						"inlongGroupId":"0fc00000046",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong0fc00000046_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo t1 t2 t3 t4",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"03600000045",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong03600000045_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo t1 t2 t3",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"05100054990",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong05100054990_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo field1 field2 field3 field4",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"09c00014434",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong09c00014434_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo id elog containerName cid setName ip",
+						"fieldOffset":2,
+						"contentOffset":0
+					},
+					{
+						"inlongGroupId":"0c900035509",
+						"inlongStreamId":"",
+						"separator":"|",
+						"indexNamePattern":"inlong0c900035509_{yyyyMMdd}",
+						"fieldNames":"ftime extinfo statTime msgTime senderIp containerName cid kafkaGroupId KafkaClusterId topic partitionId count size lastMaxOffset minOffset maxOffset minAckOffset maxAckOffset",
+						"fieldOffset":2,
+						"contentOffset":0
+					}
+				],
+				"name":"sid_es_es-rmrv7g7a_v3",
+				"sinkParams":{
+					"httpHosts":"127.0.0.1:9200",
+					"username":"elastic",
+					"password":"elastic",
+					"bulkAction":4000,
+					"bulkSizeMb":10,
+					"flushInterval":60,
+					"concurrentRequests":5,
+					"maxConnect":10,
+					"keywordMaxLength":32767,
+					"isUseIndexId":false
+				},
+				"type":"ElasticSearch"
+			}
+		]
+	}

--- a/inlong-sort-standalone/sort-standalone-source/src/test/resources/common.properties
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/resources/common.properties
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+clusterId=esv3-sz-sz1
+metricDomains=Sort
+metricDomains.Sort.domainListeners=org.apache.inlong.sort.standalone.metrics.prometheus.PrometheusMetricListener
+metricDomains.Sort.snapshotInterval=60000
+sortChannel.type=org.apache.inlong.sort.standalone.channel.BufferQueueChannel
+sortSink.type=org.apache.inlong.sort.standalone.sink.elasticsearch.EsSink
+sortSource.type=org.apache.inlong.sort.standalone.source.readapi.ReadApiSource
+sortClusterConfig.type=org.apache.inlong.sort.standalone.config.loader.ClassResourceSortClusterConfigLoader
+
+indexRequestHandler=org.apache.inlong.sort.standalone.sink.elasticsearch.DefaultEvent2IndexRequestHandler
+
+maxThreads=10
+reloadInterval=60000
+processInterval=100


### PR DESCRIPTION
### Title Name: [INLONG-2326][Inlong-SortStandalone] Inlong-Sort-Standalone support to sort the events to ElasticSearch cluster.

Fixes #2326 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
