### PR TITLE
[INLONG-2640][K8s][Audit] Fix data type error in Audit Configmap

### DIFF
--- a/docker/kubernetes/templates/audit-configmap.yaml
+++ b/docker/kubernetes/templates/audit-configmap.yaml
@@ -24,4 +24,3 @@ metadata:
     component: {{ .Values.audit.component }}
 data:
   mysqlUsername: {{ .Values.mysql.username | default "root" | quote }}
-  managerOpenApiPort: {{ .Values.manager.ports.webPort }}

--- a/docker/kubernetes/templates/audit-statefulset.yaml
+++ b/docker/kubernetes/templates/audit-statefulset.yaml
@@ -90,10 +90,7 @@ spec:
             - name: MANAGER_OPENAPI_IP
               value: {{ include "inlong.tubemqManager.hostname" . | quote }}
             - name: MANAGER_OPENAPI_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ template "inlong.fullname" . }}-{{ .Values.audit.component }}
-                  key: managerOpenApiPort
+              value: {{ .Values.manager.ports.webPort }}
             - name: PULSAR_BROKER_URL_LIST
               value: {{ .Values.pulsar.serviceUrl }}
             {{- range $key, $value := .Values.audit.env }}


### PR DESCRIPTION
Fixes: #2640

### Motivation

The value In ConfigMap must be strings and not integers.

### Modifications

- `docker/kubernetes/audit-configmap.yaml`
- `docker/kubernetes/audit-statefulset.yaml`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
