### PR TITLE
[INLONG-2530][Agent][Bug] Agent data time never changes

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -82,6 +82,14 @@ public class AgentUtils {
     }
 
     /**
+     * return system current time
+     * @return
+     */
+    public static long getCurrentTime() {
+        return System.currentTimeMillis();
+    }
+
+    /**
      * finally close resources
      *
      * @param resource -  resource which is closable.

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
@@ -172,11 +172,12 @@ public class ProxySink extends AbstractSink {
                     cache.forEach((s, packProxyMessage) -> {
                         Pair<String, List<byte[]>> result = packProxyMessage.fetchBatch();
                         if (result != null) {
+                            long sendTime = AgentUtils.getCurrentTime();
                             senderManager.sendBatch(jobInstanceId, inlongGroupId, result.getKey(),
-                                    result.getValue(), 0, dataTime);
+                                    result.getValue(), 0, sendTime);
                             LOGGER.info("send group id {} with message size {}, the job id is {}, read source is {}"
-                                            + "dataTime is {}", inlongGroupId, result.getRight().size(),
-                                    jobInstanceId, sourceName, dataTime);
+                                            + "sendTime is {}", inlongGroupId, result.getRight().size(),
+                                    jobInstanceId, sourceName, sendTime);
                         }
 
                     });


### PR DESCRIPTION
### Title Name: [INLONG-2530][Agent][Bug]Agent data time never changes #2533

Fixes #2530

### Motivation

Agent data time never changes
### Modifications

Agent data time never changes
Use Agent local time to be the send time when sending data

### Verifying this change

- [x] Make sure that the change passes the CI checks.
