### PR TITLE
[INLONG-1896][Feature][Sort]  Inlong-Sort-Standalone support to sort the events to Kafka clusters.

### DIFF
--- a/inlong-sort-standalone/pom.xml
+++ b/inlong-sort-standalone/pom.xml
@@ -43,6 +43,7 @@
         <flume.version>1.9.0</flume.version>
         <plugin.assembly.version>3.2.0</plugin.assembly.version>
         <pulsar.version>2.7.2</pulsar.version>
+        <kafka.version>2.4.1</kafka.version>
         <junit.version>4.13</junit.version>
         <powermock.version>2.0.2</powermock.version>
         <guava.version>19.0</guava.version>
@@ -50,7 +51,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler.source>1.8</compiler.source>
         <compiler.target>1.8</compiler.target>
-        <pulsar.version>2.7.2</pulsar.version>
         <hadoop.version>2.10.1</hadoop.version>
         <hive.version>2.3.9</hive.version>
         <fastjson.version>1.2.79</fastjson.version>
@@ -101,6 +101,11 @@
                     <groupId>com.google.guava</groupId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSink.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.kafka;
+
+import org.apache.flume.Context;
+import org.apache.flume.Sink;
+import org.apache.flume.conf.Configurable;
+import org.apache.flume.sink.AbstractSink;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KafkaFederationSink extends AbstractSink implements Configurable {
+    private static final Logger LOG = InlongLoggerFactory.getLogger(KafkaFederationSink.class);
+    private Context parentContext;
+    private KafkaFederationSinkContext context;
+    private List<KafkaFederationWorker> workers = new ArrayList<>();
+    private Map<String, String> dimensions;
+
+    /** init and start workers */
+    @Override
+    public void start() {
+        String sinkName = this.getName();
+        if (getChannel() == null) {
+            LOG.error("channel is null");
+        }
+        this.context = new KafkaFederationSinkContext(getName(), parentContext, getChannel());
+        this.context.start();
+        this.dimensions = new HashMap<>();
+        this.dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.context.getClusterId());
+        this.dimensions.put(SortMetricItem.KEY_TASK_NAME, this.context.getTaskName());
+        this.dimensions.put(SortMetricItem.KEY_SINK_ID, this.context.getSinkName());
+        // create worker
+        for (int i = 0; i < context.getMaxThreads(); i++) {
+            KafkaFederationWorker worker = new KafkaFederationWorker(sinkName, i, context);
+            LOG.info("new kafka worker, the context is {}", context.toString());
+            worker.start();
+            this.workers.add(worker);
+        }
+        super.start();
+    }
+
+    /** stop */
+    @Override
+    public void stop() {
+        LOG.info("stop kafka sink");
+        for (KafkaFederationWorker worker : workers) {
+            try {
+                worker.close();
+            } catch (Throwable e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+        this.context.close();
+        super.stop();
+    }
+
+    /**
+     * configure
+     * @param context context
+     */
+    @Override
+    public void configure(Context context) {
+        LOG.info(
+                "start to configure:{}, context:{}.",
+                this.getClass().getSimpleName(),
+                context.toString());
+        this.parentContext = context;
+    }
+
+    /**
+     * process
+     * @return Status
+     */
+    @Override
+    public Sink.Status process() {
+        return Sink.Status.BACKOFF;
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSinkContext.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.kafka;
+
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
+import org.apache.inlong.sort.standalone.config.pojo.CacheClusterConfig;
+import org.apache.inlong.sort.standalone.config.pojo.InlongId;
+import org.apache.inlong.sort.standalone.config.pojo.SortTaskConfig;
+import org.apache.inlong.sort.standalone.sink.SinkContext;
+import org.apache.inlong.sort.standalone.utils.Constants;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Context of kafka sink. */
+public class KafkaFederationSinkContext extends SinkContext {
+    public static final Logger LOG =
+            InlongLoggerFactory.getLogger(KafkaFederationSinkContext.class);
+
+    private Context producerContext;
+    private Map<String, String> idTopicMap = new ConcurrentHashMap<>();
+    private List<CacheClusterConfig> clusterConfigList = new ArrayList<>();
+
+    public KafkaFederationSinkContext(String sinkName, Context context, Channel channel) {
+        super(sinkName, context, channel);
+    }
+
+    /** reload context */
+    @Override
+    public void reload() {
+        LOG.info("reload KafkaFederationSinkContext.");
+        try {
+            SortTaskConfig newSortTaskConfig = SortClusterConfigHolder.getTaskConfig(taskName);
+            if (newSortTaskConfig == null) {
+                LOG.error("newSortTaskConfig is null.");
+                return;
+            }
+            if (this.sortTaskConfig != null && this.sortTaskConfig.equals(newSortTaskConfig)) {
+                LOG.info("Same sortTaskConfig, do nothing.");
+                return;
+            }
+            this.sortTaskConfig = newSortTaskConfig;
+            this.producerContext = new Context(this.sortTaskConfig.getSinkParams());
+
+            LOG.info("reload idTopicMap");
+            Map<String, String> newIdTopicMap = new ConcurrentHashMap<>();
+            List<Map<String, String>> idList = this.sortTaskConfig.getIdParams();
+            for (Map<String, String> idParam : idList) {
+                String inlongGroupId = idParam.get(Constants.INLONG_GROUP_ID);
+                String inlongStreamId = idParam.get(Constants.INLONG_STREAM_ID);
+                String uid = InlongId.generateUid(inlongGroupId, inlongStreamId);
+                String topic = idParam.getOrDefault(Constants.TOPIC, uid);
+                newIdTopicMap.put(uid, topic);
+            }
+
+            LOG.info("reload clusterConfig");
+            CacheClusterConfig clusterConfig = new CacheClusterConfig();
+            clusterConfig.setClusterName(this.taskName);
+            clusterConfig.setParams(this.sortTaskConfig.getSinkParams());
+            List<CacheClusterConfig> newClusterConfigList = new ArrayList<>();
+            newClusterConfigList.add(clusterConfig);
+            this.idTopicMap = newIdTopicMap;
+            this.clusterConfigList = newClusterConfigList;
+        } catch (Throwable e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * get ProducerContext
+     *
+     * @return ProducerContext
+     */
+    public Context getProducerContext() {
+        return producerContext;
+    }
+
+    /**
+     * get ClusterConfigList
+     *
+     * @return ClusterConfigList
+     */
+    public List<CacheClusterConfig> getClusterConfigList() {
+        return clusterConfigList;
+    }
+
+    /**
+     * get Topic by uid
+     *
+     * @param uid uid
+     * @return topic
+     */
+    public String getTopic(String uid) {
+        String topic = this.idTopicMap.get(uid);
+        if (topic == null) {
+            throw new NullPointerException("uid " + uid + "got null topic");
+        }
+        return topic;
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.kafka;
+
+import com.google.common.base.Preconditions;
+import org.apache.flume.Channel;
+import org.apache.flume.Event;
+import org.apache.flume.Transaction;
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.config.pojo.InlongId;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
+import org.apache.inlong.sort.standalone.utils.Constants;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class KafkaFederationWorker extends Thread {
+    public static final Logger LOG = InlongLoggerFactory.getLogger(KafkaFederationWorker.class);
+
+    private final String workerName;
+    private final KafkaFederationSinkContext context;
+
+    private KafkaProducerFederation producerFederation;
+    private LifecycleState status;
+    private Map<String, String> dimensions = new ConcurrentHashMap<>();
+
+    /**
+     * constructor of KafkaFederationWorker
+     *
+     * @param sinkName
+     * @param workerIndex
+     * @param context
+     */
+    public KafkaFederationWorker(
+            String sinkName, int workerIndex, KafkaFederationSinkContext context) {
+        super();
+        this.workerName = sinkName + "-" + workerIndex;
+        this.context = Preconditions.checkNotNull(context);
+        this.producerFederation =
+                new KafkaProducerFederation(String.valueOf(workerIndex), this.context);
+        this.status = LifecycleState.IDLE;
+        this.dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.context.getClusterId());
+        this.dimensions.put(SortMetricItem.KEY_TASK_NAME, this.context.getTaskName());
+        this.dimensions.put(SortMetricItem.KEY_SINK_ID, this.context.getSinkName());
+    }
+
+    /** entrance of KafkaFederationWorker */
+    @Override
+    public void start() {
+        LOG.info("start a new kafka worker {}", this.workerName);
+        this.producerFederation.start();
+        this.status = LifecycleState.START;
+        super.start();
+    }
+
+    /** close */
+    public void close() {
+        // close all producers
+        LOG.info("close a kafka worker {}", this.workerName);
+        this.producerFederation.close();
+        this.status = LifecycleState.STOP;
+    }
+
+    @Override
+    public void run() {
+        LOG.info("worker {} start to run, the state is {}", this.workerName, status.name());
+        while (status != LifecycleState.STOP) {
+            Transaction tx = null;
+            try {
+                Channel channel = context.getChannel();
+                if (channel == null) {
+                    LOG.error("in kafka worker, channel is null ");
+                    break;
+                }
+                tx = channel.getTransaction();
+                tx.begin();
+                Event rowEvent = channel.take();
+                if (rowEvent == null) {
+                    tx.commit();
+                    tx.close();
+                    sleepOneInterval();
+                    continue;
+                }
+                ProfileEvent event = (ProfileEvent) rowEvent;
+                this.fillTopic(event);
+                SortMetricItem.fillInlongId(event, dimensions);
+                this.dimensions.put(
+                        SortMetricItem.KEY_SINK_DATA_ID, event.getHeaders().get(Constants.TOPIC));
+                long msgTime = event.getRawLogTime();
+                long auditFormatTime = msgTime - msgTime % 60000L;
+                dimensions.put(SortMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+                SortMetricItem metricItem =
+                        this.context.getMetricItemSet().findMetricItem(dimensions);
+                metricItem.sendCount.incrementAndGet();
+                metricItem.sendSize.addAndGet(event.getBody().length);
+                this.producerFederation.send(event, tx);
+            } catch (Exception e) {
+                LOG.error(e.getMessage(), e);
+                if (tx != null) {
+                    tx.rollback();
+                    tx.close();
+                }
+                // metric
+                SortMetricItem metricItem =
+                        this.context.getMetricItemSet().findMetricItem(dimensions);
+                metricItem.sendFailCount.incrementAndGet();
+                sleepOneInterval();
+            }
+        }
+    }
+
+    /**
+     * fillTopic
+     *
+     * @param event
+     */
+    private void fillTopic(Event event) {
+        Map<String, String> headers = event.getHeaders();
+        String inlongGroupId = headers.get(Constants.INLONG_GROUP_ID);
+        String inlongStreamId = headers.get(Constants.INLONG_STREAM_ID);
+        String uid = InlongId.generateUid(inlongGroupId, inlongStreamId);
+        String topic = this.context.getTopic(uid);
+        if (!StringUtils.isBlank(topic)) {
+            headers.put(Constants.TOPIC, topic);
+        }
+    }
+
+    /** sleepOneInterval */
+    private void sleepOneInterval() {
+        try {
+            Thread.sleep(context.getProcessInterval());
+        } catch (InterruptedException e1) {
+            LOG.error(e1.getMessage(), e1);
+        }
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaProducerCluster.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaProducerCluster.java
@@ -1,0 +1,235 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.kafka;
+
+import com.google.common.base.Preconditions;
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.Transaction;
+import org.apache.flume.lifecycle.LifecycleAware;
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.sort.standalone.config.pojo.CacheClusterConfig;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
+import org.apache.inlong.sort.standalone.metrics.audit.AuditUtils;
+import org.apache.inlong.sort.standalone.utils.Constants;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.pulsar.shade.org.apache.commons.lang.math.NumberUtils;
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/** wrapper of kafka producer */
+public class KafkaProducerCluster implements LifecycleAware {
+    public static final Logger LOG = InlongLoggerFactory.getLogger(KafkaProducerCluster.class);
+
+    private static final String KEY_RETRIES = "retries";
+    private static final String KEY_ACKS = "acks";
+    private static final String KEY_BATCH_SIZE = "batch.size";
+    private static final String KEY_LINGER_MS = "linger.ms";
+    private static final String KEY_MAX_REQUEST_SIZE = "max.request.size";
+    private static final String KEY_BUFFER_MEMORY = "buffer.memory";
+    private static final String KEY_RECEIVE_BUFFER_BYTES = "receive.buffer.bytes";
+    private static final String KEY_SEND_BUFFER_BYTES = "send.buffer.bytes";
+    private static final String KEY_METADATA_FETCH_TIMEOUT_MS = "metadata.fetch.timeout.ms";
+    private static final String KEY_METADATA_MAX_AGE_MS = "metadata.max.age.ms";
+    private static final String KEY_COMPRESSION_TYPE = "compression.type";
+    private static final String KEY_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION =
+            "max.in.flight.requests.per.connection";
+    private static final String KEY_TIMEOUT_MS = "rpc.timeout.ms";
+    private static final String KEY_DELIVERY_TIMEOUT_MS = "delivery.timeout.ms";
+    private static final String KEY_REQUEST_TIMEOUT_MS = "request.timeout.ms";
+    private static final String KEY_ENABLE_REPLACE_PARTITION_FOR_NOT_LEADER =
+            "enable.replace.partition.for.not.leader";
+    private static final String KEY_ENABLE_REPLACE_PARTITION_FOR_CAN_RETRY =
+            "enable.replace.partition.for.can.retry";
+    private static final String KEY_ENABLE_TOPIC_PARTITION_CIRCUIT_BREAKER =
+            "enable.topic.partition.circuit.breaker";
+    private static final String KEY_MUTE_PARTITION_ERROR_MAX_TIMES =
+            "mute.partition.error.max.times";
+    private static final String KEY_MUTE_PARTITION_MAX_PERCENTAGE = "mute.partition.max.percentage";
+    private static final String KEY_UNMUTE_PARTITION_INTERVAL_MS = "unmute.partition.interval.ms";
+    private static final String KEY_MAX_BLOCK_MS = "max.block.ms";
+    private static final String KEY_METRIC_REPORTERS = "metric.reporters";
+    private static final String KEY_TOPIC_EXPIRY_MS = "topic.expiry.ms";
+    private static final String KEY_METADATA_RETRY_BACKOFF_MS = "metadata.retry.backoff.ms";
+    private static final String KEY_BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
+    private static final String KEY_CLIENT_ID_CONFIG = "client.id";
+    private static final String KEY_AUDIT_SET_NAME = "auditSetName";
+
+    private final String workerName;
+    private final CacheClusterConfig config;
+    private final KafkaFederationSinkContext sinkContext;
+    private final Context context;
+
+    private final String cacheClusterName;
+    private LifecycleState state;
+
+    private KafkaProducer<String, byte[]> producer;
+
+    /**
+     * constructor of KafkaProducerCluster
+     *
+     * @param workerName workerName
+     * @param config config of cluster
+     * @param kafkaFederationSinkContext producer context
+     */
+    public KafkaProducerCluster(
+            String workerName,
+            CacheClusterConfig config,
+            KafkaFederationSinkContext kafkaFederationSinkContext) {
+        this.workerName = Preconditions.checkNotNull(workerName);
+        this.config = Preconditions.checkNotNull(config);
+        this.sinkContext = Preconditions.checkNotNull(kafkaFederationSinkContext);
+        this.context = Preconditions.checkNotNull(kafkaFederationSinkContext.getProducerContext());
+        this.state = LifecycleState.IDLE;
+        this.cacheClusterName = Preconditions.checkNotNull(config.getClusterName());
+    }
+
+    /** start and init kafka producer */
+    @Override
+    public void start() {
+        this.state = LifecycleState.START;
+        try {
+            Properties props = new Properties();
+            props.putAll(context.getParameters());
+            props.put(
+                    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                    context.getString(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+            props.put(
+                    ProducerConfig.CLIENT_ID_CONFIG,
+                    context.getString(ProducerConfig.CLIENT_ID_CONFIG) + "-" + workerName);
+            LOG.info("init kafka client info: " + props);
+            producer =
+                    new KafkaProducer<>(props, new StringSerializer(), new ByteArraySerializer());
+            Preconditions.checkNotNull(producer);
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /** stop and close kafka producer */
+    @Override
+    public void stop() {
+        this.state = LifecycleState.STOP;
+        try {
+            LOG.info("stop kafka producer");
+            producer.close();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * get module state
+     *
+     * @return state
+     */
+    @Override
+    public LifecycleState getLifecycleState() {
+        return this.state;
+    }
+
+    /**
+     * Send data
+     *
+     * @param event data to send
+     */
+    public boolean send(Event event, Transaction tx) {
+        String topic = event.getHeaders().get(Constants.TOPIC);
+        ProducerRecord<String, byte[]> record = new ProducerRecord<>(topic, event.getBody());
+        long sendTime = System.currentTimeMillis();
+        try {
+            producer.send(
+                    record,
+                    (metadata, ex) -> {
+                        if (ex == null) {
+                            tx.commit();
+                            addMetric(event, topic, true, sendTime);
+                        } else {
+                            LOG.error(
+                                    String.format(
+                                            "send failed, topic is %s, partition is %s",
+                                            metadata.topic(), metadata.partition()),
+                                    ex);
+                            tx.rollback();
+                            addMetric(event, topic, false, 0);
+                        }
+                        tx.close();
+                    });
+            return true;
+        } catch (Exception e) {
+            tx.rollback();
+            tx.close();
+            LOG.error(e.getMessage(), e);
+            addMetric(event, topic, false, 0);
+            return false;
+        }
+    }
+
+    /**
+     * get cache cluster name
+     *
+     * @return cacheClusterName
+     */
+    public String getCacheClusterName() {
+        return cacheClusterName;
+    }
+
+    /**
+     * Report metrics to monitor, including the count, size and duration of sending, sent
+     * successfully and sent failed packet.
+     *
+     * @param currentRecord event to be reported
+     * @param topic kafka topic of event sent to
+     * @param result send result, send successfully -> true, send failed -> false.
+     * @param sendTime the time event sent to kafka
+     */
+    private void addMetric(Event currentRecord, String topic, boolean result, long sendTime) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.sinkContext.getClusterId());
+        // metric
+        SortMetricItem.fillInlongId(currentRecord, dimensions);
+        dimensions.put(SortMetricItem.KEY_SINK_ID, this.cacheClusterName);
+        dimensions.put(SortMetricItem.KEY_SINK_DATA_ID, topic);
+        long msgTime =
+                NumberUtils.toLong(
+                        currentRecord.getHeaders().get(Constants.HEADER_KEY_MSG_TIME), sendTime);
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(SortMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        String taskName = currentRecord.getHeaders().get(SortMetricItem.KEY_TASK_NAME);
+        dimensions.put(SortMetricItem.KEY_TASK_NAME, taskName);
+        SortMetricItem.reportDurations(
+                currentRecord,
+                result,
+                sendTime,
+                dimensions,
+                msgTime,
+                this.sinkContext.getMetricItemSet());
+        if (result) {
+            AuditUtils.add(AuditUtils.AUDIT_ID_SEND_SUCCESS, currentRecord);
+        }
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaProducerFederation.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaProducerFederation.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.kafka;
+
+import com.google.common.base.Preconditions;
+import org.apache.flume.Event;
+import org.apache.flume.Transaction;
+import org.apache.inlong.sort.standalone.config.pojo.CacheClusterConfig;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * KafkaProducerFederation.
+ */
+public class KafkaProducerFederation implements Runnable {
+    private static final Logger LOG = InlongLoggerFactory.getLogger(KafkaProducerFederation.class);
+    private static final int CORE_POOL_SIZE = 1;
+
+    private final String workerName;
+    private final KafkaFederationSinkContext context;
+    private ScheduledExecutorService pool;
+    private long reloadInterval;
+
+    private List<KafkaProducerCluster> clusterList = new ArrayList<>();
+    private List<KafkaProducerCluster> deletingClusterList = new ArrayList<>();
+
+    private AtomicInteger clusterIndex = new AtomicInteger(0);
+
+    /**
+     * constructor of KafkaProducerFederation
+     *
+     * @param workerName workerName
+     * @param context context
+     */
+    public KafkaProducerFederation(String workerName, KafkaFederationSinkContext context) {
+        this.workerName = Preconditions.checkNotNull(workerName);
+        this.context = Preconditions.checkNotNull(context);
+        this.reloadInterval = context.getReloadInterval();
+    }
+
+    /** close */
+    public void close() {
+        try {
+            this.pool.shutdownNow();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+        for (KafkaProducerCluster cluster : this.clusterList) {
+            cluster.stop();
+        }
+    }
+
+    /** start */
+    public void start() {
+        try {
+            this.reload();
+            this.initReloadExecutor();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /** Implements {@link Runnable} method. */
+    @Override
+    public void run() {
+        this.reload();
+    }
+
+    /** reload module */
+    private void reload() {
+        try {
+            LOG.info("stop deleting clusters, size is {}", deletingClusterList.size());
+            deletingClusterList.forEach(KafkaProducerCluster::stop);
+            deletingClusterList.clear();
+
+            LOG.info("update cluster list");
+            List<CacheClusterConfig> newClusterConfigList = this.context.getClusterConfigList();
+            // prepare
+            Set<String> newClusterNames = new HashSet<>();
+            Set<String> oldClusterNames = new HashSet<>();
+            newClusterConfigList.forEach(
+                    clusterConfig -> newClusterNames.add(clusterConfig.getClusterName()));
+            clusterList.forEach(cluster -> oldClusterNames.add(cluster.getCacheClusterName()));
+            List<KafkaProducerCluster> newClusterList =
+                    new ArrayList<>(newClusterConfigList.size());
+
+            // add new cluster
+            newClusterConfigList.forEach(
+                    config -> {
+                        if (!oldClusterNames.contains(config.getClusterName())) {
+                            KafkaProducerCluster cluster =
+                                    new KafkaProducerCluster(workerName, config, context);
+                            cluster.start();
+                            newClusterList.add(cluster);
+                        }
+                    });
+
+            // remove expire cluster
+            clusterList.forEach(
+                    cluster -> {
+                        if (!newClusterNames.contains(cluster.getCacheClusterName())) {
+                            deletingClusterList.add(cluster);
+                        } else {
+                            newClusterList.add(cluster);
+                        }
+                    });
+            LOG.info("the modified cluster list size is {}", newClusterList.size());
+            this.clusterList = newClusterList;
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * send event
+     *
+     * @param event event to send
+     * @param tx transaction
+     * @return send result
+     */
+    public boolean send(Event event, Transaction tx) {
+        int currentIndex = clusterIndex.getAndIncrement();
+        if (currentIndex > Integer.MAX_VALUE / 2) {
+            clusterIndex.set(0);
+        }
+        List<KafkaProducerCluster> currentClusterList = this.clusterList;
+        int currentSize = currentClusterList.size();
+        int realIndex = currentIndex % currentSize;
+        KafkaProducerCluster clusterProducer = currentClusterList.get(realIndex);
+        return clusterProducer.send(event, tx);
+    }
+
+    /** Init ScheduledExecutorService with fix reload rate {@link #reloadInterval}. */
+    private void initReloadExecutor() {
+        this.pool = Executors.newScheduledThreadPool(CORE_POOL_SIZE);
+        pool.scheduleAtFixedRate(this, reloadInterval, reloadInterval, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
### [INLONG-1896][Feature][Sort]  SInlong-Sort-Standalone support to sort the events to Kafka clusters.

Fixes #1896 

### Motivation

Enable sort-standalone sort the events to kafka clusters

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
