### PR TITLE
[INLONG-2380] DataProxy support Kafka sink of PB compression cache message protocol.

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/dispatch/DispatchManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/dispatch/DispatchManager.java
@@ -43,12 +43,12 @@ public class DispatchManager {
     public static final long DEFAULT_DISPATCH_MAX_PACKSIZE = 327680;
     public static final long MINUTE_MS = 60L * 1000;
 
-    private LinkedBlockingQueue<DispatchProfile> dispatchQueue;
     private final long dispatchTimeout;
     private final long maxPackCount;
     private final long maxPackSize;
+    private LinkedBlockingQueue<DispatchProfile> dispatchQueue;
     private ConcurrentHashMap<String, DispatchProfile> profileCache = new ConcurrentHashMap<>();
-    //
+    // flag that manager need to output overtime data.
     private AtomicBoolean needOutputOvertimeData = new AtomicBoolean(false);
 
     /**
@@ -78,14 +78,14 @@ public class DispatchManager {
         String eventUid = event.getUid();
         long dispatchTime = event.getMsgTime() - event.getMsgTime() % MINUTE_MS;
         String dispatchKey = eventUid + "." + dispatchTime;
-        //
+        // find dispatch profile
         DispatchProfile dispatchProfile = this.profileCache.get(dispatchKey);
         if (dispatchProfile == null) {
             dispatchProfile = new DispatchProfile(eventUid, event.getInlongGroupId(), event.getInlongStreamId(),
                     dispatchTime);
             this.profileCache.put(dispatchKey, dispatchProfile);
         }
-        //
+        // add event
         boolean addResult = dispatchProfile.addEvent(event, maxPackCount, maxPackSize);
         if (!addResult) {
             DispatchProfile newDispatchProfile = new DispatchProfile(eventUid, event.getInlongGroupId(),

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/kafkazone/KafkaClusterProducer.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/kafkazone/KafkaClusterProducer.java
@@ -1,0 +1,216 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.kafkazone;
+
+import static org.apache.inlong.sdk.commons.protocol.EventConstants.HEADER_CACHE_VERSION_1;
+import static org.apache.inlong.sdk.commons.protocol.EventConstants.HEADER_KEY_VERSION;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.flume.Context;
+import org.apache.flume.lifecycle.LifecycleAware;
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
+import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
+import org.apache.inlong.sdk.commons.protocol.EventConstants;
+import org.apache.inlong.sdk.commons.protocol.EventUtils;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * KafkaClusterProducer
+ */
+public class KafkaClusterProducer implements LifecycleAware {
+
+    public static final Logger LOG = LoggerFactory.getLogger(KafkaClusterProducer.class);
+
+    protected final String workerName;
+    private final CacheClusterConfig config;
+    private final KafkaZoneSinkContext sinkContext;
+    private final Context producerContext;
+    private final String cacheClusterName;
+    private LifecycleState state;
+
+    // kafka producer
+    private KafkaProducer<String, byte[]> producer;
+
+    /**
+     * Constructor
+     * 
+     * @param workerName
+     * @param config
+     * @param context
+     */
+    public KafkaClusterProducer(String workerName, CacheClusterConfig config, KafkaZoneSinkContext context) {
+        this.workerName = workerName;
+        this.config = config;
+        this.sinkContext = context;
+        this.producerContext = context.getProducerContext();
+        this.state = LifecycleState.IDLE;
+        this.cacheClusterName = config.getClusterName();
+    }
+
+    /**
+     * start
+     */
+    @Override
+    public void start() {
+        this.state = LifecycleState.START;
+        // create kafka producer
+        try {
+            // prepare configuration
+            Properties props = new Properties();
+            props.putAll(this.producerContext.getParameters());
+            props.putAll(config.getParams());
+            LOG.info("try to create kafka client:{}", props);
+            producer = new KafkaProducer<>(props, new StringSerializer(), new ByteArraySerializer());
+            LOG.info("create new producer success:{}", producer);
+        } catch (Throwable e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * stop
+     */
+    @Override
+    public void stop() {
+        this.state = LifecycleState.STOP;
+        // kafka producer
+        this.producer.close();
+    }
+
+    /**
+     * getLifecycleState
+     * 
+     * @return
+     */
+    @Override
+    public LifecycleState getLifecycleState() {
+        return state;
+    }
+
+    /**
+     * send
+     * 
+     * @param event
+     */
+    public boolean send(DispatchProfile event) {
+        try {
+            // topic
+            String topic = sinkContext.getIdTopicHolder().getTopic(event.getUid());
+            if (topic == null) {
+                sinkContext.addSendResultMetric(event, event.getUid(), false, 0);
+                return false;
+            }
+            // create producer failed
+            if (producer == null) {
+                sinkContext.getDispatchQueue().offer(event);
+                sinkContext.addSendResultMetric(event, topic, false, 0);
+                return false;
+            }
+            // headers
+            Map<String, String> headers = this.encodeCacheMessageHeaders(event);
+            // compress
+            byte[] bodyBytes = EventUtils.encodeCacheMessageBody(sinkContext.getCompressType(), event.getEvents());
+            // sendAsync
+            long sendTime = System.currentTimeMillis();
+
+            // prepare ProducerRecord
+            ProducerRecord<String, byte[]> producerRecord = new ProducerRecord<>(topic, bodyBytes);
+            // add headers
+            headers.forEach((key, value) -> {
+                producerRecord.headers().add(key, value.getBytes());
+            });
+
+            // callback
+            Callback callback = new Callback() {
+
+                @Override
+                public void onCompletion(RecordMetadata arg0, Exception ex) {
+                    if (ex != null) {
+                        LOG.error("Send fail:{}", ex.getMessage());
+                        LOG.error(ex.getMessage(), ex);
+                        sinkContext.getDispatchQueue().offer(event);
+                        sinkContext.addSendResultMetric(event, topic, false, sendTime);
+                    } else {
+                        sinkContext.addSendResultMetric(event, topic, true, sendTime);
+                    }
+                }
+            };
+            producer.send(producerRecord, callback);
+            return true;
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            sinkContext.getDispatchQueue().offer(event);
+            sinkContext.addSendResultMetric(event, event.getUid(), false, 0);
+            return false;
+        }
+    }
+
+    /**
+     * encodeCacheMessageHeaders
+     * 
+     * @param  event
+     * @return       Map
+     */
+    public Map<String, String> encodeCacheMessageHeaders(DispatchProfile event) {
+        Map<String, String> headers = new HashMap<>();
+        // version int32 protocol version, the value is 1
+        headers.put(HEADER_KEY_VERSION, HEADER_CACHE_VERSION_1);
+        // inlongGroupId string inlongGroupId
+        headers.put(EventConstants.INLONG_GROUP_ID, event.getInlongGroupId());
+        // inlongStreamId string inlongStreamId
+        headers.put(EventConstants.INLONG_STREAM_ID, event.getInlongStreamId());
+        // proxyName string proxy node id, IP or conainer name
+        headers.put(EventConstants.HEADER_KEY_PROXY_NAME, sinkContext.getNodeId());
+        // packTime int64 pack time, milliseconds
+        headers.put(EventConstants.HEADER_KEY_PACK_TIME, String.valueOf(System.currentTimeMillis()));
+        // msgCount int32 message count
+        headers.put(EventConstants.HEADER_KEY_MSG_COUNT, String.valueOf(event.getEvents().size()));
+        // srcLength int32 total length of raw messages body
+        headers.put(EventConstants.HEADER_KEY_SRC_LENGTH, String.valueOf(event.getSize()));
+        // compressType int
+        // compress type of body data
+        // INLONG_NO_COMPRESS = 0,
+        // INLONG_GZ = 1,
+        // INLONG_SNAPPY = 2
+        headers.put(EventConstants.HEADER_KEY_COMPRESS_TYPE,
+                String.valueOf(sinkContext.getCompressType().getNumber()));
+        // messageKey string partition hash key, optional
+        return headers;
+    }
+
+    /**
+     * get cacheClusterName
+     * 
+     * @return the cacheClusterName
+     */
+    public String getCacheClusterName() {
+        return cacheClusterName;
+    }
+
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/kafkazone/KafkaZoneProducer.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/kafkazone/KafkaZoneProducer.java
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.kafkazone;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
+import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * KafkaZoneProducer
+ */
+public class KafkaZoneProducer {
+
+    public static final Logger LOG = LoggerFactory.getLogger(KafkaZoneProducer.class);
+    public static final int MAX_INDEX = Integer.MAX_VALUE / 2;
+
+    private final String workerName;
+    private final KafkaZoneSinkContext context;
+    private Timer reloadTimer;
+
+    private List<KafkaClusterProducer> clusterList = new ArrayList<>();
+    private List<KafkaClusterProducer> deletingClusterList = new ArrayList<>();
+
+    private AtomicInteger clusterIndex = new AtomicInteger(0);
+
+    /**
+     * Constructor
+     * 
+     * @param workerName
+     * @param context
+     */
+    public KafkaZoneProducer(String workerName, KafkaZoneSinkContext context) {
+        this.workerName = workerName;
+        this.context = context;
+    }
+
+    /**
+     * start
+     */
+    public void start() {
+        try {
+            this.reload();
+            this.setReloadTimer();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * close
+     */
+    public void close() {
+        try {
+            this.reloadTimer.cancel();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+        for (KafkaClusterProducer cluster : this.clusterList) {
+            cluster.stop();
+        }
+    }
+
+    /**
+     * setReloadTimer
+     */
+    private void setReloadTimer() {
+        reloadTimer = new Timer(true);
+        TimerTask task = new TimerTask() {
+
+            public void run() {
+                reload();
+            }
+        };
+        reloadTimer.schedule(task, new Date(System.currentTimeMillis() + context.getReloadInterval()),
+                context.getReloadInterval());
+    }
+
+    /**
+     * reload
+     */
+    public void reload() {
+        try {
+            // stop deleted cluster
+            deletingClusterList.forEach(item -> {
+                item.stop();
+            });
+            deletingClusterList.clear();
+            // update cluster list
+            List<CacheClusterConfig> configList = this.context.getCacheHolder().getConfigList();
+            List<KafkaClusterProducer> newClusterList = new ArrayList<>(configList.size());
+            // prepare
+            Set<String> newClusterNames = new HashSet<>();
+            configList.forEach(item -> {
+                newClusterNames.add(item.getClusterName());
+            });
+            Set<String> oldClusterNames = new HashSet<>();
+            clusterList.forEach(item -> {
+                oldClusterNames.add(item.getCacheClusterName());
+            });
+            // add
+            for (CacheClusterConfig config : configList) {
+                if (!oldClusterNames.contains(config.getClusterName())) {
+                    KafkaClusterProducer cluster = new KafkaClusterProducer(workerName, config, context);
+                    cluster.start();
+                    newClusterList.add(cluster);
+                }
+            }
+            // remove
+            for (KafkaClusterProducer cluster : this.clusterList) {
+                if (newClusterNames.contains(cluster.getCacheClusterName())) {
+                    newClusterList.add(cluster);
+                } else {
+                    deletingClusterList.add(cluster);
+                }
+            }
+            this.clusterList = newClusterList;
+        } catch (Throwable e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * send
+     * 
+     * @param event
+     */
+    public boolean send(DispatchProfile event) {
+        int currentIndex = clusterIndex.getAndIncrement();
+        if (currentIndex > MAX_INDEX) {
+            clusterIndex.set(0);
+        }
+        List<KafkaClusterProducer> currentClusterList = this.clusterList;
+        int currentSize = currentClusterList.size();
+        int realIndex = currentIndex % currentSize;
+        KafkaClusterProducer clusterProducer = currentClusterList.get(realIndex);
+        return clusterProducer.send(event);
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/kafkazone/KafkaZoneSink.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/kafkazone/KafkaZoneSink.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.kafkazone;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.EventDeliveryException;
+import org.apache.flume.Transaction;
+import org.apache.flume.conf.Configurable;
+import org.apache.flume.sink.AbstractSink;
+import org.apache.inlong.dataproxy.dispatch.DispatchManager;
+import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
+import org.apache.inlong.sdk.commons.protocol.ProxyEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * KafkaZoneSink
+ */
+public class KafkaZoneSink extends AbstractSink implements Configurable {
+
+    public static final Logger LOG = LoggerFactory.getLogger(KafkaZoneSink.class);
+
+    private Context parentContext;
+    private KafkaZoneSinkContext context;
+    private List<KafkaZoneWorker> workers = new ArrayList<>();
+    // message group
+    private DispatchManager dispatchManager;
+    private LinkedBlockingQueue<DispatchProfile> dispatchQueue = new LinkedBlockingQueue<>();
+    // scheduled thread pool
+    // reload
+    // dispatch
+    private ScheduledExecutorService scheduledPool;
+
+    /**
+     * configure
+     * 
+     * @param context
+     */
+    @Override
+    public void configure(Context context) {
+        LOG.info("start to configure:{}, context:{}.", this.getClass().getSimpleName(), context.toString());
+        this.parentContext = context;
+    }
+
+    /**
+     * start
+     */
+    @Override
+    public void start() {
+        try {
+            this.context = new KafkaZoneSinkContext(getName(), parentContext, getChannel(), this.dispatchQueue);
+            if (getChannel() == null) {
+                LOG.error("channel is null");
+            }
+            this.context.start();
+            this.dispatchManager = new DispatchManager(parentContext, dispatchQueue);
+            this.scheduledPool = Executors.newScheduledThreadPool(2);
+            // dispatch
+            this.scheduledPool.scheduleWithFixedDelay(new Runnable() {
+
+                public void run() {
+                    dispatchManager.setNeedOutputOvertimeData();
+                }
+            }, this.dispatchManager.getDispatchTimeout(), this.dispatchManager.getDispatchTimeout(),
+                    TimeUnit.MILLISECONDS);
+            // create worker
+            for (int i = 0; i < context.getMaxThreads(); i++) {
+                KafkaZoneWorker worker = new KafkaZoneWorker(this.getName(), i, context);
+                worker.start();
+                this.workers.add(worker);
+            }
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+        super.start();
+    }
+
+    /**
+     * stop
+     */
+    @Override
+    public void stop() {
+        for (KafkaZoneWorker worker : workers) {
+            try {
+                worker.close();
+            } catch (Throwable e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+        this.context.close();
+        super.stop();
+    }
+
+    /**
+     * process
+     * 
+     * @return                        Status
+     * @throws EventDeliveryException
+     */
+    @Override
+    public Status process() throws EventDeliveryException {
+        Channel channel = getChannel();
+        Transaction tx = channel.getTransaction();
+        tx.begin();
+        try {
+            Event event = channel.take();
+            if (event == null) {
+                tx.commit();
+                return Status.BACKOFF;
+            }
+            if (!(event instanceof ProxyEvent)) {
+                tx.commit();
+                this.context.addSendFailMetric();
+                return Status.READY;
+            }
+            //
+            ProxyEvent proxyEvent = (ProxyEvent) event;
+            this.dispatchManager.addEvent(proxyEvent);
+            tx.commit();
+            return Status.READY;
+        } catch (Throwable t) {
+            LOG.error("Process event failed!" + this.getName(), t);
+            try {
+                tx.rollback();
+            } catch (Throwable e) {
+                LOG.error("Channel take transaction rollback exception:" + getName(), e);
+            }
+            return Status.BACKOFF;
+        } finally {
+            tx.close();
+        }
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/kafkazone/KafkaZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/kafkazone/KafkaZoneSinkContext.java
@@ -1,0 +1,261 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.kafkazone;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.apache.inlong.dataproxy.config.RemoteConfigManager;
+import org.apache.inlong.dataproxy.config.holder.CacheClusterConfigHolder;
+import org.apache.inlong.dataproxy.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.dataproxy.config.holder.IdTopicConfigHolder;
+import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
+import org.apache.inlong.dataproxy.metrics.DataProxyMetricItem;
+import org.apache.inlong.dataproxy.metrics.audit.AuditUtils;
+import org.apache.inlong.dataproxy.sink.SinkContext;
+import org.apache.inlong.sdk.commons.protocol.ProxySdk.INLONG_COMPRESSED_TYPE;
+
+/**
+ * 
+ * KafkaZoneSinkContext
+ */
+public class KafkaZoneSinkContext extends SinkContext {
+
+    public static final String KEY_NODE_ID = "nodeId";
+    public static final String PREFIX_PRODUCER = "producer.";
+    public static final String KEY_COMPRESS_TYPE = "compressType";
+
+    private final LinkedBlockingQueue<DispatchProfile> dispatchQueue;
+
+    private final String proxyClusterId;
+    private final String nodeId;
+    private final Context producerContext;
+    //
+    private final IdTopicConfigHolder idTopicHolder;
+    private final CacheClusterConfigHolder cacheHolder;
+    private final INLONG_COMPRESSED_TYPE compressType;
+
+    /**
+     * Constructor
+     * 
+     * @param context
+     */
+    public KafkaZoneSinkContext(String sinkName, Context context, Channel channel,
+            LinkedBlockingQueue<DispatchProfile> dispatchQueue) {
+        super(sinkName, context, channel);
+        this.dispatchQueue = dispatchQueue;
+        // proxyClusterId
+        this.proxyClusterId = CommonPropertiesHolder.getString(RemoteConfigManager.KEY_PROXY_CLUSTER_NAME);
+        // nodeId
+        this.nodeId = CommonPropertiesHolder.getString(KEY_NODE_ID, "127.0.0.1");
+        // compressionType
+        String strCompressionType = CommonPropertiesHolder.getString(KEY_COMPRESS_TYPE,
+                INLONG_COMPRESSED_TYPE.INLONG_SNAPPY.name());
+        this.compressType = INLONG_COMPRESSED_TYPE.valueOf(strCompressionType);
+        // producerContext
+        Map<String, String> producerParams = context.getSubProperties(PREFIX_PRODUCER);
+        this.producerContext = new Context(producerParams);
+        // idTopicHolder
+        this.idTopicHolder = new IdTopicConfigHolder();
+        this.idTopicHolder.configure(context);
+        // cacheHolder
+        this.cacheHolder = new CacheClusterConfigHolder();
+        this.cacheHolder.configure(context);
+    }
+
+    /**
+     * start
+     */
+    public void start() {
+        super.start();
+        this.idTopicHolder.start();
+        this.cacheHolder.start();
+    }
+
+    /**
+     * close
+     */
+    public void close() {
+        super.close();
+        this.idTopicHolder.close();
+        this.cacheHolder.close();
+    }
+
+    /**
+     * get proxyClusterId
+     * 
+     * @return the proxyClusterId
+     */
+    public String getProxyClusterId() {
+        return proxyClusterId;
+    }
+
+    /**
+     * get dispatchQueue
+     * 
+     * @return the dispatchQueue
+     */
+    public LinkedBlockingQueue<DispatchProfile> getDispatchQueue() {
+        return dispatchQueue;
+    }
+
+    /**
+     * get producerContext
+     * 
+     * @return the producerContext
+     */
+    public Context getProducerContext() {
+        return producerContext;
+    }
+
+    /**
+     * get idTopicHolder
+     * 
+     * @return the idTopicHolder
+     */
+    public IdTopicConfigHolder getIdTopicHolder() {
+        return idTopicHolder;
+    }
+
+    /**
+     * get cacheHolder
+     * 
+     * @return the cacheHolder
+     */
+    public CacheClusterConfigHolder getCacheHolder() {
+        return cacheHolder;
+    }
+
+    /**
+     * get compressType
+     * 
+     * @return the compressType
+     */
+    public INLONG_COMPRESSED_TYPE getCompressType() {
+        return compressType;
+    }
+
+    /**
+     * get nodeId
+     * 
+     * @return the nodeId
+     */
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    /**
+     * addSendingMetric
+     * 
+     * @param currentRecord
+     * @param bid
+     */
+    public void addSendingMetric(DispatchProfile currentRecord, String bid) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(DataProxyMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        // metric
+        fillInlongId(currentRecord, dimensions);
+        dimensions.put(DataProxyMetricItem.KEY_SINK_ID, this.getSinkName());
+        dimensions.put(DataProxyMetricItem.KEY_SINK_DATA_ID, bid);
+        long msgTime = currentRecord.getDispatchTime();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(DataProxyMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        DataProxyMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        long count = currentRecord.getCount();
+        long size = currentRecord.getSize();
+        metricItem.sendCount.addAndGet(count);
+        metricItem.sendSize.addAndGet(size);
+    }
+
+    /**
+     * addReadFailMetric
+     */
+    public void addSendFailMetric() {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(DataProxyMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        dimensions.put(DataProxyMetricItem.KEY_SINK_ID, this.getSinkName());
+        long msgTime = System.currentTimeMillis();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(DataProxyMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        DataProxyMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        metricItem.readFailCount.incrementAndGet();
+    }
+
+    /**
+     * fillInlongId
+     * 
+     * @param currentRecord
+     * @param dimensions
+     */
+    public static void fillInlongId(DispatchProfile currentRecord, Map<String, String> dimensions) {
+        String inlongGroupId = currentRecord.getInlongGroupId();
+        inlongGroupId = (StringUtils.isBlank(inlongGroupId)) ? "-" : inlongGroupId;
+        String inlongStreamId = currentRecord.getInlongStreamId();
+        inlongStreamId = (StringUtils.isBlank(inlongStreamId)) ? "-" : inlongStreamId;
+        dimensions.put(DataProxyMetricItem.KEY_INLONG_GROUP_ID, inlongGroupId);
+        dimensions.put(DataProxyMetricItem.KEY_INLONG_STREAM_ID, inlongStreamId);
+    }
+
+    /**
+     * addSendResultMetric
+     * 
+     * @param currentRecord
+     * @param bid
+     * @param result
+     * @param sendTime
+     */
+    public void addSendResultMetric(DispatchProfile currentRecord, String bid, boolean result, long sendTime) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(DataProxyMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        // metric
+        fillInlongId(currentRecord, dimensions);
+        dimensions.put(DataProxyMetricItem.KEY_SINK_ID, this.getSinkName());
+        dimensions.put(DataProxyMetricItem.KEY_SINK_DATA_ID, bid);
+        long msgTime = currentRecord.getDispatchTime();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(DataProxyMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        DataProxyMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        long count = currentRecord.getCount();
+        long size = currentRecord.getSize();
+        if (result) {
+            metricItem.sendSuccessCount.addAndGet(count);
+            metricItem.sendSuccessSize.addAndGet(size);
+            currentRecord.getEvents().forEach((event) -> {
+                AuditUtils.add(AuditUtils.AUDIT_ID_DATAPROXY_READ_SUCCESS, event);
+            });
+            if (sendTime > 0) {
+                long currentTime = System.currentTimeMillis();
+                currentRecord.getEvents().forEach((event) -> {
+                    long sinkDuration = currentTime - sendTime;
+                    long nodeDuration = currentTime - event.getMsgTime();
+                    long wholeDuration = currentTime - msgTime;
+                    metricItem.sinkDuration.addAndGet(sinkDuration * count);
+                    metricItem.nodeDuration.addAndGet(nodeDuration * count);
+                    metricItem.wholeDuration.addAndGet(wholeDuration * count);
+                });
+            }
+        } else {
+            metricItem.sendFailCount.addAndGet(count);
+            metricItem.sendFailSize.addAndGet(size);
+        }
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/kafkazone/KafkaZoneWorker.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/kafkazone/KafkaZoneWorker.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.kafkazone;
+
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * KafkaZoneWorker
+ */
+public class KafkaZoneWorker extends Thread {
+
+    public static final Logger LOG = LoggerFactory.getLogger(KafkaZoneWorker.class);
+
+    private final String workerName;
+    private final KafkaZoneSinkContext context;
+
+    private KafkaZoneProducer zoneProducer;
+    private LifecycleState status;
+
+    /**
+     * Constructor
+     * 
+     * @param sinkName
+     * @param workerIndex
+     * @param context
+     */
+    public KafkaZoneWorker(String sinkName, int workerIndex, KafkaZoneSinkContext context) {
+        super();
+        this.workerName = sinkName + "-worker-" + workerIndex;
+        this.context = context;
+        this.zoneProducer = new KafkaZoneProducer(workerName, this.context);
+        this.status = LifecycleState.IDLE;
+    }
+
+    /**
+     * start
+     */
+    @Override
+    public void start() {
+        this.zoneProducer.start();
+        this.status = LifecycleState.START;
+        super.start();
+    }
+
+    /**
+     * 
+     * close
+     */
+    public void close() {
+        // close all producers
+        this.zoneProducer.close();
+        this.status = LifecycleState.STOP;
+    }
+
+    /**
+     * run
+     */
+    @Override
+    public void run() {
+        LOG.info(String.format("start KafkaZoneWorker:%s", this.workerName));
+        while (status != LifecycleState.STOP) {
+            try {
+                DispatchProfile event = context.getDispatchQueue().poll();
+                if (event == null) {
+                    this.sleepOneInterval();
+                    continue;
+                }
+                // metric
+                context.addSendingMetric(event, workerName);
+                // send
+                this.zoneProducer.send(event);
+            } catch (Throwable e) {
+                LOG.error(e.getMessage(), e);
+                this.sleepOneInterval();
+            }
+        }
+    }
+
+    /**
+     * sleepOneInterval
+     */
+    private void sleepOneInterval() {
+        try {
+            Thread.sleep(context.getProcessInterval());
+        } catch (InterruptedException e1) {
+            LOG.error(e1.getMessage(), e1);
+        }
+    }
+}


### PR DESCRIPTION
### Title Name: [INLONG-2380][Inlong-DataProxy] DataProxy support Kafka sink of PB compression cache message protocol.

Fixes #2380 


### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
