### PR TITLE
[INLONG-2649][Sort] Define DefaultEvent2LogItemHandler

### DIFF
--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/UnescapeHelper.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/UnescapeHelper.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper to unescape string.
+ */
+public class UnescapeHelper {
+
+    /**
+     * Unescape String format field values to List<String> format by separator.
+     *
+     * @param  fieldValues FiledValues in String format.
+     * @param  separator Separator.
+     * @return FiledValues in List<String> format.
+     */
+    public static List<String> toFiledList(String fieldValues, char separator) {
+        List<String> fields = new ArrayList<String>();
+        if (fieldValues.length() <= 0) {
+            return fields;
+        }
+
+        int fieldLen = fieldValues.length();
+        StringBuilder builder = new StringBuilder();
+        int i = 0;
+        for (; i < fieldLen - 1; i++) {
+            char value = fieldValues.charAt(i);
+            if (value == '\\') {
+                char nextValue = fieldValues.charAt(i + 1);
+                switch (nextValue) {
+                    case '0':
+                        builder.append(0x00);
+                        i++;
+                        break;
+                    case 'n':
+                        builder.append('\n');
+                        i++;
+                        break;
+                    case 'r':
+                        builder.append('\r');
+                        i++;
+                        break;
+                    case '\\':
+                        builder.append('\\');
+                        i++;
+                        break;
+                    default:
+                        if (nextValue == separator) {
+                            builder.append(separator);
+                            i++;
+                        } else {
+                            builder.append(value);
+                        }
+                        break;
+                }
+                if (i == fieldLen - 1) {
+                    fields.add(builder.toString());
+                }
+            } else {
+                if (value == separator) {
+                    fields.add(builder.toString());
+                    builder.delete(0, builder.length());
+                } else {
+                    builder.append(value);
+                }
+            }
+        }
+
+        if (i == fieldLen - 1) {
+            char value = fieldValues.charAt(i);
+            if (value == separator) {
+                fields.add(builder.toString());
+                fields.add("");
+            } else {
+                builder.append(value);
+                fields.add(builder.toString());
+            }
+        }
+        return fields;
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/SinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/SinkContext.java
@@ -18,15 +18,19 @@
 package org.apache.inlong.sort.standalone.sink;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.apache.inlong.common.metric.MetricRegister;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
 import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
 import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
 import org.apache.inlong.sort.standalone.config.pojo.SortTaskConfig;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
 import org.apache.inlong.sort.standalone.metrics.SortMetricItemSet;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 import org.slf4j.Logger;
@@ -216,5 +220,20 @@ public class SinkContext {
      */
     public SortMetricItemSet getMetricItemSet() {
         return metricItemSet;
+    }
+
+    /**
+     * fillInlongId
+     *
+     * @param currentRecord
+     * @param dimensions
+     */
+    public static void fillInlongId(ProfileEvent currentRecord, Map<String, String> dimensions) {
+        String inlongGroupId = currentRecord.getInlongGroupId();
+        inlongGroupId = (StringUtils.isBlank(inlongGroupId)) ? "-" : inlongGroupId;
+        String inlongStreamId = currentRecord.getInlongStreamId();
+        inlongStreamId = (StringUtils.isBlank(inlongStreamId)) ? "-" : inlongStreamId;
+        dimensions.put(SortMetricItem.KEY_INLONG_GROUP_ID, inlongGroupId);
+        dimensions.put(SortMetricItem.KEY_INLONG_STREAM_ID, inlongStreamId);
     }
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSinkContext.java
@@ -22,16 +22,22 @@ import com.tencentcloudapi.cls.producer.AsyncProducerClient;
 import com.tencentcloudapi.cls.producer.AsyncProducerConfig;
 import com.tencentcloudapi.cls.producer.errors.ProducerException;
 import com.tencentcloudapi.cls.producer.util.NetworkUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
 import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
 import org.apache.inlong.sort.standalone.config.pojo.InlongId;
 import org.apache.inlong.sort.standalone.config.pojo.SortTaskConfig;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
+import org.apache.inlong.sort.standalone.metrics.audit.AuditUtils;
 import org.apache.inlong.sort.standalone.sink.SinkContext;
 import org.apache.inlong.sort.standalone.utils.Constants;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 import org.slf4j.Logger;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -191,4 +197,64 @@ public class ClsSinkContext extends SinkContext {
         }
         deletingClients.add(clientMap.remove(secretId));
     }
+
+    /**
+     * Add send result.
+     *
+     * @param currentRecord Event to be sent.
+     * @param bid Topic or dest ip of event.
+     * @param result Result of send.
+     * @param sendTime Time of sending.
+     */
+    public void addSendResultMetric(ProfileEvent currentRecord, String bid, boolean result, long sendTime) {
+        Map<String, String> dimensions = this.getDimensions(currentRecord, bid);
+        SortMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        long count = 1;
+        long size = currentRecord.getBody().length;
+        if (result) {
+            metricItem.sendSuccessCount.addAndGet(count);
+            metricItem.sendSuccessSize.addAndGet(size);
+            AuditUtils.add(AuditUtils.AUDIT_ID_SEND_SUCCESS, currentRecord);
+            if (sendTime > 0) {
+                long currentTime = System.currentTimeMillis();
+                long sinkDuration = currentTime - sendTime;
+                long nodeDuration = currentTime
+                        - NumberUtils.toLong(Constants.HEADER_KEY_SOURCE_TIME, currentRecord.getRawLogTime());
+                long wholeDuration = currentTime - currentRecord.getRawLogTime();
+                metricItem.sinkDuration.addAndGet(sinkDuration * count);
+                metricItem.nodeDuration.addAndGet(nodeDuration * count);
+                metricItem.wholeDuration.addAndGet(wholeDuration * count);
+            }
+        } else {
+            metricItem.sendFailCount.addAndGet(count);
+            metricItem.sendFailSize.addAndGet(size);
+        }
+    }
+
+    private Map<String, String> getDimensions (ProfileEvent currentRecord, String bid) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        dimensions.put(SortMetricItem.KEY_TASK_NAME, this.getTaskName());
+        // metric
+        fillInlongId(currentRecord, dimensions);
+        dimensions.put(SortMetricItem.KEY_SINK_ID, this.getSinkName());
+        dimensions.put(SortMetricItem.KEY_SINK_DATA_ID, bid);
+        long msgTime = currentRecord.getRawLogTime();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(SortMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        return dimensions;
+    }
+
+
+    /**
+     * Get {@link ClsIdConfig} by uid.
+     * @param uid
+     * @return
+     */
+    public ClsIdConfig getIdConfig(String uid) {
+        return idConfigMap.get(uid);
+    }
+
+
+
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSinkContext.java
@@ -63,6 +63,9 @@ public class ClsSinkContext extends SinkContext {
     private static final String KEY_BASE_RETRY_BACKOFF_MS = "baseRetryBackoffMs";
     private static final String KEY_MAX_RETRY_BACKOFF_MS = "maxRetryBackoffMs";
 
+    private static final int DEFAULT_KEYWORD_MAX_LENGTH = 32 * 1024 - 1;
+    private int keywordMaxLength = DEFAULT_KEYWORD_MAX_LENGTH;
+
     private final Map<String, AsyncProducerClient> clientMap;
     private List<AsyncProducerClient> deletingClients;
     private Context sinkContext;
@@ -255,6 +258,13 @@ public class ClsSinkContext extends SinkContext {
         return idConfigMap.get(uid);
     }
 
+    /**
+     * Get max length of single value.
+     * @return
+     */
+    public int getKeywordMaxLength() {
+        return keywordMaxLength;
+    }
 
 
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/DefaultEvent2LogItemHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/DefaultEvent2LogItemHandler.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.cls;
+
+import com.tencentcloudapi.cls.producer.common.LogItem;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.apache.inlong.sort.standalone.utils.UnescapeHelper;
+import org.slf4j.Logger;
+
+import java.nio.charset.Charset;
+import java.util.List;
+
+public class DefaultEvent2LogItemHandler implements IEvent2LogItemHandler{
+
+    private static final Logger LOG = InlongLoggerFactory.getLogger(DefaultEvent2LogItemHandler.class);
+
+    @Override
+    public List<LogItem> parse(ClsSinkContext context, ProfileEvent event) {
+        String uid = event.getUid();
+        ClsIdConfig idConfig = context.getIdConfig(uid);
+        if (idConfig == null) {
+            LOG.error("There is no cls id config for uid {}, discard it", uid);
+            context.addSendResultMetric(event, context.getTaskName(), false, System.currentTimeMillis());
+            return null;
+        }
+
+        String stringValues = this.getStringValues(event, idConfig);
+        char delimeter = idConfig.getSeparator().charAt(0);
+        List<String> listValues = UnescapeHelper.toFiledList(stringValues, delimeter);
+
+
+        return null;
+    }
+
+    private String getStringValues(ProfileEvent event, ClsIdConfig idConfig) {
+        byte[] bodyBytes = event.getBody();
+        int msgLength = event.getBody().length;
+        int contentOffset = idConfig.getContentOffset();
+        if (contentOffset > 0 && msgLength >= 1) {
+            return new String(bodyBytes, contentOffset, msgLength - contentOffset, Charset.defaultCharset());
+        } else {
+            return new String(bodyBytes, Charset.defaultCharset());
+        }
+    }
+
+
+
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/DefaultEvent2IndexRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/DefaultEvent2IndexRequestHandler.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.utils.UnescapeHelper;
 
 /**
  * 
@@ -67,7 +68,7 @@ public class DefaultEvent2IndexRequestHandler implements IEvent2IndexRequestHand
             strContext = new String(bodyBytes, Charset.defaultCharset());
         }
         // unescape
-        List<String> columnVlues = unescapeFields(strContext, cDelimeter);
+        List<String> columnVlues = UnescapeHelper.toFiledList(strContext, cDelimeter);
         int valueLength = columnVlues.size();
         List<String> fieldList = idConfig.getFieldList();
         int columnLength = fieldList.size();
@@ -103,80 +104,7 @@ public class DefaultEvent2IndexRequestHandler implements IEvent2IndexRequestHand
         return indexRequest;
     }
 
-    /**
-     * unescapeFields
-     * 
-     * @param  fieldValues
-     * @param  separator
-     * @return
-     */
-    public static List<String> unescapeFields(String fieldValues, char separator) {
-        List<String> fields = new ArrayList<String>();
-        if (fieldValues.length() <= 0) {
-            return fields;
-        }
 
-        int fieldLen = fieldValues.length();
-        StringBuilder builder = new StringBuilder();
-        int i = 0;
-        for (; i < fieldLen - 1; i++) {
-            char value = fieldValues.charAt(i);
-            switch (value) {
-                case '\\' :
-                    char nextValue = fieldValues.charAt(i + 1);
-                    switch (nextValue) {
-                        case '0' :
-                            builder.append(0x00);
-                            i++;
-                            break;
-                        case 'n' :
-                            builder.append('\n');
-                            i++;
-                            break;
-                        case 'r' :
-                            builder.append('\r');
-                            i++;
-                            break;
-                        case '\\' :
-                            builder.append('\\');
-                            i++;
-                            break;
-                        default :
-                            if (nextValue == separator) {
-                                builder.append(separator);
-                                i++;
-                            } else {
-                                builder.append(value);
-                            }
-                            break;
-                    }
-                    if (i == fieldLen - 1) {
-                        fields.add(builder.toString());
-                    }
-                    break;
-                default :
-                    if (value == separator) {
-                        fields.add(builder.toString());
-                        builder.delete(0, builder.length());
-                    } else {
-                        builder.append(value);
-                    }
-                    break;
-            }
-        }
-
-        if (i == fieldLen - 1) {
-            char value = fieldValues.charAt(i);
-            if (value == separator) {
-                fields.add(builder.toString());
-                fields.add("");
-            } else {
-                builder.append(value);
-                fields.add(builder.toString());
-            }
-        }
-        return fields;
-    }
 
     /**
      * getExtInfo

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/DefaultEvent2IndexRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/DefaultEvent2IndexRequestHandler.java
@@ -19,7 +19,6 @@ package org.apache.inlong.sort.standalone.sink.elasticsearch;
 
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -103,8 +102,6 @@ public class DefaultEvent2IndexRequestHandler implements IEvent2IndexRequestHand
         indexRequest.source(fieldMap);
         return indexRequest;
     }
-
-
 
     /**
      * getExtInfo

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSinkContext.java
@@ -226,21 +226,6 @@ public class EsSinkContext extends SinkContext {
     }
 
     /**
-     * fillInlongId
-     * 
-     * @param currentRecord
-     * @param dimensions
-     */
-    public static void fillInlongId(ProfileEvent currentRecord, Map<String, String> dimensions) {
-        String inlongGroupId = currentRecord.getInlongGroupId();
-        inlongGroupId = (StringUtils.isBlank(inlongGroupId)) ? "-" : inlongGroupId;
-        String inlongStreamId = currentRecord.getInlongStreamId();
-        inlongStreamId = (StringUtils.isBlank(inlongStreamId)) ? "-" : inlongStreamId;
-        dimensions.put(SortMetricItem.KEY_INLONG_GROUP_ID, inlongGroupId);
-        dimensions.put(SortMetricItem.KEY_INLONG_STREAM_ID, inlongStreamId);
-    }
-
-    /**
      * addSendResultMetric
      * 
      * @param currentRecord


### PR DESCRIPTION
### Title Name: [INLONG-2649][Sort] Define DefaultEvent2LogItemHandler

Fixes #2649

Define the default handler to convert event to LogItem format

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
