### PR TITLE
[INLONG-2404][Manager] Upgrade log4j to 2.17.1 due to CVEs

### DIFF
--- a/inlong-manager/pom.xml
+++ b/inlong-manager/pom.xml
@@ -71,7 +71,7 @@
         <knife4j.version>2.0.5</knife4j.version>
         <swagger.version>3.0.0</swagger.version>
         <swagger-annotations.version>1.6.2</swagger-annotations.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <checkstyle.version>6.19</checkstyle.version>


### PR DESCRIPTION
### Title Name: [INLONG-2404][Manager] Upgrade log4j to 2.17.1 due to CVEs

Fixes #2404

### Motivation

security vulnerability

### Modifications

pom change

### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
