### PR TITLE
[INLONG-2667][Sort] Fix bugs that occur when starting up sort-single-tenant

### DIFF
--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -249,10 +249,6 @@
                         <artifactId>xml-apis</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.apache.hive</groupId>
-                        <artifactId>hive-service-rpc</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-web</artifactId>
                     </exclusion>

--- a/inlong-sort/sort-connectors/src/main/java/org/apache/inlong/sort/flink/hive/partition/RowPartitionComputer.java
+++ b/inlong-sort/sort-connectors/src/main/java/org/apache/inlong/sort/flink/hive/partition/RowPartitionComputer.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.flink.hive.partition;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import java.io.Serializable;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -103,12 +104,14 @@ public class RowPartitionComputer implements PartitionComputer<Row> {
         }
     }
 
-    interface PartitionValueTransformer {
+    interface PartitionValueTransformer extends Serializable {
 
         String transform(Object fieldValue);
     }
 
     private static class FieldPartitionValueTransformer implements PartitionValueTransformer {
+
+        private static final long serialVersionUID = 4704634852937539161L;
 
         @Override
         public String transform(Object fieldValue) {
@@ -117,6 +120,8 @@ public class RowPartitionComputer implements PartitionComputer<Row> {
     }
 
     private static class TimeFieldPartitionValueTransformer implements PartitionValueTransformer {
+
+        private static final long serialVersionUID = -6757777703443121967L;
 
         private final SimpleDateFormat dateFormat;
 


### PR DESCRIPTION
### Title Name: [INLONG-2667][Sort] Fix bugs that occur when starting up sort-single-tenant

Fixes #2667 

### Motivation

1. Some classes are not serializable.
2. dependency hive-service-rpc is not included.

### Verifying this change

- [x] Make sure that the change passes the CI checks.