### PR TITLE
[INLONG-2422] [Bug] upgrade logback to 1.2.10 due to security issues

### DIFF
--- a/inlong-audit/pom.xml
+++ b/inlong-audit/pom.xml
@@ -60,7 +60,7 @@
         <lombok.verison>1.18.12</lombok.verison>
         <druid.version>1.2.6</druid.version>
         <elasticsearch.version>6.4.3</elasticsearch.version>
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.2.10</logback.version>
         <gson.version>2.8.6</gson.version>
         <jackson.version>2.12.3</jackson.version>
         <junit.version>4.12</junit.version>

--- a/inlong-tubemq/tubemq-manager/pom.xml
+++ b/inlong-tubemq/tubemq-manager/pom.xml
@@ -115,17 +115,17 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.1.3</version>
+            <version>1.2.10</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-access</artifactId>
-            <version>1.1.3</version>
+            <version>1.2.10</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.3</version>
+            <version>1.2.10</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION

Fixes #2422

### Motivation

use secure libs

### Modifications

pom changes

### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
