### PR TITLE
[INLONG-2344][Bug][InLong-Sort] Fix kafka sink ut failed under multithread compiling

### DIFF
--- a/inlong-sort/sort-single-tenant/src/test/java/org/apache/inlong/sort/singletenant/flink/kafka/KafkaSinkTestBase.java
+++ b/inlong-sort/sort-single-tenant/src/test/java/org/apache/inlong/sort/singletenant/flink/kafka/KafkaSinkTestBase.java
@@ -66,7 +66,6 @@ public abstract class KafkaSinkTestBase {
     public static TemporaryFolder tempFolder = new TemporaryFolder();
 
     private final int zkTimeout = 30000;
-    private final String topic = "test_kafka_sink";
 
     private TestingServer zkServer;
 
@@ -77,20 +76,21 @@ public abstract class KafkaSinkTestBase {
     private Properties kafkaClientProperties;
 
     // prepare data below in subclass
+    protected String topic;
     protected List<Row> testRows;
     protected FieldInfo[] fieldInfos;
     protected SerializationInfo serializationInfo;
 
     @Before
     public void setup() throws Exception {
+        prepareData();
+
         startZK();
         startKafkaServer();
         prepareKafkaClientProps();
         kafkaAdmin = AdminClient.create(kafkaClientProperties);
         addTopic();
         kafkaConsumer = new KafkaConsumer<>(kafkaClientProperties);
-
-        prepareData();
     }
 
     private void startZK() throws Exception {
@@ -150,9 +150,16 @@ public abstract class KafkaSinkTestBase {
     @After
     public void clean() throws IOException {
         kafkaConsumer.close();
+        kafkaConsumer = null;
+
         kafkaAdmin.close();
+        kafkaAdmin = null;
+
         kafkaServer.shutdown();
+        kafkaServer = null;
+
         zkServer.close();
+        zkServer = null;
     }
 
     @Test(timeout = 3 * 60 * 1000)

--- a/inlong-sort/sort-single-tenant/src/test/java/org/apache/inlong/sort/singletenant/flink/kafka/RowToJsonKafkaSinkTest.java
+++ b/inlong-sort/sort-single-tenant/src/test/java/org/apache/inlong/sort/singletenant/flink/kafka/RowToJsonKafkaSinkTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertNull;
 public class RowToJsonKafkaSinkTest extends KafkaSinkTestBase {
     @Override
     protected void prepareData() {
+        topic = "test_kafka_row_to_json";
         prepareKafkaSinkInfo();
         prepareTestRows();
     }

--- a/inlong-sort/sort-single-tenant/src/test/java/org/apache/inlong/sort/singletenant/flink/kafka/RowToStringKafkaSinkTest.java
+++ b/inlong-sort/sort-single-tenant/src/test/java/org/apache/inlong/sort/singletenant/flink/kafka/RowToStringKafkaSinkTest.java
@@ -35,6 +35,7 @@ public class RowToStringKafkaSinkTest extends KafkaSinkTestBase {
 
     @Override
     protected void prepareData() {
+        topic = "test_kafka_row_to_string";
         prepareKafkaSinkInfo();
         prepareTestRows();
     }


### PR DESCRIPTION
### Title Name: [INLONG-2344][Bug][InLong-Sort] Fix kafka sink ut failed under multithread compiling

Fixes #2344 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
