### PR TITLE
[INLONG-2719][DataProxy] Setting multiple topics for the same groupId doesn't work for Pulsar

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/AttributeConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/AttributeConstants.java
@@ -21,6 +21,7 @@ public interface AttributeConstants {
 
     String SEPARATOR = "&";
     String KEY_VALUE_SEPARATOR = "=";
+    String COMMA_SEPARATOR = ",";
 
     String REQUEST_TYPE = "requestType";
 

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/config/loader/TestThirdPartyClusterConfigLoader.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/config/loader/TestThirdPartyClusterConfigLoader.java
@@ -23,10 +23,20 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.testng.AssertJUnit.assertEquals;
 
 public class TestThirdPartyClusterConfigLoader {
+
+    @Test
+    public void testMultiTopics() {
+        Set<String> topics = ConfigManager.getInstance().getTopicSet();
+        assertEquals(topics.size(), 4);
+        Map<String, String> id2topics = ConfigManager.getInstance().getTopicProperties();
+        assertEquals(id2topics.size(), 3);
+        assertEquals(id2topics.get("groupId1"), "topic-1,topic2,topic2");
+    }
 
     @Test
     public void testUpdateUrl() {

--- a/inlong-dataproxy/dataproxy-source/src/test/resources/topics.properties
+++ b/inlong-dataproxy/dataproxy-source/src/test/resources/topics.properties
@@ -16,3 +16,5 @@
 #
 
 b_docker_test_1.docker_test_1=persistent://public/b_docker_test_1/docker_test_1
+groupId1=topic-1,topic2,topic2
+groupId2=topic000


### PR DESCRIPTION
### Title Name: [INLONG-2719][DataProxy] Setting multiple topics for the same groupId doesn't work for Pulsar

Fixes #2719 

### Modifications

Support multiple topics for the same groupId

### Verifying this change

- [X] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduces a new feature?  no
