### PR TITLE
[INLONG-2659][Sort] Modify the name of the inlong-sort component startup jar package

### DIFF
--- a/bin/inlong-daemon
+++ b/bin/inlong-daemon
@@ -199,7 +199,7 @@ start_inlong_sort() {
   flagfile=$(find / -name find-flink-home.sh)
   flink_bin=$(dirname $flagfile)
   cd $INLONG_HOME
-  $flink_bin/flink run -c org.apache.inlong.sort.flink.Entrance inlong-sort/sort-core*.jar \
+  $flink_bin/flink run -c org.apache.inlong.sort.flink.Entrance inlong-sort/sort-dist*.jar \
   --cluster-id $sort_app_name --zookeeper.quorum $zkserver_addr --zookeeper.path.root $cluster_zk_root \
   --source.type $source_type --sink.type $sink_type &
 }


### PR DESCRIPTION
### Title Name: [INLONG-2659][Sort] Modify the name of the inlong-sort component startup jar package

Fixes  https://github.com/apache/incubator-inlong/issues/2659

### Motivation
 Could not build the program from JAR file. Because the inlong-sort folder only has the sort-dist-*.jar file


### Modifications
Modify the name of the inlong-sort component startup jar package
<img width="1407" alt="image" src="https://user-images.githubusercontent.com/20356765/155134016-23ca7042-13e0-4492-914c-605eb77d7caa.png">

