### PR TITLE
[INLONG-2638][Manager] apache_inlong_manager.sql file execution exception

### DIFF
--- a/inlong-manager/manager-test/src/main/resources/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-test/src/main/resources/sql/apache_inlong_manager.sql
@@ -291,7 +291,7 @@ CREATE TABLE `data_proxy_cluster`
     `modifier`    varchar(64)       DEFAULT NULL COMMENT 'Modifier name',
     `create_time` timestamp    NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
     `modify_time` timestamp    NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
-    `mq_set_name` varchar(128) NOT NULL COMMENT 'mq set name',
+    `mq_set_name` varchar(128) DEFAULT NULL COMMENT 'mq set name',
     PRIMARY KEY (`id`),
     UNIQUE KEY `cluster_name` (`name`, `is_deleted`)
 );

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -307,7 +307,7 @@ CREATE TABLE `data_proxy_cluster`
     `modifier`    varchar(64)       DEFAULT NULL COMMENT 'Modifier name',
     `create_time` timestamp    NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
     `modify_time` timestamp    NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
-    `mq_set_name` varchar(128) NOT NULL COMMENT 'mq set name',
+    `mq_set_name` varchar(128) DEFAULT NULL COMMENT 'mq set name',
     PRIMARY KEY (`id`),
     UNIQUE KEY `cluster_name` (`name`, `is_deleted`)
 ) ENGINE = InnoDB


### PR DESCRIPTION
https://inlong.apache.org/docs/next/modules/manager/quick_start . initialize database there is sql/apache_inlong_manager.sql. Throw an exception: ERROR 1364 (HY000) at line 316: Field 'mq_set_name' doesn't have a default value


### Title Name: 
[INLONG-2638][Manager] apache_inlong_manager.sql file execution exception
Fix: https://github.com/apache/incubator-inlong/issues/2638

### Motivation

Failed to initialize database

### Modifications

Because the subsequently inserted instance does not assign a value to the mq_set_name field, the default value should be nullable 

