### PR TITLE
[INLONG-2631][k8s] make MySQL optional 

### DIFF
--- a/docker/kubernetes/templates/_helpers.tpl
+++ b/docker/kubernetes/templates/_helpers.tpl
@@ -105,7 +105,33 @@ ${HOSTNAME}.{{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component
 Define the mysql hostname
 */}}
 {{- define "inlong.mysql.hostname" -}}
+{{- if .Values.mysql.enabled -}}
 ${HOSTNAME}.{{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- else -}}
+{{ .Values.externalMySQL.hostname }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define the mysql port
+*/}}
+{{- define "inlong.mysql.port" -}}
+{{- if .Values.mysql.enabled -}}
+{{ .Values.mysql.ports.server }}
+{{- else -}}
+{{ .Values.externalMySQL.port }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define the mysql username
+*/}}
+{{- define "inlong.mysql.username" -}}
+{{- if .Values.mysql.enabled -}}
+{{ .Values.mysql.username }}
+{{- else -}}
+{{ .Values.externalMySQL.username }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/docker/kubernetes/templates/audit-statefulset.yaml
+++ b/docker/kubernetes/templates/audit-statefulset.yaml
@@ -79,21 +79,14 @@ spec:
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           env:
             - name: JDBC_URL
-              value: "jdbc:mysql://{{ include "inlong.mysql.hostname" . }}:{{ .Values.mysql.ports.server }}/apache_inlong_audit?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&nullCatalogMeansCurrent=true&serverTimezone=GMT%2b8"
+              value: "jdbc:mysql://{{ template "inlong.mysql.hostname" . }}:{{ .Values.mysql.ports.server }}/apache_inlong_audit?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&nullCatalogMeansCurrent=true&serverTimezone=GMT%2b8"
             - name: USERNAME
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ template "inlong.fullname" . }}-{{ .Values.audit.component }}
-                  key: mysqlUsername
+              value: {{ include "inlong.mysql.username" . | quote }}
             - name: PASSWORD
-              {{- if eq .Values.mysql.username "root" }}
               valueFrom:
                 secretKeyRef:
                   name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
-                  key: mysql-root-password
-              {{- else }}
-              value: {{ .Values.mysql.password | quote }}
-              {{- end }}
+                  key: mysql-password
             - name: MANAGER_OPENAPI_IP
               value: {{ include "inlong.tubemqManager.hostname" . | quote }}
             - name: MANAGER_OPENAPI_PORT

--- a/docker/kubernetes/templates/manager-statefulset.yaml
+++ b/docker/kubernetes/templates/manager-statefulset.yaml
@@ -65,9 +65,12 @@ spec:
             - name: JDBC_URL
               value: "{{ template "inlong.mysql.hostname" . }}:{{ .Values.mysql.ports.server }}"
             - name: USERNAME
-              value: {{ .Values.manager.username }}
+              value: {{ include "inlong.mysql.username" . | quote }}
             - name: PASSWORD
-              value: {{ .Values.manager.password }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
+                  key: mysql-password
             - name: TUBE_MANAGER
               value: "http://{{ template "inlong.tubemqManager.hostname" . }}:{{ .Values.tubemqManager.containerPort }}"
             - name: TUBE_MASTER

--- a/docker/kubernetes/templates/mysql-pvc.yaml
+++ b/docker/kubernetes/templates/mysql-pvc.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{- if .Values.mysql.persistentVolumeClaim.enabled }}
+{{- if and .Values.mysql.enabled .Values.mysql.persistentVolumeClaim.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/docker/kubernetes/templates/mysql-secret.yaml
+++ b/docker/kubernetes/templates/mysql-secret.yaml
@@ -25,8 +25,8 @@ metadata:
     component: {{ .Values.mysql.component }}
 type: Opaque
 data:
-  {{- if .Values.mysql.rootPassword }}
-  mysql-root-password: {{ .Values.mysql.rootPassword | b64enc | quote }}
+  {{- if .Values.mysql.enabled }}
+  mysql-password: {{ .Values.mysql.password | b64enc | quote }}
   {{- else }}
-  mysql-root-password: {{ "inlong" | b64enc | quote }}
+  mysql-password: {{ .Values.externalMySQL.password | b64enc | quote }}
   {{- end }}

--- a/docker/kubernetes/templates/mysql-service.yaml
+++ b/docker/kubernetes/templates/mysql-service.yaml
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+{{- if .Values.mysql.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -31,3 +32,4 @@ spec:
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.mysql.component }}
+{{- end }}

--- a/docker/kubernetes/templates/mysql-statefulset.yaml
+++ b/docker/kubernetes/templates/mysql-statefulset.yaml
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+{{- if .Values.mysql.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -70,3 +71,4 @@ spec:
           emptyDir: {}
           {{- end }}
       restartPolicy: Always
+{{- end }}

--- a/docker/kubernetes/templates/tubemq-manager-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-manager-statefulset.yaml
@@ -81,12 +81,12 @@ spec:
             - name: MYSQL_HOST
               value: {{ include "inlong.mysql.hostname" . | quote }}
             - name: MYSQL_USER
-              value: {{ .Values.tubemqManager.mysqlUser | quote }}
+              value: {{ include "inlong.mysql.username" . | quote }}
             - name: MYSQL_PASSWD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}
-                  key: mysql-root-password
+                  key: mysql-password
             - name: TUBE_MASTER_IP
               value: {{ include "inlong.tubemqMaster.hostname" . | quote }}
           ports:

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -127,14 +127,13 @@ pulsar:
     storageClassName: "-"
     storage: "8Gi"
 
+# If not exists external MySQL, by default, InLong will use it.
 mysql:
   component: "mysql"
+  enabled: false
   replicaCount: 1
   username: "root"
-  # If the MySQL username is root,
-  # the password parameter can be omitted and the rootPassword will be used.
   password: "inlong"
-  rootPassword: "inlong"
   ports:
     server: 3306
   persistentVolumeClaim:
@@ -143,6 +142,14 @@ mysql:
       - "ReadWriteOnce"
     storageClassName: "-"
     storage: "8Gi"
+
+# If exists external MySQL, or the value of the mysql.enabled is false,
+# InLong will use the external MySQL.
+externalMySQL:
+  hostname: "localhost"
+  port: 3306
+  username: "root"
+  password: "password"
 
 zookeeper:
   component: "zookeeper"


### PR DESCRIPTION
issue: #2631

### Motivation

sometimes, there are existed MySQL services we can reuse.

### Modifications

- `docker/kubernetes`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
