### PR TITLE
[INLONG-2579][Manager] support data flow to ClickHouse

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/BizConstant.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/BizConstant.java
@@ -24,6 +24,8 @@ public class BizConstant {
 
     public static final String STORAGE_HIVE = "HIVE";
 
+    public static final String STORAGE_CLICKHOUSE = "CLICKHOUSE";
+
     public static final String DATA_SOURCE_DB = "DB";
 
     public static final String DATA_SOURCE_FILE = "FILE";

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/datastorage/ck/ClickHouseStorageDTO.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/datastorage/ck/ClickHouseStorageDTO.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.pojo.datastorage.ck;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.inlong.manager.common.enums.BizErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+
+/**
+ * ClickHouse storage info
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClickHouseStorageDTO {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @ApiModelProperty("ClickHouse JDBC URL")
+    private String jdbcUrl;
+
+    @ApiModelProperty("Target database name")
+    private String databaseName;
+
+    @ApiModelProperty("Target table name")
+    private String tableName;
+
+    @ApiModelProperty("Username for JDBC URL")
+    private String username;
+
+    @ApiModelProperty("User password")
+    private String password;
+
+    @ApiModelProperty("Whether distributed table")
+    private Boolean distributedTable;
+
+    @ApiModelProperty("Partition strategy,support: BALANCE, RANDOM, HASH")
+    private String partitionStrategy;
+
+    @ApiModelProperty("Partition key")
+    private String partitionKey;
+
+    @ApiModelProperty("Key field names")
+    private String[] keyFieldNames;
+
+    @ApiModelProperty("Flush interval")
+    private Integer flushInterval;
+
+    @ApiModelProperty("Flush record number")
+    private Integer flushRecordNumber;
+
+    @ApiModelProperty("Write max retry times")
+    private Integer writeMaxRetryTimes;
+
+    /**
+     * Get the dto instance from the request
+     */
+    public static ClickHouseStorageDTO getFromRequest(ClickHouseStorageRequest request) {
+        return ClickHouseStorageDTO.builder()
+                .jdbcUrl(request.getJdbcUrl())
+                .username(request.getUsername())
+                .password(request.getPassword())
+                .databaseName(request.getDatabaseName())
+                .tableName(request.getTableName())
+                .distributedTable(request.getDistributedTable())
+                .partitionStrategy(request.getPartitionStrategy())
+                .partitionKey(request.getPartitionKey())
+                .keyFieldNames(request.getKeyFieldNames())
+                .flushInterval(request.getFlushInterval())
+                .flushRecordNumber(request.getFlushRecordNumber())
+                .writeMaxRetryTimes(request.getWriteMaxRetryTimes())
+                .build();
+    }
+
+    public static ClickHouseStorageDTO getFromJson(@NotNull String extParams) {
+        try {
+            OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            return OBJECT_MAPPER.readValue(extParams, ClickHouseStorageDTO.class);
+        } catch (Exception e) {
+            throw new BusinessException(BizErrorCodeEnum.STORAGE_INFO_INCORRECT.getMessage());
+        }
+    }
+
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/datastorage/ck/ClickHouseStorageListResponse.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/datastorage/ck/ClickHouseStorageListResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.pojo.datastorage.ck;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.inlong.manager.common.pojo.datastorage.StorageListResponse;
+
+/**
+ * Response of ClickHouse storage list
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ApiModel("Response of ClickHouse storage paging list")
+public class ClickHouseStorageListResponse extends StorageListResponse {
+
+    @ApiModelProperty("ClickHouse JDBC URL")
+    private String jdbcUrl;
+
+    @ApiModelProperty("Target database name")
+    private String databaseName;
+
+    @ApiModelProperty("Target table name")
+    private String tableName;
+
+    @ApiModelProperty("Username for JDBC URL")
+    private String username;
+
+    @ApiModelProperty("User password")
+    private String password;
+
+    @ApiModelProperty("Whether distributed table")
+    private Boolean distributedTable;
+
+    @ApiModelProperty("Partition strategy,support: BALANCE, RANDOM, HASH")
+    private String partitionStrategy;
+
+    @ApiModelProperty("Partition key")
+    private String partitionKey;
+
+    @ApiModelProperty("Key field names")
+    private String[] keyFieldNames;
+
+    @ApiModelProperty("Flush interval")
+    private Integer flushInterval;
+
+    @ApiModelProperty("Flush record number")
+    private Integer flushRecordNumber;
+
+    @ApiModelProperty("Write max retry times")
+    private Integer writeMaxRetryTimes;
+
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/datastorage/ck/ClickHouseStorageRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/datastorage/ck/ClickHouseStorageRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.pojo.datastorage.ck;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.enums.BizConstant;
+import org.apache.inlong.manager.common.pojo.datastorage.StorageRequest;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+
+/**
+ * Request of the ClickHouse storage info
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(value = "Request of the ClickHouse storage info")
+@JsonTypeDefine(value = BizConstant.STORAGE_CLICKHOUSE)
+public class ClickHouseStorageRequest extends StorageRequest {
+
+    @ApiModelProperty("ClickHouse JDBC URL")
+    private String jdbcUrl;
+
+    @ApiModelProperty("Target database name")
+    private String databaseName;
+
+    @ApiModelProperty("Target table name")
+    private String tableName;
+
+    @ApiModelProperty("Username for JDBC URL")
+    private String username;
+
+    @ApiModelProperty("User password")
+    private String password;
+
+    @ApiModelProperty("Whether distributed table")
+    private Boolean distributedTable;
+
+    @ApiModelProperty("Partition strategy,support: BALANCE, RANDOM, HASH")
+    private String partitionStrategy;
+
+    @ApiModelProperty("Partition key")
+    private String partitionKey;
+
+    @ApiModelProperty("Key field names")
+    private String[] keyFieldNames;
+
+    @ApiModelProperty("Flush interval")
+    private Integer flushInterval;
+
+    @ApiModelProperty("Flush record number")
+    private Integer flushRecordNumber;
+
+    @ApiModelProperty("Write max retry times")
+    private Integer writeMaxRetryTimes;
+
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/datastorage/ck/ClickHouseStorageResponse.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/datastorage/ck/ClickHouseStorageResponse.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.pojo.datastorage.ck;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.enums.BizConstant;
+import org.apache.inlong.manager.common.pojo.datastorage.StorageResponse;
+
+/**
+ * Response of the ClickHouse storage
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(value = "Response of the ClickHouse storage")
+public class ClickHouseStorageResponse extends StorageResponse {
+
+    private String storageType = BizConstant.STORAGE_CLICKHOUSE;
+
+    @ApiModelProperty("ClickHouse JDBC URL")
+    private String jdbcUrl;
+
+    @ApiModelProperty("Target database name")
+    private String databaseName;
+
+    @ApiModelProperty("Target table name")
+    private String tableName;
+
+    @ApiModelProperty("Username for JDBC URL")
+    private String username;
+
+    @ApiModelProperty("User password")
+    private String password;
+
+    @ApiModelProperty("Whether distributed table")
+    private Boolean distributedTable;
+
+    @ApiModelProperty("Partition strategy,support: BALANCE, RANDOM, HASH")
+    private String partitionStrategy;
+
+    @ApiModelProperty("Partition key")
+    private String partitionKey;
+
+    @ApiModelProperty("Key field names")
+    private String[] keyFieldNames;
+
+    @ApiModelProperty("Flush interval")
+    private Integer flushInterval;
+
+    @ApiModelProperty("Flush record number")
+    private Integer flushRecordNumber;
+
+    @ApiModelProperty("Write max retry times")
+    private Integer writeMaxRetryTimes;
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/storage/ck/ClickHouseStorageOperation.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/storage/ck/ClickHouseStorageOperation.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.storage.ck;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.pagehelper.Page;
+import com.github.pagehelper.PageInfo;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Supplier;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.enums.BizConstant;
+import org.apache.inlong.manager.common.enums.BizErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.EntityStatus;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.pojo.datastorage.StorageFieldRequest;
+import org.apache.inlong.manager.common.pojo.datastorage.StorageFieldResponse;
+import org.apache.inlong.manager.common.pojo.datastorage.StorageListResponse;
+import org.apache.inlong.manager.common.pojo.datastorage.StorageRequest;
+import org.apache.inlong.manager.common.pojo.datastorage.StorageResponse;
+import org.apache.inlong.manager.common.pojo.datastorage.ck.ClickHouseStorageDTO;
+import org.apache.inlong.manager.common.pojo.datastorage.ck.ClickHouseStorageListResponse;
+import org.apache.inlong.manager.common.pojo.datastorage.ck.ClickHouseStorageRequest;
+import org.apache.inlong.manager.common.pojo.datastorage.ck.ClickHouseStorageResponse;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.dao.entity.StorageEntity;
+import org.apache.inlong.manager.dao.entity.StorageFieldEntity;
+import org.apache.inlong.manager.dao.mapper.StorageEntityMapper;
+import org.apache.inlong.manager.dao.mapper.StorageFieldEntityMapper;
+import org.apache.inlong.manager.service.storage.StorageOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * ClickHouse storage operation
+ */
+@Service
+public class ClickHouseStorageOperation implements StorageOperation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClickHouseStorageOperation.class);
+
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private StorageEntityMapper storageMapper;
+    @Autowired
+    private StorageFieldEntityMapper storageFieldMapper;
+
+    @Override
+    public Boolean accept(String storageType) {
+        return BizConstant.STORAGE_CLICKHOUSE.equals(storageType);
+    }
+
+    @Override
+    public Integer saveOpt(StorageRequest request, String operator) {
+        String storageType = request.getStorageType();
+        Preconditions.checkTrue(BizConstant.STORAGE_CLICKHOUSE.equals(storageType),
+                BizErrorCodeEnum.STORAGE_TYPE_NOT_SUPPORT.getMessage() + ": " + storageType);
+
+        ClickHouseStorageRequest clickHouseStorageRequest = (ClickHouseStorageRequest) request;
+        StorageEntity entity = CommonBeanUtils.copyProperties(clickHouseStorageRequest, StorageEntity::new);
+        entity.setStatus(EntityStatus.DATA_STORAGE_NEW.getCode());
+        entity.setIsDeleted(EntityStatus.UN_DELETED.getCode());
+        entity.setCreator(operator);
+        entity.setModifier(operator);
+        Date now = new Date();
+        entity.setCreateTime(now);
+        entity.setModifyTime(now);
+
+        // get the ext params
+        ClickHouseStorageDTO dto = ClickHouseStorageDTO.getFromRequest(clickHouseStorageRequest);
+        try {
+            entity.setExtParams(objectMapper.writeValueAsString(dto));
+        } catch (Exception e) {
+            throw new BusinessException(BizErrorCodeEnum.STORAGE_SAVE_FAILED);
+        }
+        storageMapper.insert(entity);
+
+        Integer storageId = entity.getId();
+        request.setId(storageId);
+        this.saveFieldOpt(request);
+
+        return storageId;
+    }
+
+    @Override
+    public void saveFieldOpt(StorageRequest request) {
+        List<StorageFieldRequest> fieldList = request.getFieldList();
+        LOGGER.info("begin to save field={}", fieldList);
+        if (CollectionUtils.isEmpty(fieldList)) {
+            return;
+        }
+
+        int size = fieldList.size();
+        List<StorageFieldEntity> entityList = new ArrayList<>(size);
+        String groupId = request.getInlongGroupId();
+        String streamId = request.getInlongStreamId();
+        String storageType = request.getStorageType();
+        Integer storageId = request.getId();
+        for (StorageFieldRequest fieldInfo : fieldList) {
+            StorageFieldEntity fieldEntity = CommonBeanUtils.copyProperties(fieldInfo, StorageFieldEntity::new);
+            if (StringUtils.isEmpty(fieldEntity.getFieldComment())) {
+                fieldEntity.setFieldComment(fieldEntity.getFieldName());
+            }
+            fieldEntity.setInlongGroupId(groupId);
+            fieldEntity.setInlongStreamId(streamId);
+            fieldEntity.setStorageType(storageType);
+            fieldEntity.setStorageId(storageId);
+            fieldEntity.setIsDeleted(EntityStatus.UN_DELETED.getCode());
+            entityList.add(fieldEntity);
+        }
+
+        storageFieldMapper.insertAll(entityList);
+        LOGGER.info("success to save clickHouse field");
+    }
+
+    @Override
+    public StorageResponse getById(@NotNull String storageType, @NotNull Integer id) {
+        StorageEntity entity = storageMapper.selectByPrimaryKey(id);
+        Preconditions.checkNotNull(entity, BizErrorCodeEnum.STORAGE_INFO_NOT_FOUND.getMessage());
+        String existType = entity.getStorageType();
+        Preconditions.checkTrue(BizConstant.STORAGE_CLICKHOUSE.equals(existType),
+                String.format(BizConstant.STORAGE_TYPE_NOT_SAME, BizConstant.STORAGE_CLICKHOUSE, existType));
+
+        StorageResponse response = this.getFromEntity(entity, ClickHouseStorageResponse::new);
+        List<StorageFieldEntity> entities = storageFieldMapper.selectByStorageId(id);
+        List<StorageFieldResponse> infos = CommonBeanUtils.copyListProperties(entities,
+                StorageFieldResponse::new);
+        response.setFieldList(infos);
+
+        return response;
+    }
+
+    @Override
+    public <T> T getFromEntity(StorageEntity entity, Supplier<T> target) {
+        T result = target.get();
+        if (entity == null) {
+            return result;
+        }
+
+        String existType = entity.getStorageType();
+        Preconditions.checkTrue(BizConstant.STORAGE_CLICKHOUSE.equals(existType),
+                String.format(BizConstant.STORAGE_TYPE_NOT_SAME, BizConstant.STORAGE_CLICKHOUSE, existType));
+
+        ClickHouseStorageDTO dto = ClickHouseStorageDTO.getFromJson(entity.getExtParams());
+        CommonBeanUtils.copyProperties(entity, result, true);
+        CommonBeanUtils.copyProperties(dto, result, true);
+
+        return result;
+    }
+
+    @Override
+    public PageInfo<? extends StorageListResponse> getPageInfo(Page<StorageEntity> entityPage) {
+        if (CollectionUtils.isEmpty(entityPage)) {
+            return new PageInfo<>();
+        }
+        return entityPage.toPageInfo(entity -> this.getFromEntity(entity, ClickHouseStorageListResponse::new));
+    }
+
+    @Override
+    public void updateOpt(StorageRequest request, String operator) {
+        String storageType = request.getStorageType();
+        Preconditions.checkTrue(BizConstant.STORAGE_CLICKHOUSE.equals(storageType),
+                String.format(BizConstant.STORAGE_TYPE_NOT_SAME, BizConstant.STORAGE_CLICKHOUSE, storageType));
+
+        StorageEntity entity = storageMapper.selectByPrimaryKey(request.getId());
+        Preconditions.checkNotNull(entity, BizErrorCodeEnum.STORAGE_INFO_NOT_FOUND.getMessage());
+        ClickHouseStorageRequest clickHouseStorageRequest = (ClickHouseStorageRequest) request;
+        CommonBeanUtils.copyProperties(clickHouseStorageRequest, entity, true);
+        try {
+            ClickHouseStorageDTO dto = ClickHouseStorageDTO.getFromRequest(clickHouseStorageRequest);
+            entity.setExtParams(objectMapper.writeValueAsString(dto));
+        } catch (Exception e) {
+            throw new BusinessException(BizErrorCodeEnum.STORAGE_INFO_INCORRECT.getMessage());
+        }
+
+        entity.setPreviousStatus(entity.getStatus());
+        entity.setStatus(EntityStatus.BIZ_CONFIG_ING.getCode());
+        entity.setModifier(operator);
+        entity.setModifyTime(new Date());
+        storageMapper.updateByPrimaryKeySelective(entity);
+
+        boolean onlyAdd = EntityStatus.DATA_STORAGE_CONFIG_SUCCESSFUL.getCode().equals(entity.getPreviousStatus());
+        this.updateFieldOpt(onlyAdd, clickHouseStorageRequest);
+
+        LOGGER.info("success to update storage of type={}", storageType);
+    }
+
+    @Override
+    public void updateFieldOpt(Boolean onlyAdd, StorageRequest request) {
+        Integer storageId = request.getId();
+        List<StorageFieldRequest> fieldRequestList = request.getFieldList();
+        if (CollectionUtils.isEmpty(fieldRequestList)) {
+            return;
+        }
+
+        if (onlyAdd) {
+            List<StorageFieldEntity> existsFieldList = storageFieldMapper.selectByStorageId(storageId);
+            if (existsFieldList.size() > fieldRequestList.size()) {
+                throw new BusinessException(BizErrorCodeEnum.STORAGE_FIELD_UPDATE_NOT_ALLOWED);
+            }
+            for (int i = 0; i < existsFieldList.size(); i++) {
+                if (!existsFieldList.get(i).getFieldName().equals(fieldRequestList.get(i).getFieldName())) {
+                    throw new BusinessException(BizErrorCodeEnum.STORAGE_FIELD_UPDATE_NOT_ALLOWED);
+                }
+            }
+        }
+
+        // First physically delete the existing fields
+        storageFieldMapper.deleteAll(storageId);
+        // Then batch save the storage fields
+        this.saveFieldOpt(request);
+
+        LOGGER.info("success to update field");
+    }
+
+}

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/service/core/ClickHouseStorageServiceTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/service/core/ClickHouseStorageServiceTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.core;
+
+import org.apache.inlong.manager.common.enums.BizConstant;
+import org.apache.inlong.manager.common.pojo.datastorage.StorageResponse;
+import org.apache.inlong.manager.common.pojo.datastorage.ck.ClickHouseStorageRequest;
+import org.apache.inlong.manager.common.pojo.datastorage.ck.ClickHouseStorageResponse;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.service.storage.StorageService;
+import org.apache.inlong.manager.web.WebBaseTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Data storage service test
+ */
+public class ClickHouseStorageServiceTest extends WebBaseTest {
+
+    @Autowired
+    private StorageService storageService;
+    @Autowired
+    private DataStreamServiceTest streamServiceTest;
+
+    // Partial test data
+    private static final String globalGroupId = "b_group1";
+    private static final String globalStreamId = "stream1";
+    private static final String globalOperator = "test_user";
+    private static final String ckJdbcUrl = "jdbc:clickhouse://127.0.0.1:8123/default";
+    private static final String ckUsername = "ck_user";
+    private static final String ckDatabaseName = "ck_db";
+    private static final String ckTableName = "ck_tbl";
+
+    private static Integer ckStorageId;
+
+    @Before
+    public void saveStorage() {
+        streamServiceTest.saveDataStream(globalGroupId, globalStreamId, globalOperator);
+        ClickHouseStorageRequest storageInfo = new ClickHouseStorageRequest();
+        storageInfo.setInlongGroupId(globalGroupId);
+        storageInfo.setInlongStreamId(globalStreamId);
+        storageInfo.setStorageType(BizConstant.STORAGE_CLICKHOUSE);
+        storageInfo.setJdbcUrl(ckJdbcUrl);
+        storageInfo.setUsername(ckUsername);
+        storageInfo.setDatabaseName(ckDatabaseName);
+        storageInfo.setTableName(ckTableName);
+        storageInfo.setEnableCreateResource(BizConstant.DISABLE_CREATE_RESOURCE);
+        ckStorageId = storageService.save(storageInfo, globalOperator);
+    }
+
+    @After
+    public void deleteKafkaStorage() {
+        boolean result = storageService.delete(ckStorageId, BizConstant.STORAGE_CLICKHOUSE, globalOperator);
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testListByIdentifier() {
+        StorageResponse storage = storageService.get(ckStorageId, BizConstant.STORAGE_CLICKHOUSE);
+        Assert.assertEquals(globalGroupId, storage.getInlongGroupId());
+    }
+
+    @Test
+    public void testGetAndUpdate() {
+        StorageResponse response = storageService.get(ckStorageId, BizConstant.STORAGE_CLICKHOUSE);
+        Assert.assertEquals(globalGroupId, response.getInlongGroupId());
+
+        ClickHouseStorageResponse kafkaStorageResponse = (ClickHouseStorageResponse) response;
+        kafkaStorageResponse.setEnableCreateResource(BizConstant.ENABLE_CREATE_RESOURCE);
+
+        ClickHouseStorageRequest request = CommonBeanUtils
+                .copyProperties(kafkaStorageResponse, ClickHouseStorageRequest::new);
+        boolean result = storageService.update(request, globalOperator);
+        Assert.assertTrue(result);
+    }
+
+}


### PR DESCRIPTION
### Title Name: [INLONG-2579][Manager] support data flow to ClickHouse

Fixes #2579

### Motivation

*  InLong  Manager support data flow to ClickHouse

### Modifications

* add clickhouse storage type in InLong  Manager 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
