### PR TITLE
[INLONG-2753][CI] Add support for pushing docker images when building them

### DIFF
--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -57,7 +57,7 @@ jobs:
           CI: false
 
       - name: Push docker image to Docker Hub
-        if: ${{ success() && github.event_name == 'push' && github.ref_name == 'master' && github.repository == 'apache/incubator-inlong' }}
+        if: ${{ success() && github.event_name == 'push' && github.ref_name == 'master' && github.repository_owner == 'apache' }}
         run: sh docker/publish.sh
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -62,4 +62,3 @@ jobs:
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_REGISTRY: 'hub.docker.com'

--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -57,7 +57,7 @@ jobs:
           CI: false
 
       - name: Push docker image to Docker Hub
-        if: ${{ success() && github.event_name == 'push' && github.event.repository.owner.id == github.event.sender.id }}
+        if: ${{ success() && github.event_name == 'push' && github.repository == 'apache/incubator-inlong' }}
         run: sh docker/publish.sh
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -37,6 +37,11 @@ jobs:
           java-version: 8
           distribution: adopt
 
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
@@ -50,3 +55,11 @@ jobs:
         run: mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker
         env:
           CI: false
+
+      - name: Push docker image to Docker Hub
+        if: ${{ success() && github.event_name == 'push' && github.event.repository.owner.id == github.event.sender.id }}
+        run: sh docker/publish.sh
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_REGISTRY: 'hub.docker.com'

--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -57,7 +57,7 @@ jobs:
           CI: false
 
       - name: Push docker image to Docker Hub
-        if: ${{ success() && github.event_name == 'push' && github.repository == 'apache/incubator-inlong' }}
+        if: ${{ success() && github.event_name == 'push' && github.ref_name == 'master' && github.repository == 'apache/incubator-inlong' }}
         run: sh docker/publish.sh
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}


### PR DESCRIPTION
fix: #2753

### Motivation

Add support for pushing the latest docker images when building them.

### Modifications

- `.github/workflows/ci_build_docker.yml`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
