### PR TITLE
[INLONG-2453] [TUBEMQ] upgrade velocity to secure version

### DIFF
--- a/inlong-tubemq/pom.xml
+++ b/inlong-tubemq/pom.xml
@@ -280,23 +280,9 @@
                 <version>4.0.1</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.velocity</groupId>
-                <artifactId>velocity-tools</artifactId>
-                <version>2.0</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.struts</groupId>
-                        <artifactId>struts-taglib</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.struts</groupId>
-                        <artifactId>struts-tiles</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.struts</groupId>
-                        <artifactId>struts-core</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>org.apache.velocity.tools</groupId>
+                <artifactId>velocity-tools-generic</artifactId>
+                <version>3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -339,8 +325,8 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.velocity</groupId>
-                <artifactId>velocity</artifactId>
-                <version>1.7</version>
+                <artifactId>velocity-engine-core</artifactId>
+                <version>2.3</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
@@ -356,6 +342,11 @@
                 <groupId>org.ini4j</groupId>
                 <artifactId>ini4j</artifactId>
                 <version>0.5.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.dom4j</groupId>
+                <artifactId>dom4j</artifactId>
+                <version>2.1.3</version>
             </dependency>
             <dependency>
                 <groupId>org.easymock</groupId>

--- a/inlong-tubemq/tubemq-server/pom.xml
+++ b/inlong-tubemq/tubemq-server/pom.xml
@@ -154,7 +154,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -181,8 +181,9 @@
             <artifactId>spring-orm</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity-tools</artifactId>
+            <groupId>org.apache.velocity.tools</groupId>
+            <artifactId>velocity-tools-generic</artifactId>
+            <version>3.1</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -199,6 +200,10 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/VelocityTemplateEngine.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/simplemvc/VelocityTemplateEngine.java
@@ -42,7 +42,6 @@ public class VelocityTemplateEngine implements TemplateEngine {
             engine.setProperty(VelocityEngine.FILE_RESOURCE_LOADER_PATH, config.getTemplatePath());
             engine.setProperty(VelocityEngine.FILE_RESOURCE_LOADER_CACHE, false);
             engine.setProperty(VelocityEngine.INPUT_ENCODING, TBaseConstants.META_DEFAULT_CHARSET_NAME);
-            engine.setProperty(VelocityEngine.OUTPUT_ENCODING, TBaseConstants.META_DEFAULT_CHARSET_NAME);
             engine.init();
         } else {
             engine.init(config.getVelocityConfigFilePath());

--- a/licenses/inlong-dataproxy/LICENSE-binary
+++ b/licenses/inlong-dataproxy/LICENSE-binary
@@ -280,7 +280,7 @@ Apache License Version 2.0:
  * Snappy for Java
    - org.xerial.snappy:snappy-java:snappy-java-1.1.0.jar
  * Apache Velocity
-   - org.apache.velocity:velocity:velocity-1.7.jar
+   - org.apache.velocity:velocity:velocity-engine-core-2.3.jar
  * Apache ZooKeeper
    - org.apache.zookeeper:zookeeper:zookeeper-3.4.6.jar
 

--- a/licenses/inlong-tubemq/LICENSE-binary
+++ b/licenses/inlong-tubemq/LICENSE-binary
@@ -231,8 +231,8 @@ Apache License Version 2.0:
    - commons-cli:commons-cli:commons-cli-1.4.jar
    - org.apache.commons:commons-lang3:3.10
  * Apache Velocity
-   - org.apache.velocity:velocity:velocity-1.7.jar
-   - org.apache.velocity:velocity-tools:velocity-tools-2.0.jar
+   - org.apache.velocity:velocity:velocity-engine-core-2.3.jar
+   - org.apache.velocity.tools:velocity-tools:velocity-tools-generic-3.1.jar
  * HttpClient
    - org.apache.httpcomponents:httpclient:httpclient-4.5.13.jar
    - org.apache.httpcomponents:httpcore:httpcore-4.4.13.jar


### PR DESCRIPTION

Fixes #2453

### Motivation

using secure libraries

### Modifications

* pom changes
* Velocity OUTPUT_ENCODING property no longer seems to be supported but velocity code defaults to UTF-8 anyway

### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
