### PR TITLE
[INLONG-2381] DataProxy support Tube sink of PB compression cache message protocol. 

### DIFF
--- a/inlong-dataproxy/dataproxy-source/pom.xml
+++ b/inlong-dataproxy/dataproxy-source/pom.xml
@@ -48,5 +48,10 @@
             <artifactId>audit-sdk</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sdk-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/CommonPropertiesHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/CommonPropertiesHolder.java
@@ -37,6 +37,7 @@ public class CommonPropertiesHolder {
     public static final Logger LOG = LoggerFactory.getLogger(CommonPropertiesHolder.class);
     public static final String KEY_COMMON_PROPERTIES = "common-properties-loader";
     public static final String DEFAULT_LOADER = ClassResourceCommonPropertiesLoader.class.getName();
+    public static final String KEY_CLUSTER_ID = "clusterId";
 
     private static Map<String, String> props;
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/dispatch/DispatchManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/dispatch/DispatchManager.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.dispatch;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.flume.Context;
+import org.apache.inlong.sdk.commons.protocol.ProxyEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * DispatchManager
+ */
+public class DispatchManager {
+
+    public static final Logger LOG = LoggerFactory.getLogger(DispatchManager.class);
+    public static final String KEY_DISPATCH_TIMEOUT = "dispatchTimeout";
+    public static final String KEY_DISPATCH_MAX_PACKCOUNT = "dispatchMaxPackCount";
+    public static final String KEY_DISPATCH_MAX_PACKSIZE = "dispatchMaxPackSize";
+    public static final long DEFAULT_DISPATCH_TIMEOUT = 2000;
+    public static final long DEFAULT_DISPATCH_MAX_PACKCOUNT = 256;
+    public static final long DEFAULT_DISPATCH_MAX_PACKSIZE = 327680;
+    public static final long MINUTE_MS = 60L * 1000;
+
+    private LinkedBlockingQueue<DispatchProfile> dispatchQueue;
+    private final long dispatchTimeout;
+    private final long maxPackCount;
+    private final long maxPackSize;
+    private ConcurrentHashMap<String, DispatchProfile> profileCache = new ConcurrentHashMap<>();
+    //
+    private AtomicBoolean needOutputOvertimeData = new AtomicBoolean(false);
+
+    /**
+     * Constructor
+     * 
+     * @param context
+     * @param dispatchQueue
+     */
+    public DispatchManager(Context context, LinkedBlockingQueue<DispatchProfile> dispatchQueue) {
+        this.dispatchQueue = dispatchQueue;
+        this.dispatchTimeout = context.getLong(KEY_DISPATCH_TIMEOUT, DEFAULT_DISPATCH_TIMEOUT);
+        this.maxPackCount = context.getLong(KEY_DISPATCH_MAX_PACKCOUNT, DEFAULT_DISPATCH_MAX_PACKCOUNT);
+        this.maxPackSize = context.getLong(KEY_DISPATCH_MAX_PACKSIZE, DEFAULT_DISPATCH_MAX_PACKSIZE);
+    }
+
+    /**
+     * addEvent
+     * 
+     * @param event
+     */
+    public void addEvent(ProxyEvent event) {
+        if (needOutputOvertimeData.get()) {
+            this.outputOvertimeData();
+            this.needOutputOvertimeData.set(false);
+        }
+        // parse
+        String eventUid = event.getUid();
+        long dispatchTime = event.getMsgTime() - event.getMsgTime() % MINUTE_MS;
+        String dispatchKey = eventUid + "." + dispatchTime;
+        //
+        DispatchProfile dispatchProfile = this.profileCache.get(dispatchKey);
+        if (dispatchProfile == null) {
+            dispatchProfile = new DispatchProfile(eventUid, event.getInlongGroupId(), event.getInlongStreamId(),
+                    dispatchTime);
+            this.profileCache.put(dispatchKey, dispatchProfile);
+        }
+        //
+        boolean addResult = dispatchProfile.addEvent(event, maxPackCount, maxPackSize);
+        if (!addResult) {
+            DispatchProfile newDispatchProfile = new DispatchProfile(eventUid, event.getInlongGroupId(),
+                    event.getInlongStreamId(), dispatchTime);
+            DispatchProfile oldDispatchProfile = this.profileCache.put(dispatchKey, newDispatchProfile);
+            this.dispatchQueue.offer(oldDispatchProfile);
+            newDispatchProfile.addEvent(event, maxPackCount, maxPackSize);
+        }
+    }
+
+    /**
+     * outputOvertimeData
+     * 
+     * @return
+     */
+    public void outputOvertimeData() {
+        LOG.info("start to outputOvertimeData profileCacheSize:{},dispatchQueueSize:{}",
+                profileCache.size(), dispatchQueue.size());
+        long currentTime = System.currentTimeMillis();
+        long createThreshold = currentTime - dispatchTimeout;
+        List<String> removeKeys = new ArrayList<>();
+        long eventCount = 0;
+        for (Entry<String, DispatchProfile> entry : this.profileCache.entrySet()) {
+            DispatchProfile dispatchProfile = entry.getValue();
+            eventCount += dispatchProfile.getCount();
+            if (!dispatchProfile.isTimeout(createThreshold)) {
+                continue;
+            }
+            removeKeys.add(entry.getKey());
+        }
+        // output
+        removeKeys.forEach((key) -> {
+            dispatchQueue.offer(this.profileCache.remove(key));
+        });
+        LOG.info("end to outputOvertimeData profileCacheSize:{},dispatchQueueSize:{},eventCount:{}",
+                profileCache.size(), dispatchQueue.size(), eventCount);
+    }
+
+    /**
+     * get dispatchTimeout
+     * 
+     * @return the dispatchTimeout
+     */
+    public long getDispatchTimeout() {
+        return dispatchTimeout;
+    }
+
+    /**
+     * get maxPackCount
+     * 
+     * @return the maxPackCount
+     */
+    public long getMaxPackCount() {
+        return maxPackCount;
+    }
+
+    /**
+     * get maxPackSize
+     * 
+     * @return the maxPackSize
+     */
+    public long getMaxPackSize() {
+        return maxPackSize;
+    }
+
+    /**
+     * setNeedOutputOvertimeData
+     */
+    public void setNeedOutputOvertimeData() {
+        this.needOutputOvertimeData.set(true);
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/dispatch/DispatchProfile.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/dispatch/DispatchProfile.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.dispatch;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.inlong.sdk.commons.protocol.ProxyEvent;
+
+/**
+ * 
+ * DispatchProfile
+ */
+public class DispatchProfile {
+
+    private final String inlongGroupId;
+    private final String inlongStreamId;
+    private final String uid;
+    private List<ProxyEvent> events = new ArrayList<>();
+    private long createTime = System.currentTimeMillis();
+    private long count = 0;
+    private long size = 0;
+    private long dispatchTime;
+
+    /**
+     * Constructor
+     * 
+     * @param uid
+     * @param inlongGroupId
+     * @param inlongStreamId
+     * @param dispatchTime
+     */
+    public DispatchProfile(String uid, String inlongGroupId, String inlongStreamId, long dispatchTime) {
+        this.uid = uid;
+        this.inlongGroupId = inlongGroupId;
+        this.inlongStreamId = inlongStreamId;
+        this.dispatchTime = dispatchTime;
+    }
+
+    /**
+     * addEvent
+     * 
+     * @param  event
+     * @param  maxPackCount
+     * @param  maxPackSize
+     * @return
+     */
+    public boolean addEvent(ProxyEvent event, long maxPackCount, long maxPackSize) {
+        long eventLength = event.getBody().length;
+        if (count >= maxPackCount || (count > 0 && size + eventLength > maxPackSize)) {
+            return false;
+        }
+        this.events.add(event);
+        this.count++;
+        this.size += eventLength;
+        return true;
+    }
+
+    /**
+     * isTimeout
+     * 
+     * @param  createThreshold
+     * @return
+     */
+    public boolean isTimeout(long createThreshold) {
+        return createThreshold >= createTime;
+    }
+
+    /**
+     * get uid
+     * 
+     * @return the uid
+     */
+    public String getUid() {
+        return uid;
+    }
+
+    /**
+     * get events
+     * 
+     * @return the events
+     */
+    public List<ProxyEvent> getEvents() {
+        return events;
+    }
+
+    /**
+     * set events
+     * 
+     * @param events the events to set
+     */
+    public void setEvents(List<ProxyEvent> events) {
+        this.events = events;
+    }
+
+    /**
+     * get count
+     * 
+     * @return the count
+     */
+    public long getCount() {
+        return count;
+    }
+
+    /**
+     * set count
+     * 
+     * @param count the count to set
+     */
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    /**
+     * get size
+     * 
+     * @return the size
+     */
+    public long getSize() {
+        return size;
+    }
+
+    /**
+     * set size
+     * 
+     * @param size the size to set
+     */
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    /**
+     * get inlongGroupId
+     * 
+     * @return the inlongGroupId
+     */
+    public String getInlongGroupId() {
+        return inlongGroupId;
+    }
+
+    /**
+     * get inlongStreamId
+     * 
+     * @return the inlongStreamId
+     */
+    public String getInlongStreamId() {
+        return inlongStreamId;
+    }
+
+    /**
+     * getDispatchTime
+     * 
+     * @return
+     */
+    public long getDispatchTime() {
+        return dispatchTime;
+    }
+
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/DataProxyMetricItem.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/DataProxyMetricItem.java
@@ -114,6 +114,9 @@ public class DataProxyMetricItem extends MetricItem {
      * @param dimensions
      */
     public static void fillInlongId(Event event, Map<String, String> dimensions) {
+        if (event == null) {
+            return;
+        }
         Map<String, String> headers = event.getHeaders();
         String inlongGroupId = getInlongGroupId(headers);
         String inlongStreamId = getInlongStreamId(headers);
@@ -128,7 +131,7 @@ public class DataProxyMetricItem extends MetricItem {
      * @param dimensions
      */
     public static void fillAuditFormatTime(Event event, Map<String, String> dimensions) {
-        long msgTime = AuditUtils.getLogTime(event);
+        long msgTime = (event != null) ? AuditUtils.getLogTime(event) : System.currentTimeMillis();
         long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
         dimensions.put(DataProxyMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/SinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/SinkContext.java
@@ -1,0 +1,190 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink;
+
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.apache.inlong.commons.config.metrics.MetricRegister;
+import org.apache.inlong.dataproxy.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.dataproxy.metrics.DataProxyMetricItemSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * SinkContext
+ */
+public class SinkContext {
+
+    public static final Logger LOG = LoggerFactory.getLogger(SinkContext.class);
+
+    public static final String KEY_MAX_THREADS = "maxThreads";
+    public static final String KEY_PROCESSINTERVAL = "processInterval";
+    public static final String KEY_RELOADINTERVAL = "reloadInterval";
+
+    protected final String clusterId;
+    protected final String sinkName;
+    protected final Context sinkContext;
+
+    protected final Channel channel;
+    //
+    protected final int maxThreads;
+    protected final long processInterval;
+    protected final long reloadInterval;
+    //
+    protected final DataProxyMetricItemSet metricItemSet;
+    protected Timer reloadTimer;
+
+    /**
+     * Constructor
+     * 
+     * @param sinkName
+     * @param context
+     * @param channel
+     */
+    public SinkContext(String sinkName, Context context, Channel channel) {
+        this.sinkName = sinkName;
+        this.sinkContext = context;
+        this.channel = channel;
+        this.clusterId = context.getString(CommonPropertiesHolder.KEY_CLUSTER_ID);
+        this.maxThreads = sinkContext.getInteger(KEY_MAX_THREADS, 10);
+        this.processInterval = sinkContext.getInteger(KEY_PROCESSINTERVAL, 100);
+        this.reloadInterval = sinkContext.getLong(KEY_RELOADINTERVAL, 60000L);
+        //
+        this.metricItemSet = new DataProxyMetricItemSet(sinkName);
+        MetricRegister.register(this.metricItemSet);
+    }
+
+    /**
+     * start
+     */
+    public void start() {
+        try {
+            this.reload();
+            this.setReloadTimer();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * close
+     */
+    public void close() {
+        try {
+            this.reloadTimer.cancel();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * setReloadTimer
+     */
+    protected void setReloadTimer() {
+        reloadTimer = new Timer(true);
+        TimerTask task = new TimerTask() {
+
+            public void run() {
+                reload();
+            }
+        };
+        reloadTimer.schedule(task, new Date(System.currentTimeMillis() + reloadInterval), reloadInterval);
+    }
+
+    /**
+     * reload
+     */
+    public void reload() {
+    }
+
+    /**
+     * get clusterId
+     * 
+     * @return the clusterId
+     */
+    public String getClusterId() {
+        return clusterId;
+    }
+
+    /**
+     * get sinkName
+     * 
+     * @return the sinkName
+     */
+    public String getSinkName() {
+        return sinkName;
+    }
+
+    /**
+     * get sinkContext
+     * 
+     * @return the sinkContext
+     */
+    public Context getSinkContext() {
+        return sinkContext;
+    }
+
+    /**
+     * get channel
+     * 
+     * @return the channel
+     */
+    public Channel getChannel() {
+        return channel;
+    }
+
+    /**
+     * get maxThreads
+     * 
+     * @return the maxThreads
+     */
+    public int getMaxThreads() {
+        return maxThreads;
+    }
+
+    /**
+     * get processInterval
+     * 
+     * @return the processInterval
+     */
+    public long getProcessInterval() {
+        return processInterval;
+    }
+
+    /**
+     * get reloadInterval
+     * 
+     * @return the reloadInterval
+     */
+    public long getReloadInterval() {
+        return reloadInterval;
+    }
+
+    /**
+     * get metricItemSet
+     * 
+     * @return the metricItemSet
+     */
+    public DataProxyMetricItemSet getMetricItemSet() {
+        return metricItemSet;
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/tubezone/TubeClusterProducer.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/tubezone/TubeClusterProducer.java
@@ -1,0 +1,275 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.tubezone;
+
+import static org.apache.inlong.sdk.commons.protocol.EventConstants.HEADER_CACHE_VERSION_1;
+import static org.apache.inlong.sdk.commons.protocol.EventConstants.HEADER_KEY_VERSION;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.flume.Context;
+import org.apache.flume.lifecycle.LifecycleAware;
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
+import org.apache.inlong.dataproxy.consts.ConfigConstants;
+import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
+import org.apache.inlong.sdk.commons.protocol.EventConstants;
+import org.apache.inlong.sdk.commons.protocol.EventUtils;
+import org.apache.inlong.tubemq.client.config.TubeClientConfig;
+import org.apache.inlong.tubemq.client.exception.TubeClientException;
+import org.apache.inlong.tubemq.client.factory.TubeMultiSessionFactory;
+import org.apache.inlong.tubemq.client.producer.MessageProducer;
+import org.apache.inlong.tubemq.client.producer.MessageSentCallback;
+import org.apache.inlong.tubemq.client.producer.MessageSentResult;
+import org.apache.inlong.tubemq.corebase.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TubeClusterProducer
+ */
+public class TubeClusterProducer implements LifecycleAware {
+
+    public static final Logger LOG = LoggerFactory.getLogger(TubeClusterProducer.class);
+    private static String MASTER_HOST_PORT_LIST = "master-host-port-list";
+
+    protected final String workerName;
+    private final CacheClusterConfig config;
+    private final TubeZoneSinkContext sinkContext;
+    private final Context producerContext;
+    private final String cacheClusterName;
+    private LifecycleState state;
+
+    // parameter
+    private String masterHostAndPortList;
+    private long linkMaxAllowedDelayedMsgCount;
+    private long sessionWarnDelayedMsgCount;
+    private long sessionMaxAllowedDelayedMsgCount;
+    private long nettyWriteBufferHighWaterMark;
+    // tube producer
+    private TubeMultiSessionFactory sessionFactory;
+    private MessageProducer producer;
+    private Set<String> topicSet = new HashSet<>();
+
+    /**
+     * Constructor
+     * 
+     * @param workerName
+     * @param config
+     * @param context
+     */
+    public TubeClusterProducer(String workerName, CacheClusterConfig config, TubeZoneSinkContext context) {
+        this.workerName = workerName;
+        this.config = config;
+        this.sinkContext = context;
+        this.producerContext = context.getProducerContext();
+        this.state = LifecycleState.IDLE;
+        this.cacheClusterName = config.getClusterName();
+    }
+
+    /**
+     * start
+     */
+    @Override
+    public void start() {
+        this.state = LifecycleState.START;
+        // create tube producer
+        try {
+            // prepare configuration
+            TubeClientConfig conf = initTubeConfig();
+            LOG.info("try to create producer:{}", conf.toJsonString());
+            this.sessionFactory = new TubeMultiSessionFactory(conf);
+            this.producer = sessionFactory.createProducer();
+            LOG.info("create new producer success:{}", producer);
+        } catch (Throwable e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * initTubeConfig
+     * 
+     * @return
+     * @throws Exception
+     */
+    private TubeClientConfig initTubeConfig() throws Exception {
+        // get parameter
+        Context configContext = new Context(this.producerContext.getParameters());
+        configContext.putAll(this.config.getParams());
+        masterHostAndPortList = configContext.getString(MASTER_HOST_PORT_LIST);
+        linkMaxAllowedDelayedMsgCount = configContext.getLong(ConfigConstants.LINK_MAX_ALLOWED_DELAYED_MSG_COUNT,
+                80000L);
+        sessionWarnDelayedMsgCount = configContext.getLong(ConfigConstants.SESSION_WARN_DELAYED_MSG_COUNT,
+                2000000L);
+        sessionMaxAllowedDelayedMsgCount = configContext.getLong(
+                ConfigConstants.SESSION_MAX_ALLOWED_DELAYED_MSG_COUNT,
+                4000000L);
+        nettyWriteBufferHighWaterMark = configContext.getLong(ConfigConstants.NETTY_WRITE_BUFFER_HIGH_WATER_MARK,
+                15 * 1024 * 1024L);
+        // config
+        final TubeClientConfig tubeClientConfig = new TubeClientConfig(this.masterHostAndPortList);
+        tubeClientConfig.setLinkMaxAllowedDelayedMsgCount(linkMaxAllowedDelayedMsgCount);
+        tubeClientConfig.setSessionWarnDelayedMsgCount(sessionWarnDelayedMsgCount);
+        tubeClientConfig.setSessionMaxAllowedDelayedMsgCount(sessionMaxAllowedDelayedMsgCount);
+        tubeClientConfig.setNettyWriteBufferHighWaterMark(nettyWriteBufferHighWaterMark);
+        tubeClientConfig.setHeartbeatPeriodMs(15000L);
+        tubeClientConfig.setRpcTimeoutMs(20000L);
+
+        return tubeClientConfig;
+    }
+
+    /**
+     * stop
+     */
+    @Override
+    public void stop() {
+        this.state = LifecycleState.STOP;
+        // producer
+        if (this.producer != null) {
+            try {
+                this.producer.shutdown();
+            } catch (Throwable e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+        if (this.sessionFactory != null) {
+            try {
+                this.sessionFactory.shutdown();
+            } catch (TubeClientException e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * getLifecycleState
+     * 
+     * @return
+     */
+    @Override
+    public LifecycleState getLifecycleState() {
+        return state;
+    }
+
+    /**
+     * send
+     * 
+     * @param event
+     */
+    public boolean send(DispatchProfile event) {
+        try {
+            // topic
+            String topic = sinkContext.getIdTopicHolder().getTopic(event.getUid());
+            if (topic == null) {
+                sinkContext.addSendResultMetric(event, event.getUid(), false, 0);
+                return false;
+            }
+            // publish
+            if (!this.topicSet.contains(topic)) {
+                this.producer.publish(topic);
+                this.topicSet.add(topic);
+            }
+            // create producer failed
+            if (producer == null) {
+                sinkContext.getDispatchQueue().offer(event);
+                sinkContext.addSendResultMetric(event, topic, false, 0);
+                return false;
+            }
+            // headers
+            Map<String, String> headers = this.encodeCacheMessageHeaders(event);
+            // compress
+            byte[] bodyBytes = EventUtils.encodeCacheMessageBody(sinkContext.getCompressType(), event.getEvents());
+            // sendAsync
+            Message message = new Message(topic, bodyBytes);
+            // add headers
+            headers.forEach((key, value) -> {
+                message.setAttrKeyVal(key, value);
+            });
+            // callback
+            long sendTime = System.currentTimeMillis();
+            MessageSentCallback callback = new MessageSentCallback() {
+
+                @Override
+                public void onMessageSent(MessageSentResult result) {
+                    sinkContext.addSendResultMetric(event, topic, true, sendTime);
+                }
+
+                @Override
+                public void onException(Throwable ex) {
+                    LOG.error("Send fail:{}", ex.getMessage());
+                    LOG.error(ex.getMessage(), ex);
+                    sinkContext.getDispatchQueue().offer(event);
+                    sinkContext.addSendResultMetric(event, topic, false, sendTime);
+                }
+            };
+            producer.sendMessage(message, callback);
+            return true;
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            sinkContext.getDispatchQueue().offer(event);
+            sinkContext.addSendResultMetric(event, event.getUid(), false, 0);
+            return false;
+        }
+    }
+
+    /**
+     * encodeCacheMessageHeaders
+     * 
+     * @param  event
+     * @return       Map
+     */
+    public Map<String, String> encodeCacheMessageHeaders(DispatchProfile event) {
+        Map<String, String> headers = new HashMap<>();
+        // version int32 protocol version, the value is 1
+        headers.put(HEADER_KEY_VERSION, HEADER_CACHE_VERSION_1);
+        // inlongGroupId string inlongGroupId
+        headers.put(EventConstants.INLONG_GROUP_ID, event.getInlongGroupId());
+        // inlongStreamId string inlongStreamId
+        headers.put(EventConstants.INLONG_STREAM_ID, event.getInlongStreamId());
+        // proxyName string proxy node id, IP or conainer name
+        headers.put(EventConstants.HEADER_KEY_PROXY_NAME, sinkContext.getNodeId());
+        // packTime int64 pack time, milliseconds
+        headers.put(EventConstants.HEADER_KEY_PACK_TIME, String.valueOf(System.currentTimeMillis()));
+        // msgCount int32 message count
+        headers.put(EventConstants.HEADER_KEY_MSG_COUNT, String.valueOf(event.getEvents().size()));
+        // srcLength int32 total length of raw messages body
+        headers.put(EventConstants.HEADER_KEY_SRC_LENGTH, String.valueOf(event.getSize()));
+        // compressType int
+        // compress type of body data
+        // INLONG_NO_COMPRESS = 0,
+        // INLONG_GZ = 1,
+        // INLONG_SNAPPY = 2
+        headers.put(EventConstants.HEADER_KEY_COMPRESS_TYPE,
+                String.valueOf(sinkContext.getCompressType().getNumber()));
+        // messageKey string partition hash key, optional
+        return headers;
+    }
+
+    /**
+     * get cacheClusterName
+     * 
+     * @return the cacheClusterName
+     */
+    public String getCacheClusterName() {
+        return cacheClusterName;
+    }
+
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/tubezone/TubeZoneProducer.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/tubezone/TubeZoneProducer.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.tubezone;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
+import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TubeZoneProducer
+ */
+public class TubeZoneProducer {
+
+    public static final Logger LOG = LoggerFactory.getLogger(TubeZoneProducer.class);
+
+    private final String workerName;
+    private final TubeZoneSinkContext context;
+    private Timer reloadTimer;
+
+    private List<TubeClusterProducer> clusterList = new ArrayList<>();
+    private List<TubeClusterProducer> deletingClusterList = new ArrayList<>();
+
+    private AtomicInteger clusterIndex = new AtomicInteger(0);
+
+    /**
+     * Constructor
+     * 
+     * @param workerName
+     * @param context
+     */
+    public TubeZoneProducer(String workerName, TubeZoneSinkContext context) {
+        this.workerName = workerName;
+        this.context = context;
+    }
+
+    /**
+     * start
+     */
+    public void start() {
+        try {
+            this.reload();
+            this.setReloadTimer();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * close
+     */
+    public void close() {
+        try {
+            this.reloadTimer.cancel();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+        for (TubeClusterProducer cluster : this.clusterList) {
+            cluster.stop();
+        }
+    }
+
+    /**
+     * setReloadTimer
+     */
+    private void setReloadTimer() {
+        reloadTimer = new Timer(true);
+        TimerTask task = new TimerTask() {
+
+            public void run() {
+                reload();
+            }
+        };
+        reloadTimer.schedule(task, new Date(System.currentTimeMillis() + context.getReloadInterval()),
+                context.getReloadInterval());
+    }
+
+    /**
+     * reload
+     */
+    public void reload() {
+        try {
+            // stop deleted cluster
+            deletingClusterList.forEach(item -> {
+                item.stop();
+            });
+            deletingClusterList.clear();
+            // update cluster list
+            List<CacheClusterConfig> configList = this.context.getCacheHolder().getConfigList();
+            List<TubeClusterProducer> newClusterList = new ArrayList<>(configList.size());
+            // prepare
+            Set<String> newClusterNames = new HashSet<>();
+            configList.forEach(item -> {
+                newClusterNames.add(item.getClusterName());
+            });
+            Set<String> oldClusterNames = new HashSet<>();
+            clusterList.forEach(item -> {
+                oldClusterNames.add(item.getCacheClusterName());
+            });
+            // add
+            for (CacheClusterConfig config : configList) {
+                if (!oldClusterNames.contains(config.getClusterName())) {
+                    TubeClusterProducer cluster = new TubeClusterProducer(workerName, config, context);
+                    cluster.start();
+                    newClusterList.add(cluster);
+                }
+            }
+            // remove
+            for (TubeClusterProducer cluster : this.clusterList) {
+                if (newClusterNames.contains(cluster.getCacheClusterName())) {
+                    newClusterList.add(cluster);
+                } else {
+                    deletingClusterList.add(cluster);
+                }
+            }
+            this.clusterList = newClusterList;
+        } catch (Throwable e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * send
+     * 
+     * @param event
+     */
+    public boolean send(DispatchProfile event) {
+        int currentIndex = clusterIndex.getAndIncrement();
+        if (currentIndex > Integer.MAX_VALUE / 2) {
+            clusterIndex.set(0);
+        }
+        List<TubeClusterProducer> currentClusterList = this.clusterList;
+        int currentSize = currentClusterList.size();
+        int realIndex = currentIndex % currentSize;
+        TubeClusterProducer clusterProducer = currentClusterList.get(realIndex);
+        return clusterProducer.send(event);
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/tubezone/TubeZoneSink.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/tubezone/TubeZoneSink.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.tubezone;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.EventDeliveryException;
+import org.apache.flume.Transaction;
+import org.apache.flume.conf.Configurable;
+import org.apache.flume.sink.AbstractSink;
+import org.apache.inlong.dataproxy.dispatch.DispatchManager;
+import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
+import org.apache.inlong.sdk.commons.protocol.ProxyEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TubeZoneSink
+ */
+public class TubeZoneSink extends AbstractSink implements Configurable {
+
+    public static final Logger LOG = LoggerFactory.getLogger(TubeZoneSink.class);
+
+    private Context parentContext;
+    private TubeZoneSinkContext context;
+    private List<TubeZoneWorker> workers = new ArrayList<>();
+    // message group
+    private DispatchManager dispatchManager;
+    private LinkedBlockingQueue<DispatchProfile> dispatchQueue = new LinkedBlockingQueue<>();
+    // scheduled thread pool
+    // reload
+    // dispatch
+    private ScheduledExecutorService scheduledPool;
+
+    /**
+     * configure
+     * 
+     * @param context
+     */
+    @Override
+    public void configure(Context context) {
+        LOG.info("start to configure:{}, context:{}.", this.getClass().getSimpleName(), context.toString());
+        this.parentContext = context;
+    }
+
+    /**
+     * start
+     */
+    @Override
+    public void start() {
+        try {
+            this.context = new TubeZoneSinkContext(getName(), parentContext, getChannel(), this.dispatchQueue);
+            if (getChannel() == null) {
+                LOG.error("channel is null");
+            }
+            this.context.start();
+            this.dispatchManager = new DispatchManager(parentContext, dispatchQueue);
+            this.scheduledPool = Executors.newScheduledThreadPool(2);
+            // dispatch
+            this.scheduledPool.scheduleWithFixedDelay(new Runnable() {
+
+                public void run() {
+                    dispatchManager.setNeedOutputOvertimeData();
+                }
+            }, this.dispatchManager.getDispatchTimeout(), this.dispatchManager.getDispatchTimeout(),
+                    TimeUnit.MILLISECONDS);
+            // create worker
+            for (int i = 0; i < context.getMaxThreads(); i++) {
+                TubeZoneWorker worker = new TubeZoneWorker(this.getName(), i, context);
+                worker.start();
+                this.workers.add(worker);
+            }
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+        super.start();
+    }
+
+    /**
+     * stop
+     */
+    @Override
+    public void stop() {
+        for (TubeZoneWorker worker : workers) {
+            try {
+                worker.close();
+            } catch (Throwable e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+        this.context.close();
+        super.stop();
+    }
+
+    /**
+     * process
+     * 
+     * @return                        Status
+     * @throws EventDeliveryException
+     */
+    @Override
+    public Status process() throws EventDeliveryException {
+        Channel channel = getChannel();
+        Transaction tx = channel.getTransaction();
+        tx.begin();
+        try {
+            Event event = channel.take();
+            if (event == null) {
+                tx.commit();
+                return Status.BACKOFF;
+            }
+            if (!(event instanceof ProxyEvent)) {
+                tx.commit();
+                this.context.addSendFailMetric();
+                return Status.READY;
+            }
+            //
+            ProxyEvent proxyEvent = (ProxyEvent) event;
+            this.dispatchManager.addEvent(proxyEvent);
+            tx.commit();
+            return Status.READY;
+        } catch (Throwable t) {
+            LOG.error("Process event failed!" + this.getName(), t);
+            try {
+                tx.rollback();
+            } catch (Throwable e) {
+                LOG.error("Channel take transaction rollback exception:" + getName(), e);
+            }
+            return Status.BACKOFF;
+        } finally {
+            tx.close();
+        }
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/tubezone/TubeZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/tubezone/TubeZoneSinkContext.java
@@ -1,0 +1,261 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.tubezone;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.apache.inlong.dataproxy.config.RemoteConfigManager;
+import org.apache.inlong.dataproxy.config.holder.CacheClusterConfigHolder;
+import org.apache.inlong.dataproxy.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.dataproxy.config.holder.IdTopicConfigHolder;
+import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
+import org.apache.inlong.dataproxy.metrics.DataProxyMetricItem;
+import org.apache.inlong.dataproxy.metrics.audit.AuditUtils;
+import org.apache.inlong.dataproxy.sink.SinkContext;
+import org.apache.inlong.sdk.commons.protocol.ProxySdk.INLONG_COMPRESSED_TYPE;
+
+/**
+ * 
+ * TubeZoneSinkContext
+ */
+public class TubeZoneSinkContext extends SinkContext {
+
+    public static final String KEY_NODE_ID = "nodeId";
+    public static final String PREFIX_PRODUCER = "producer.";
+    public static final String KEY_COMPRESS_TYPE = "compressType";
+
+    private final LinkedBlockingQueue<DispatchProfile> dispatchQueue;
+
+    private final String proxyClusterId;
+    private final String nodeId;
+    private final Context producerContext;
+    //
+    private final IdTopicConfigHolder idTopicHolder;
+    private final CacheClusterConfigHolder cacheHolder;
+    private final INLONG_COMPRESSED_TYPE compressType;
+
+    /**
+     * Constructor
+     * 
+     * @param context
+     */
+    public TubeZoneSinkContext(String sinkName, Context context, Channel channel,
+            LinkedBlockingQueue<DispatchProfile> dispatchQueue) {
+        super(sinkName, context, channel);
+        this.dispatchQueue = dispatchQueue;
+        // proxyClusterId
+        this.proxyClusterId = CommonPropertiesHolder.getString(RemoteConfigManager.KEY_PROXY_CLUSTER_NAME);
+        // nodeId
+        this.nodeId = CommonPropertiesHolder.getString(KEY_NODE_ID, "127.0.0.1");
+        // compressionType
+        String strCompressionType = CommonPropertiesHolder.getString(KEY_COMPRESS_TYPE,
+                INLONG_COMPRESSED_TYPE.INLONG_SNAPPY.name());
+        this.compressType = INLONG_COMPRESSED_TYPE.valueOf(strCompressionType);
+        // producerContext
+        Map<String, String> producerParams = context.getSubProperties(PREFIX_PRODUCER);
+        this.producerContext = new Context(producerParams);
+        // idTopicHolder
+        this.idTopicHolder = new IdTopicConfigHolder();
+        this.idTopicHolder.configure(context);
+        // cacheHolder
+        this.cacheHolder = new CacheClusterConfigHolder();
+        this.cacheHolder.configure(context);
+    }
+
+    /**
+     * start
+     */
+    public void start() {
+        super.start();
+        this.idTopicHolder.start();
+        this.cacheHolder.start();
+    }
+
+    /**
+     * close
+     */
+    public void close() {
+        super.close();
+        this.idTopicHolder.close();
+        this.cacheHolder.close();
+    }
+
+    /**
+     * get proxyClusterId
+     * 
+     * @return the proxyClusterId
+     */
+    public String getProxyClusterId() {
+        return proxyClusterId;
+    }
+
+    /**
+     * get dispatchQueue
+     * 
+     * @return the dispatchQueue
+     */
+    public LinkedBlockingQueue<DispatchProfile> getDispatchQueue() {
+        return dispatchQueue;
+    }
+
+    /**
+     * get producerContext
+     * 
+     * @return the producerContext
+     */
+    public Context getProducerContext() {
+        return producerContext;
+    }
+
+    /**
+     * get idTopicHolder
+     * 
+     * @return the idTopicHolder
+     */
+    public IdTopicConfigHolder getIdTopicHolder() {
+        return idTopicHolder;
+    }
+
+    /**
+     * get cacheHolder
+     * 
+     * @return the cacheHolder
+     */
+    public CacheClusterConfigHolder getCacheHolder() {
+        return cacheHolder;
+    }
+
+    /**
+     * get compressType
+     * 
+     * @return the compressType
+     */
+    public INLONG_COMPRESSED_TYPE getCompressType() {
+        return compressType;
+    }
+
+    /**
+     * get nodeId
+     * 
+     * @return the nodeId
+     */
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    /**
+     * addSendMetric
+     * 
+     * @param currentRecord
+     * @param bid
+     */
+    public void addSendMetric(DispatchProfile currentRecord, String bid) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(DataProxyMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        // metric
+        fillInlongId(currentRecord, dimensions);
+        dimensions.put(DataProxyMetricItem.KEY_SINK_ID, this.getSinkName());
+        dimensions.put(DataProxyMetricItem.KEY_SINK_DATA_ID, bid);
+        long msgTime = currentRecord.getDispatchTime();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(DataProxyMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        DataProxyMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        long count = currentRecord.getCount();
+        long size = currentRecord.getSize();
+        metricItem.sendCount.addAndGet(count);
+        metricItem.sendSize.addAndGet(size);
+    }
+
+    /**
+     * addReadFailMetric
+     */
+    public void addSendFailMetric() {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(DataProxyMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        dimensions.put(DataProxyMetricItem.KEY_SINK_ID, this.getSinkName());
+        long msgTime = System.currentTimeMillis();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(DataProxyMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        DataProxyMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        metricItem.readFailCount.incrementAndGet();
+    }
+
+    /**
+     * fillInlongId
+     * 
+     * @param currentRecord
+     * @param dimensions
+     */
+    public static void fillInlongId(DispatchProfile currentRecord, Map<String, String> dimensions) {
+        String inlongGroupId = currentRecord.getInlongGroupId();
+        inlongGroupId = (StringUtils.isBlank(inlongGroupId)) ? "-" : inlongGroupId;
+        String inlongStreamId = currentRecord.getInlongStreamId();
+        inlongStreamId = (StringUtils.isBlank(inlongStreamId)) ? "-" : inlongStreamId;
+        dimensions.put(DataProxyMetricItem.KEY_INLONG_GROUP_ID, inlongGroupId);
+        dimensions.put(DataProxyMetricItem.KEY_INLONG_STREAM_ID, inlongStreamId);
+    }
+
+    /**
+     * addSendResultMetric
+     * 
+     * @param currentRecord
+     * @param bid
+     * @param result
+     * @param sendTime
+     */
+    public void addSendResultMetric(DispatchProfile currentRecord, String bid, boolean result, long sendTime) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(DataProxyMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        // metric
+        fillInlongId(currentRecord, dimensions);
+        dimensions.put(DataProxyMetricItem.KEY_SINK_ID, this.getSinkName());
+        dimensions.put(DataProxyMetricItem.KEY_SINK_DATA_ID, bid);
+        long msgTime = currentRecord.getDispatchTime();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(DataProxyMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        DataProxyMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        long count = currentRecord.getCount();
+        long size = currentRecord.getSize();
+        if (result) {
+            metricItem.sendSuccessCount.addAndGet(count);
+            metricItem.sendSuccessSize.addAndGet(size);
+            currentRecord.getEvents().forEach((event) -> {
+                AuditUtils.add(AuditUtils.AUDIT_ID_DATAPROXY_READ_SUCCESS, event);
+            });
+            if (sendTime > 0) {
+                long currentTime = System.currentTimeMillis();
+                currentRecord.getEvents().forEach((event) -> {
+                    long sinkDuration = currentTime - sendTime;
+                    long nodeDuration = currentTime - event.getMsgTime();
+                    long wholeDuration = currentTime - msgTime;
+                    metricItem.sinkDuration.addAndGet(sinkDuration * count);
+                    metricItem.nodeDuration.addAndGet(nodeDuration * count);
+                    metricItem.wholeDuration.addAndGet(wholeDuration * count);
+                });
+            }
+        } else {
+            metricItem.sendFailCount.addAndGet(count);
+            metricItem.sendFailSize.addAndGet(size);
+        }
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/tubezone/TubeZoneWorker.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/tubezone/TubeZoneWorker.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.tubezone;
+
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TubeZoneWorker
+ */
+public class TubeZoneWorker extends Thread {
+
+    public static final Logger LOG = LoggerFactory.getLogger(TubeZoneWorker.class);
+
+    private final String workerName;
+    private final TubeZoneSinkContext context;
+
+    private TubeZoneProducer zoneProducer;
+    private LifecycleState status;
+
+    /**
+     * Constructor
+     * 
+     * @param sinkName
+     * @param workerIndex
+     * @param context
+     */
+    public TubeZoneWorker(String sinkName, int workerIndex, TubeZoneSinkContext context) {
+        super();
+        this.workerName = sinkName + "-worker-" + workerIndex;
+        this.context = context;
+        this.zoneProducer = new TubeZoneProducer(workerName, this.context);
+        this.status = LifecycleState.IDLE;
+    }
+
+    /**
+     * start
+     */
+    @Override
+    public void start() {
+        this.zoneProducer.start();
+        this.status = LifecycleState.START;
+        super.start();
+    }
+
+    /**
+     * 
+     * close
+     */
+    public void close() {
+        // close all producers
+        this.zoneProducer.close();
+        this.status = LifecycleState.STOP;
+    }
+
+    /**
+     * run
+     */
+    @Override
+    public void run() {
+        LOG.info(String.format("start TubeZoneWorker:%s", this.workerName));
+        while (status != LifecycleState.STOP) {
+            try {
+                DispatchProfile event = context.getDispatchQueue().poll();
+                if (event == null) {
+                    this.sleepOneInterval();
+                    continue;
+                }
+                // metric
+                context.addSendMetric(event, workerName);
+                // send
+                this.zoneProducer.send(event);
+            } catch (Throwable e) {
+                LOG.error(e.getMessage(), e);
+                this.sleepOneInterval();
+            }
+        }
+    }
+
+    /**
+     * sleepOneInterval
+     */
+    private void sleepOneInterval() {
+        try {
+            Thread.sleep(context.getProcessInterval());
+        } catch (InterruptedException e1) {
+            LOG.error(e1.getMessage(), e1);
+        }
+    }
+}

--- a/inlong-dataproxy/pom.xml
+++ b/inlong-dataproxy/pom.xml
@@ -47,6 +47,7 @@
         <servlet.version>2.5-20110124</servlet.version>
         <inlong-common.version>1.3.4</inlong-common.version>
         <pulsar.version>2.8.1</pulsar.version>
+        <kafka.version>2.4.1</kafka.version>
         <testng.version>6.14.3</testng.version>
         <guava.version>19.0</guava.version>
         <powermock.version>2.0.9</powermock.version>
@@ -104,7 +105,12 @@
             <artifactId>pulsar-client</artifactId>
             <version>${pulsar.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>


### PR DESCRIPTION
### Title Name: [INLONG-2381][Inlong-DataProxy] DataProxy support Tube sink of PB compression cache message protocol. 

Fixes #2381 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
