### PR TITLE
[INLONG-2717][Manager][Sort] Support none of middleware and Add DataTypeEnum

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/DataTypeEnum.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/DataTypeEnum.java
@@ -15,25 +15,30 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.client.api;
+package org.apache.inlong.common.enums;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
-@ApiModel("Base configuration for message queue")
-public abstract class MqBaseConf implements Serializable {
+public enum DataTypeEnum {
+    CSV("csv"),
+    AVRO("avro"),
+    JSON("json"),
+    CANAL("canal"),
+    DEBEZIUM_JSON("debezium_json");
 
-    public enum MqType {
-        PULSAR,
-        TUBE,
-        NONE;
+    @Getter
+    private String name;
+
+    DataTypeEnum(String name) {
+        this.name = name;
     }
 
-    @ApiModelProperty("The number of partitions of Topic, 1-20")
-    private int topicPartitionNum = 3;
-
-    public abstract MqType getType();
+    public static DataTypeEnum forName(String name) {
+        for (DataTypeEnum dataType : values()) {
+            if (dataType.getName().equals(name)) {
+                return dataType;
+            }
+        }
+        throw new IllegalArgumentException(String.format("Unsupport dataType for Inlong:%s", name));
+    }
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/FlinkSortBaseConf.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/FlinkSortBaseConf.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.client.api;
 
+import com.google.common.collect.Maps;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.Map;
@@ -39,6 +40,6 @@ public class FlinkSortBaseConf extends SortBaseConf {
     @ApiModelProperty("Region for flink cluster, for example:ap-beijing|ap-chengdu|ap-chongqing or null if not exists")
     private String region;
 
-    @ApiModelProperty("Other properties if need")
-    private Map<String, String> properties;
+    @ApiModelProperty("Other properties if needed")
+    private Map<String, String> properties = Maps.newHashMap();
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/MqBaseConf.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/MqBaseConf.java
@@ -26,7 +26,7 @@ import lombok.Data;
 @ApiModel("Base configuration for message queue")
 public abstract class MqBaseConf implements Serializable {
 
-    public static final MqBaseConf noneMqConf = new MqBaseConf() {
+    public static final MqBaseConf blankMqBaseConf = new MqBaseConf() {
         @Override
         public MqType getType() {
             return MqType.NONE;

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/MqBaseConf.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/MqBaseConf.java
@@ -26,7 +26,7 @@ import lombok.Data;
 @ApiModel("Base configuration for message queue")
 public abstract class MqBaseConf implements Serializable {
 
-    public static final MqBaseConf blankMqBaseConf = new MqBaseConf() {
+    public static final MqBaseConf BLANK_MQ_CONF = new MqBaseConf() {
         @Override
         public MqType getType() {
             return MqType.NONE;

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/MqBaseConf.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/MqBaseConf.java
@@ -26,6 +26,13 @@ import lombok.Data;
 @ApiModel("Base configuration for message queue")
 public abstract class MqBaseConf implements Serializable {
 
+    public static final MqBaseConf noneMqConf = new MqBaseConf() {
+        @Override
+        public MqType getType() {
+            return MqType.NONE;
+        }
+    };
+
     public enum MqType {
         PULSAR,
         TUBE,

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/TubeBaseConf.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/TubeBaseConf.java
@@ -19,21 +19,28 @@ package org.apache.inlong.manager.client.api;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
-@ApiModel("Base configuration for message queue")
-public abstract class MqBaseConf implements Serializable {
+@AllArgsConstructor
+@NoArgsConstructor
+@ApiModel("Base configuration for Tube")
+public class TubeBaseConf extends MqBaseConf {
 
-    public enum MqType {
-        PULSAR,
-        TUBE,
-        NONE;
-    }
+    @ApiModelProperty("Message queue type")
+    private MqType type = MqType.TUBE;
 
-    @ApiModelProperty("The number of partitions of Topic, 1-20")
-    private int topicPartitionNum = 3;
+    @ApiModelProperty("Tube manager URL")
+    private String tubeManagerUrl;
 
-    public abstract MqType getType();
+    @ApiModelProperty("Tube master URL")
+    private String tubeMasterUrl;
+
+    @ApiModelProperty("Tube Cluster Id")
+    private int tubeClusterId = 1;
+
+    @ApiModelProperty("GroupName for tube producer")
+    private String groupName;
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/UserDefinedSortConf.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/UserDefinedSortConf.java
@@ -17,18 +17,22 @@
 
 package org.apache.inlong.manager.client.api;
 
+import com.google.common.collect.Maps;
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Map;
 import lombok.Data;
 
 @Data
-@ApiModel("Sort configuration for inlong group")
-public abstract class SortBaseConf {
+@ApiModel("Base configuration for user defined sort functions")
+public class UserDefinedSortConf extends SortBaseConf {
 
-    public enum SortType {
-        FLINK,
-        LOCAL,
-        USER_DEFINED;
-    }
+    @ApiModelProperty(value = "Sort type")
+    private SortType type = SortType.USER_DEFINED;
 
-    public abstract SortType getType();
+    @ApiModelProperty("Name for user defined sort functions")
+    private String sortName;
+
+    @ApiModelProperty("Properties for user defined sort functions if needed")
+    private Map<String, String> properties = Maps.newHashMap();
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongGroupTransfer.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongGroupTransfer.java
@@ -27,6 +27,7 @@ import org.apache.inlong.manager.client.api.MqBaseConf.MqType;
 import org.apache.inlong.manager.client.api.PulsarBaseConf;
 import org.apache.inlong.manager.client.api.SortBaseConf;
 import org.apache.inlong.manager.client.api.SortBaseConf.SortType;
+import org.apache.inlong.manager.client.api.TubeBaseConf;
 import org.apache.inlong.manager.client.api.auth.Authentication;
 import org.apache.inlong.manager.client.api.auth.Authentication.AuthType;
 import org.apache.inlong.manager.client.api.auth.SecretTokenAuthentication;
@@ -66,8 +67,12 @@ public class InlongGroupTransfer {
             List<InlongGroupExtInfo> extInfos = createPulsarExtInfo(pulsarBaseConf);
             groupInfo.getExtList().addAll(extInfos);
             groupInfo.setTopicPartitionNum(pulsarBaseConf.getTopicPartitionNum());
-        } else {
-            // todo tubemq
+        } else if (mqType == MqType.TUBE) {
+            TubeBaseConf tubeBaseConf = (TubeBaseConf) mqConf;
+            List<InlongGroupExtInfo> extInfos = createTubeExtInfo(tubeBaseConf);
+            groupInfo.setMqResourceObj(tubeBaseConf.getGroupName());
+            groupInfo.getExtList().addAll(extInfos);
+            groupInfo.setTopicPartitionNum(tubeBaseConf.getTopicPartitionNum());
         }
         SortBaseConf sortBaseConf = groupConf.getSortBaseConf();
         SortType sortType = sortBaseConf.getType();
@@ -124,6 +129,29 @@ public class InlongGroupTransfer {
             pulsarServiceUrl.setKeyName(InlongGroupSettings.PULSAR_SERVICE_URL);
             pulsarServiceUrl.setKeyValue(pulsarBaseConf.getPulsarServiceUrl());
             extInfos.add(pulsarServiceUrl);
+        }
+        return extInfos;
+    }
+
+    public static List<InlongGroupExtInfo> createTubeExtInfo(TubeBaseConf tubeBaseConf) {
+        List<InlongGroupExtInfo> extInfos = new ArrayList<>();
+        if (StringUtils.isNotEmpty(tubeBaseConf.getTubeMasterUrl())) {
+            InlongGroupExtInfo tubeManagerUrl = new InlongGroupExtInfo();
+            tubeManagerUrl.setKeyName(InlongGroupSettings.TUBE_MANAGER_URL);
+            tubeManagerUrl.setKeyValue(tubeBaseConf.getTubeManagerUrl());
+            extInfos.add(tubeManagerUrl);
+        }
+        if (StringUtils.isNotEmpty(tubeBaseConf.getTubeMasterUrl())) {
+            InlongGroupExtInfo tubeMasterUrl = new InlongGroupExtInfo();
+            tubeMasterUrl.setKeyName(InlongGroupSettings.TUBE_MASTER_URL);
+            tubeMasterUrl.setKeyValue(tubeBaseConf.getTubeMasterUrl());
+            extInfos.add(tubeMasterUrl);
+        }
+        if (tubeBaseConf.getTubeClusterId() > 0) {
+            InlongGroupExtInfo tubeClusterId = new InlongGroupExtInfo();
+            tubeClusterId.setKeyName(InlongGroupSettings.TUBE_CLUSTER_ID);
+            tubeClusterId.setKeyValue(String.valueOf(tubeBaseConf.getTubeClusterId()));
+            extInfos.add(tubeClusterId);
         }
         return extInfos;
     }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongGroupTransfer.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongGroupTransfer.java
@@ -28,6 +28,7 @@ import org.apache.inlong.manager.client.api.PulsarBaseConf;
 import org.apache.inlong.manager.client.api.SortBaseConf;
 import org.apache.inlong.manager.client.api.SortBaseConf.SortType;
 import org.apache.inlong.manager.client.api.TubeBaseConf;
+import org.apache.inlong.manager.client.api.UserDefinedSortConf;
 import org.apache.inlong.manager.client.api.auth.Authentication;
 import org.apache.inlong.manager.client.api.auth.Authentication.AuthType;
 import org.apache.inlong.manager.client.api.auth.SecretTokenAuthentication;
@@ -79,6 +80,10 @@ public class InlongGroupTransfer {
         if (sortType == SortType.FLINK) {
             FlinkSortBaseConf flinkSortBaseConf = (FlinkSortBaseConf) sortBaseConf;
             List<InlongGroupExtInfo> sortExtInfos = createFlinkExtInfo(flinkSortBaseConf);
+            groupInfo.getExtList().addAll(sortExtInfos);
+        } else if (sortType == SortType.USER_DEFINED) {
+            UserDefinedSortConf udf = (UserDefinedSortConf) sortBaseConf;
+            List<InlongGroupExtInfo> sortExtInfos = createUserDefinedSortExtInfo(udf);
             groupInfo.getExtList().addAll(sortExtInfos);
         } else {
             //todo local
@@ -158,6 +163,10 @@ public class InlongGroupTransfer {
 
     public static List<InlongGroupExtInfo> createFlinkExtInfo(FlinkSortBaseConf flinkSortBaseConf) {
         List<InlongGroupExtInfo> extInfos = new ArrayList<>();
+        InlongGroupExtInfo sortType = new InlongGroupExtInfo();
+        sortType.setKeyName(InlongGroupSettings.SORT_TYPE);
+        sortType.setKeyValue(InlongGroupSettings.DEFAULT_SORT_TYPE);
+        extInfos.add(sortType);
         if (flinkSortBaseConf.getAuthentication() != null) {
             Authentication authentication = flinkSortBaseConf.getAuthentication();
             AuthType authType = authentication.getAuthType();
@@ -183,6 +192,21 @@ public class InlongGroupTransfer {
             InlongGroupExtInfo flinkProperties = new InlongGroupExtInfo();
             flinkProperties.setKeyName(InlongGroupSettings.SORT_PROPERTIES);
             flinkProperties.setKeyValue(JsonUtils.toJson(flinkSortBaseConf.getProperties()));
+            extInfos.add(flinkProperties);
+        }
+        return extInfos;
+    }
+
+    public static List<InlongGroupExtInfo> createUserDefinedSortExtInfo(UserDefinedSortConf userDefinedSortConf) {
+        List<InlongGroupExtInfo> extInfos = new ArrayList<>();
+        InlongGroupExtInfo sortType = new InlongGroupExtInfo();
+        sortType.setKeyName(InlongGroupSettings.SORT_TYPE);
+        sortType.setKeyValue(userDefinedSortConf.getSortName());
+        extInfos.add(sortType);
+        if (MapUtils.isNotEmpty(userDefinedSortConf.getProperties())) {
+            InlongGroupExtInfo flinkProperties = new InlongGroupExtInfo();
+            flinkProperties.setKeyName(InlongGroupSettings.SORT_PROPERTIES);
+            flinkProperties.setKeyValue(JsonUtils.toJson(userDefinedSortConf.getProperties()));
             extInfos.add(flinkProperties);
         }
         return extInfos;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/Constant.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/Constant.java
@@ -60,6 +60,8 @@ public class Constant {
 
     public static final String MIDDLEWARE_PULSAR = "PULSAR";
 
+    public static final String MIDDLEWARE_NONE = "NONE";
+
     public static final String SCHEMA_M0_DAY = "m0_day";
 
     public static final String CLUSTER_HIVE_TOPO = "HIVE_TOPO";

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/settings/InlongGroupSettings.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/settings/InlongGroupSettings.java
@@ -72,6 +72,10 @@ public class InlongGroupSettings {
 
     public static String FS_OFS_USER_APPID = "fs.ofs.user.appid";
 
+    public static String SORT_TYPE = "sort.type";
+
+    public static String DEFAULT_SORT_TYPE = "flink";
+
     public static String SORT_URL = "sort.url";
 
     public static String SORT_AUTHENTICATION = "sort.authentication";

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/settings/InlongGroupSettings.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/settings/InlongGroupSettings.java
@@ -29,6 +29,12 @@ public class InlongGroupSettings {
 
     public static String DEFAULT_PULSAR_AUTHENTICATION_TYPE = "token";
 
+    public static String TUBE_MANAGER_URL = "tube.manager.url";
+
+    public static String TUBE_MASTER_URL = "tube.master.url";
+
+    public static String TUBE_CLUSTER_ID = "tube.cluster.id";
+
     /**
      * oceanus need param start
      */

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdparty/sort/ZkDisabledEventSelector.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdparty/sort/ZkDisabledEventSelector.java
@@ -37,13 +37,13 @@ public class ZkDisabledEventSelector implements EventSelector {
         if (processForm instanceof GroupResourceProcessForm) {
             GroupResourceProcessForm groupResourceForm = (GroupResourceProcessForm) processForm;
             InlongGroupRequest groupInfo = groupResourceForm.getGroupInfo();
-            return groupInfo.getZookeeperEnabled() == 0 &&
-                    !groupInfo.getMiddlewareType().equals(Constant.MIDDLEWARE_NONE);
+            return groupInfo.getZookeeperEnabled() == 0
+                    && !groupInfo.getMiddlewareType().equals(Constant.MIDDLEWARE_NONE);
         } else if (processForm instanceof UpdateGroupProcessForm) {
             UpdateGroupProcessForm updateGroupProcessForm = (UpdateGroupProcessForm) processForm;
             InlongGroupRequest groupInfo = updateGroupProcessForm.getGroupInfo();
-            return groupInfo.getZookeeperEnabled() == 0 &&
-                    !groupInfo.getMiddlewareType().equals(Constant.MIDDLEWARE_NONE);
+            return groupInfo.getZookeeperEnabled() == 0
+                    && !groupInfo.getMiddlewareType().equals(Constant.MIDDLEWARE_NONE);
         } else {
             return false;
         }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdparty/sort/ZkDisabledEventSelector.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdparty/sort/ZkDisabledEventSelector.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.service.thirdparty.sort;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.inlong.manager.common.enums.Constant;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupRequest;
 import org.apache.inlong.manager.common.pojo.workflow.form.GroupResourceProcessForm;
 import org.apache.inlong.manager.common.pojo.workflow.form.ProcessForm;
@@ -36,11 +37,13 @@ public class ZkDisabledEventSelector implements EventSelector {
         if (processForm instanceof GroupResourceProcessForm) {
             GroupResourceProcessForm groupResourceForm = (GroupResourceProcessForm) processForm;
             InlongGroupRequest groupInfo = groupResourceForm.getGroupInfo();
-            return groupInfo.getZookeeperEnabled() == 0;
+            return groupInfo.getZookeeperEnabled() == 0 &&
+                    !groupInfo.getMiddlewareType().equals(Constant.MIDDLEWARE_NONE);
         } else if (processForm instanceof UpdateGroupProcessForm) {
             UpdateGroupProcessForm updateGroupProcessForm = (UpdateGroupProcessForm) processForm;
             InlongGroupRequest groupInfo = updateGroupProcessForm.getGroupInfo();
-            return groupInfo.getZookeeperEnabled() == 0;
+            return groupInfo.getZookeeperEnabled() == 0 &&
+                    !groupInfo.getMiddlewareType().equals(Constant.MIDDLEWARE_NONE);
         } else {
             return false;
         }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdparty/sort/ZkEnabledEventSelector.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/thirdparty/sort/ZkEnabledEventSelector.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.service.thirdparty.sort;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.inlong.manager.common.enums.Constant;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupRequest;
 import org.apache.inlong.manager.common.pojo.workflow.form.GroupResourceProcessForm;
 import org.apache.inlong.manager.workflow.WorkflowContext;
@@ -37,7 +38,7 @@ public class ZkEnabledEventSelector implements EventSelector {
         }
         GroupResourceProcessForm groupResourceForm = (GroupResourceProcessForm) processForm;
         InlongGroupRequest groupInfo = groupResourceForm.getGroupInfo();
-        return groupInfo.getZookeeperEnabled() == 1;
+        return groupInfo.getZookeeperEnabled() == 1 && !groupInfo.getMiddlewareType().equals(Constant.MIDDLEWARE_NONE);
     }
 
 }

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/deserialization/DeserializationInfo.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/deserialization/DeserializationInfo.java
@@ -36,11 +36,11 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTyp
         @Type(value = JsonDeserializationInfo.class, name = "json"),
         @Type(value = CanalDeserializationInfo.class, name = "canal"),
         @Type(value = DebeziumDeserializationInfo.class, name = "debezium_json"),
-        @Type(value = InLongMsgCsvDeserializationInfo.class, name = "inlongmsg_csv"),
-        @Type(value = InLongMsgCsv2DeserializationInfo.class, name = "inlongmsg_csv2"),
-        @Type(value = InLongMsgKvDeserializationInfo.class, name = "inlongmsg_kv"),
-        @Type(value = InLongMsgTlogCsvDeserializationInfo.class, name = "inlongmsg_tlog_csv"),
-        @Type(value = InLongMsgTlogKvDeserializationInfo.class, name = "inlongmsg_tlog_kv")
+        @Type(value = InLongMsgCsvDeserializationInfo.class, name = "inlong_msg_csv"),
+        @Type(value = InLongMsgCsv2DeserializationInfo.class, name = "inlong_msg_csv2"),
+        @Type(value = InLongMsgKvDeserializationInfo.class, name = "inlong_msg_kv"),
+        @Type(value = InLongMsgTlogCsvDeserializationInfo.class, name = "inlong_msg_tlog_csv"),
+        @Type(value = InLongMsgTlogKvDeserializationInfo.class, name = "inlong_msg_tlog_kv")
 })
 public interface DeserializationInfo extends Serializable {
 


### PR DESCRIPTION
### Title Name: [INLONG-2717][Manager][Sort] Support none of middleware and Add DataTypeEnum

Fixes #2717 

### Motivation

If middleware(queue) is not necessary then use none of the middleware to identify.

### Modifications

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduces a new feature? no
