### PR TITLE
[INLONG-2701][DataProxy] Fix NPE in manager-web because of proxy_custer_name is nul

### DIFF
--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -20,6 +20,8 @@
 cluster_id=1
 # manager open api address
 manager_hosts=127.0.0.1:8083
+# manager cluster name
+proxy_cluster_name=default_dataproxy
 # check interval of local config (millisecond)
 configCheckInterval=10000
 


### PR DESCRIPTION
### Title Name: [INLONG-2701][DataProxy] Fix NPE in manager-web because of proxy_custer_name is nul

Fixes #2701

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduces a new feature? no
