### PR TITLE
[INLONG-2747][Feature][CI]: Add support for uploading binary package

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -50,3 +50,16 @@ jobs:
         run: mvn --batch-mode --update-snapshots -e -V clean install -DskipTests
         env:
           CI: false
+
+      - name: Get inlong version
+        if: ${{ success() }}
+        run: |
+          version=`mvn -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive exec:exec -q`
+          echo "VERSION=${version}" >> $GITHUB_ENV
+
+      - name: Upload binary package
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: apache-inlong-${VERSION}-bin.tar.gz
+          path: ./inlong-distribution/target/apache-inlong-${VERSION}-bin.tar.gz

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -61,5 +61,5 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v2
         with:
-          name: apache-inlong-${VERSION}-bin.tar.gz
-          path: ./inlong-distribution/target/apache-inlong-${VERSION}-bin.tar.gz
+          name: apache-inlong-${{ env.VERSION }}-bin.tar.gz
+          path: ./inlong-distribution/target/apache-inlong-${{ env.VERSION }}-bin.tar.gz


### PR DESCRIPTION
fix: #2747

### Motivation

Add support for uploading binary package when building the project on GitHub Actions.

### Modifications

- `.github/workflows/ci_build.yml`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
