### PR TITLE
[INLONG-2646][MQ]The startup script cannot detect that pulsar starts the process in standalone mode

### DIFF
--- a/bin/inlong-daemon
+++ b/bin/inlong-daemon
@@ -213,7 +213,7 @@ start_inlong_all() {
   echo "Judge the choice of message middleware tubemq or pulsar"
   if [ $source_type == "pulsar" ]; then
     # Judge whether the pulsar cluster is started in the current system
-    pulsar_thread=$($JAVA_HOME/bin/jps | grep PulsarBrokerStarter)
+    pulsar_thread=$($JAVA_HOME/bin/jps | egrep 'PulsarBrokerStarter|PulsarStandaloneStarter')
     if [ ! -n "$pulsar_thread" ]; then
       echo "The system does not start the pulsar. Please start the pulsar manually first"
       exit 1

--- a/bin/inlong-daemon
+++ b/bin/inlong-daemon
@@ -213,7 +213,7 @@ start_inlong_all() {
   echo "Judge the choice of message middleware tubemq or pulsar"
   if [ $source_type == "pulsar" ]; then
     # Judge whether the pulsar cluster is started in the current system
-    pulsar_thread=$($JAVA_HOME/bin/jps | egrep 'PulsarBrokerStarter|PulsarStandaloneStarter')
+    pulsar_thread=$($JAVA_HOME/bin/jps | egrep 'PulsarBrokerStarter | PulsarStandaloneStarter')
     if [ ! -n "$pulsar_thread" ]; then
       echo "The system does not start the pulsar. Please start the pulsar manually first"
       exit 1


### PR DESCRIPTION

### Title Name: [INLONG-2646][MQ] The startup script cannot detect that pulsar starts the process in standalone mode

Fixes [#2646](https://github.com/apache/incubator-inlong/issues/2646)

### Motivation

When starting inlong, the message middleware selects pulsar, but the script does not detect it.

### Modifications

the detection of the pulsar process adds another startup class PulsarStandaloneStarter

