### PR TITLE
[INLONG-2509][Feature][Audit][DockerCompose] Add support for Audit on Docker Compose

### DIFF
--- a/docker/docker-compose/README.md
+++ b/docker/docker-compose/README.md
@@ -9,10 +9,11 @@ Requirements:
 
 ### Deploy
 
-Manually copy SQL files from `inlong-manager/sql` to the `docker/compose/sql` directory.
+Manually copy SQL files from `inlong-manager/sql` and `inlong-audit/sql` to the `docker/docker-compose/sql` directory.
 
 ```shell
-cp inlong-manager/sql/apache_inlong_manager.sql  docker/docker-compose/sql
+cp inlong-manager/sql/apache_inlong_manager.sql docker/docker-compose/sql
+cp inlong-audit/sql/apache_inlong_audit.sql docker/docker-compose/sql
 ```
 
 Then, start all components.

--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -33,6 +33,19 @@ services:
       - ./mysql:/var/lib/mysql
       - ./sql:/docker-entrypoint-initdb.d
 
+  pulsar:
+    image: apachepulsar/pulsar
+    container_name: pulsar
+    environment:
+      - PULSAR_MEM="-Xms256m -Xmx512m -XX:MaxDirectMemorySize=1g"
+    ports:
+      - "6650:6650"
+      - "8181:8080"
+    volumes:
+      - ./pulsar/data:/pulsar/data
+      - ./pulsar/conf:/pulsar/conf
+    command: bin/pulsar standalone
+
   tubemq-server:
     image: inlong/tubemq-all:latest
     container_name: tubemq-server
@@ -124,3 +137,19 @@ services:
       - "8008:8008"
     volumes:
       - ./collect-data:/data/collect-data
+
+  audit:
+    image: inlong/audit:latest
+    container_name: audit
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      - JDBC_URL="jdbc:mysql:\/\/mysql:3306\/apache_inlong_audit?useSSL=false\&allowPublicKeyRetrieval=true\&characterEncoding=UTF-8\&nullCatalogMeansCurrent=true\&serverTimezone=GMT%2b8"
+      - USERNAME=root
+      - PASSWORD=inlong
+      - MANAGER_OPENAPI_IP=manager
+      - MANAGER_OPENAPI_PORT=8083
+      - PULSAR_BROKER_URL_LIST="pulsar://pulsar:6650"
+    ports:
+      - "46801:46801"

--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       - PULSAR_MEM="-Xms256m -Xmx512m -XX:MaxDirectMemorySize=1g"
     ports:
       - "6650:6650"
-      - "8181:8080"
     volumes:
       - ./pulsar/data:/pulsar/data
       - ./pulsar/conf:/pulsar/conf


### PR DESCRIPTION
Fixes: #2509

### Motivation

The audit feature has been brought in #1738. Next we should add support for it on Docker Compose.

### Modifications

- `docker/docker-compose/docker-compose.yml`
- `docker/docker-compose/README.md`
