### PR TITLE
[INLONG-2430] upgrade to jetty 9.4.44.v20210927

### DIFF
--- a/inlong-agent/pom.xml
+++ b/inlong-agent/pom.xml
@@ -67,7 +67,7 @@
         <fastjson.version>1.2.68</fastjson.version>
         <sleepycat.version>7.3.7</sleepycat.version>
         <hippoclient.version>2.0.5</hippoclient.version>
-        <jetty.version>9.4.34.v20201102</jetty.version>
+        <jetty.version>9.4.44.v20210927</jetty.version>
         <rocksdb.version>6.14.6</rocksdb.version>
         <codec.version>1.15</codec.version>
         <lombok.version>1.18.12</lombok.version>

--- a/inlong-tubemq/pom.xml
+++ b/inlong-tubemq/pom.xml
@@ -345,12 +345,12 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>9.4.31.v20200723</version>
+                <version>9.4.44.v20210927</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
-                <version>9.4.31.v20200723</version>
+                <version>9.4.44.v20210927</version>
             </dependency>
             <dependency>
                 <groupId>org.ini4j</groupId>

--- a/licenses/inlong-dataproxy/LICENSE-binary
+++ b/licenses/inlong-dataproxy/LICENSE-binary
@@ -255,13 +255,13 @@ Apache License Version 2.0:
    - org.mortbay.jetty:jetty:jetty-6.1.26.jar
    - org.mortbay.jetty:jetty-util:jetty-util-6.1.26.jar
    - org.mortbay.jetty:servlet-api:servlet-api-2.5-20110124.jar
-   - org.eclipse.jetty:jetty-http:jetty-http-9.4.6.v20170531.jar
-   - org.eclipse.jetty:jetty-io:jetty-io-9.4.6.v20170531.jar
-   - org.eclipse.jetty:jetty-jmx:jetty-jmx-9.4.6.v20170531.jar
-   - org.eclipse.jetty:jetty-security:jetty-security-9.4.6.v20170531.jar
-   - org.eclipse.jetty:jetty-server:jetty-server-9.4.6.v20170531.jar
-   - org.eclipse.jetty:jetty-servlet:jetty-servlet-9.4.6.v20170531.jar
-   - org.eclipse.jetty:jetty-util:jetty-util-9.4.6.v20170531.jar
+   - org.eclipse.jetty:jetty-http:jetty-http-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-io:jetty-io-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-jmx:jetty-jmx-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-security:jetty-security-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-server:jetty-server-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-servlet:jetty-servlet-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-util:jetty-util-9.4.44.v20210927.jar
  * Joda-Time
    - joda-time:joda-time:joda-time-2.9.9.jar
  * FindBugs-jsr305

--- a/licenses/inlong-tubemq/LICENSE-binary
+++ b/licenses/inlong-tubemq/LICENSE-binary
@@ -237,12 +237,12 @@ Apache License Version 2.0:
    - org.apache.httpcomponents:httpclient:httpclient-4.5.13.jar
    - org.apache.httpcomponents:httpcore:httpcore-4.4.13.jar
  * Jetty
-   - org.eclipse.jetty:jetty-server:jetty-server-9.4.31.v20200723.jar
-   - org.eclipse.jetty:jetty-http:jetty-http-9.4.31.v20200723.jar
-   - org.eclipse.jetty:jetty-util:jetty-util-9.4.31.v20200723.jar
-   - org.eclipse.jetty:jetty-io:jetty-io-9.4.31.v20200723.jar
-   - org.eclipse.jetty:jetty-servlet:jetty-servlet-9.4.31.v20200723.jar
-   - org.eclipse.jetty:jetty-security:jetty-security-9.4.31.v20200723.jar
+   - org.eclipse.jetty:jetty-server:jetty-server-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-http:jetty-http-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-util:jetty-util-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-io:jetty-io-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-servlet:jetty-servlet-9.4.44.v20210927.jar
+   - org.eclipse.jetty:jetty-security:jetty-security-9.4.44.v20210927.jar
  * ini4j
    - org.ini4j:ini4j:ini4j-0.5.1.jar
  * Spring Framework


### PR DESCRIPTION

Fixes #2430 

### Motivation

use secure libs

### Modifications

pom changes

### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
