### PR TITLE
[INLONG-2741][Manager] Inlong client adds an interface for querying inlong group

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
@@ -17,7 +17,10 @@
 
 package org.apache.inlong.manager.client.api;
 
+import com.github.pagehelper.PageInfo;
 import org.apache.inlong.manager.client.api.impl.InlongClientImpl;
+import org.apache.inlong.manager.common.pojo.group.InlongGroupListResponse;
+import org.apache.inlong.manager.common.pojo.group.InlongGroupRequest;
 
 /**
  * An interface to manipulate Inlong Cluster
@@ -43,13 +46,42 @@ import org.apache.inlong.manager.client.api.impl.InlongClientImpl;
  */
 public interface InlongClient {
 
+    /**
+     * Create inlong client.
+     *
+     * @param serviceUrl    the service url
+     * @param configuration the configuration
+     * @return the inlong client
+     */
     static InlongClient create(String serviceUrl, ClientConfiguration configuration) {
         return new InlongClientImpl(serviceUrl, configuration);
     }
 
     /**
      * Create stream group by conf
+     *
+     * @param groupConf the group conf
+     * @return the inlong group
+     * @throws Exception the exception
      */
     InlongGroup createGroup(InlongGroupConf groupConf) throws Exception;
+
+
+    /**
+     * List group list.
+     *
+     * @return the list
+     * @throws Exception the exception
+     */
+    PageInfo<InlongGroupListResponse> listGroup(String keyword, int status, int pageNum, int pageSize) throws Exception;
+
+    /**
+     * Gets group.
+     *
+     * @param groupId the group name
+     * @return the group
+     * @throws Exception the exception
+     */
+    InlongGroupRequest getGroup(String groupId) throws Exception;
 
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.client.api.impl;
 
+import com.github.pagehelper.PageInfo;
 import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -26,9 +27,12 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.MapUtils;
 import org.apache.inlong.manager.client.api.ClientConfiguration;
+import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.client.api.InlongGroup;
 import org.apache.inlong.manager.client.api.InlongGroupConf;
-import org.apache.inlong.manager.client.api.InlongClient;
+import org.apache.inlong.manager.client.api.inner.InnerInlongManagerClient;
+import org.apache.inlong.manager.common.pojo.group.InlongGroupListResponse;
+import org.apache.inlong.manager.common.pojo.group.InlongGroupRequest;
 
 @Slf4j
 public class InlongClientImpl implements InlongClient {
@@ -67,6 +71,19 @@ public class InlongClientImpl implements InlongClient {
     @Override
     public InlongGroup createGroup(InlongGroupConf groupConf) throws Exception {
         return new InlongGroupImpl(groupConf, this);
+    }
+
+    @Override
+    public PageInfo<InlongGroupListResponse> listGroup(String keyword, int status,
+            int pageNum, int pageSize) throws Exception {
+        InnerInlongManagerClient managerClient = new InnerInlongManagerClient(this);
+        return managerClient.listGroupInfo(keyword, status, pageNum, pageSize);
+    }
+
+    @Override
+    public InlongGroupRequest getGroup(String groupId) throws Exception {
+        InnerInlongManagerClient managerClient = new InnerInlongManagerClient(this);
+        return managerClient.getGroupInfo(groupId);
     }
 
     private boolean checkConnectivity(String host, int port, int connectTimeout) {

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
@@ -39,6 +39,7 @@ import org.apache.inlong.manager.client.api.util.AssertUtil;
 import org.apache.inlong.manager.client.api.util.GsonUtil;
 import org.apache.inlong.manager.client.api.util.InlongParser;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupApproveRequest;
+import org.apache.inlong.manager.common.pojo.group.InlongGroupListResponse;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupRequest;
 import org.apache.inlong.manager.common.pojo.sink.SinkListResponse;
 import org.apache.inlong.manager.common.pojo.sink.SinkRequest;
@@ -123,6 +124,45 @@ public class InnerInlongManagerClient {
                 }
             } else {
                 return InlongParser.parseGroupInfo(responseBody);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Inlong group get failed: %s", e.getMessage()), e);
+        }
+    }
+
+    public PageInfo<InlongGroupListResponse> listGroupInfo(String keyword, int status, int pageNum, int pageSize) {
+        if (pageNum <= 0) {
+            pageNum = 1;
+        }
+        JSONObject groupQuery = new JSONObject();
+        groupQuery.put("keyWord", pageNum);
+        groupQuery.put("status", status);
+        groupQuery.put("pageNum", pageNum);
+        groupQuery.put("pageSize", pageSize);
+        String operationData = GsonUtil.toJson(groupQuery);
+        RequestBody requestBody = RequestBody.create(MediaType.parse("application/json"), operationData);
+        String path = HTTP_PATH + "/group/list";
+        final String url = formatUrl(path);
+        Request request = new Request.Builder().get()
+                .url(url)
+                .method("POST", requestBody)
+                .build();
+
+        Call call = httpClient.newCall(request);
+        try {
+            Response response = call.execute();
+            assert response.body() != null;
+            String body = response.body().string();
+            AssertUtil.isTrue(response.isSuccessful(), String.format("Inlong request failed: %s", body));
+            org.apache.inlong.manager.common.beans.Response responseBody = InlongParser.parseResponse(body);
+            if (responseBody.getErrMsg() != null) {
+                if (responseBody.getErrMsg().contains("Inlong group does not exist")) {
+                    return null;
+                } else {
+                    throw new RuntimeException(responseBody.getErrMsg());
+                }
+            } else {
+                return InlongParser.parseGroupList(responseBody);
             }
         } catch (Exception e) {
             throw new RuntimeException(String.format("Inlong group get failed: %s", e.getMessage()), e);

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongParser.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongParser.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.inlong.manager.common.beans.Response;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupApproveRequest;
+import org.apache.inlong.manager.common.pojo.group.InlongGroupListResponse;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupPulsarInfo;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupRequest;
 import org.apache.inlong.manager.common.pojo.sink.SinkListResponse;
@@ -54,6 +55,15 @@ public class InlongParser {
     public static InlongGroupRequest parseGroupInfo(Response response) {
         Object data = response.getData();
         return GsonUtil.fromJson(GsonUtil.toJson(data), InlongGroupRequest.class);
+    }
+
+    public static PageInfo<InlongGroupListResponse> parseGroupList(Response response) {
+        Object data = response.getData();
+        String pageInfoJson = GsonUtil.toJson(data);
+        PageInfo<InlongGroupListResponse> pageInfo = GsonUtil.fromJson(pageInfoJson,
+                new TypeToken<PageInfo<InlongGroupListResponse>>() {
+                }.getType());
+        return pageInfo;
     }
 
     public static InlongStreamInfo parseStreamInfo(Response response) {


### PR DESCRIPTION
### Title Name: [INLONG-2741][Manager] Inlong client adds an interface for querying inlong group

Fixes #2741

### Motivation

Inlong client adds an api to get groupinfo and list groups.

### Modifications

support getGroupInfo for inlong client
support ListGroupList for inlong client

### Verifying this change

- [x] Make sure that the change passes the CI checks.
