### PR TITLE
[INLONG-2531][Doc]The Quick Start URL is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ InLong is based on MQ and aims to provide a one-stop, practice-tested module plu
 InLong is only a one-stop data reporting pipeline platform. It cannot be used as a persistent data storage, nor does it support complex business logic processing on data streams.
 
 ## Build InLong
-More detailed instructions can be found at [Quick Start](https://inlong.apache.org/docs/next/introduction) section in the documentation.
+More detailed instructions can be found at [Quick Start](https://inlong.apache.org/docs/next/quick_start/how_to_build) section in the documentation.
 
 Requirements:
 - Java [JDK 8](https://adoptopenjdk.net/?variant=openjdk8)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ InLong is based on MQ and aims to provide a one-stop, practice-tested module plu
 InLong is only a one-stop data reporting pipeline platform. It cannot be used as a persistent data storage, nor does it support complex business logic processing on data streams.
 
 ## Build InLong
-More detailed instructions can be found at [Quick Start](https://inlong.apache.org/docs/user_guide/quick_start) section in the documentation.
+More detailed instructions can be found at [Quick Start](https://inlong.apache.org/docs/next/introduction) section in the documentation.
 
 Requirements:
 - Java [JDK 8](https://adoptopenjdk.net/?variant=openjdk8)


### PR DESCRIPTION
### Modifications
The Quick Start URL is invalid, Now modify it to the URL of Quick Start in the official website(https://inlong.apache.org)

### Motivation
issue: https://github.com/apache/incubator-inlong/issues/2531
