### PR TITLE
[INLONG-2688][Agent] Agent support freeze and restart task when needed

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -87,6 +87,7 @@ import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_LOCAL_IP
 import static org.apache.inlong.agent.constant.FetcherConstants.VERSION;
 import static org.apache.inlong.agent.constant.JobConstants.JOB_OP;
 import static org.apache.inlong.agent.constant.JobConstants.JOB_RETRY_TIME;
+import static org.apache.inlong.agent.constant.JobConstants.JOB_TRIGGER;
 import static org.apache.inlong.agent.plugin.fetcher.ManagerResultFormatter.getResultData;
 import static org.apache.inlong.agent.plugin.utils.PluginUtils.copyJobProfile;
 
@@ -274,7 +275,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
 
         for (DataConfig dataConfig : taskResult.getDataConfigs()) {
             TriggerProfile profile = TriggerProfile.getTriggerProfiles(dataConfig);
-            if (profile.hasKey(JobConstants.JOB_TRIGGER)) {
+            if (profile.hasKey(JOB_TRIGGER)) {
                 dealWithTdmTriggerProfile(profile);
             } else {
                 dealWithJobProfile(profile);

--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/ManagerOpEnum.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/ManagerOpEnum.java
@@ -20,7 +20,8 @@ package org.apache.inlong.common.enums;
 import static java.util.Objects.requireNonNull;
 
 public enum ManagerOpEnum {
-    ADD(0), DEL(1), RETRY(2), BACKTRACK(3), FROZEN(4), ACTIVE(5), CHECK(6), REDOMETRIC(7), MAKEUP(8);
+    ADD(0), DEL(1), RETRY(2), BACKTRACK(3), FROZEN(4),
+    ACTIVE(5), CHECK(6), REDOMETRIC(7), MAKEUP(8);
 
     private int type;
 


### PR DESCRIPTION
### Title Name: [INLONG-2688][Agent] Agent support freeze and restart task when needed

Fixes #2688 

### Motivation

Agent support task freeze and restart when needed

### Modifications

Agent support task freeze and restart when needed

And when the job is Binlog or Kafka the job instance id should be equal with job id since it's a single job 

### Verifying this change

- [X] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (yes)
