### PR TITLE
[INLONG-2404] update more refs to logj2 version (update to 2.17.1)

### DIFF
--- a/inlong-agent/pom.xml
+++ b/inlong-agent/pom.xml
@@ -50,7 +50,7 @@
         <gson.version>2.8.5</gson.version>
         <guava.version>12.0.1</guava.version>
         <jdk.version>1.8</jdk.version>
-        <log4j2.version>2.13.1</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <mockito.version>3.3.3</mockito.version>
         <plugin.assembly.version>3.2.0</plugin.assembly.version>
         <slf4j.version>1.7.30</slf4j.version>

--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -48,7 +48,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <slf4j.version>1.7.15</slf4j.version>
-        <log4j.version>2.13.3</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <mockito.version>3.6.28</mockito.version>
         <curator.version>2.12.0</curator.version>
         <log4j.configuration>log4j-test.properties</log4j.configuration>


### PR DESCRIPTION
Fixes #2404

### Motivation

ensure new version of log4j used in all modules

### Modifications

pom changes

### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
