### PR TITLE
[INLONG-2790][Agent] [Bug] Agent log4j cannot be output due to jar conflict #2790

### DIFF
--- a/inlong-agent/agent-docker/pom.xml
+++ b/inlong-agent/agent-docker/pom.xml
@@ -35,6 +35,16 @@
       <artifactId>agent-release</artifactId>
       <version>${project.parent.version}</version>
       <classifier>bin</classifier>
+      <exclusions>
+        <exclusion>
+          <artifactId>log4j-api</artifactId>
+          <groupId>org.apache.logging.log4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j-slf4j-impl</artifactId>
+          <groupId>org.apache.logging.log4j</groupId>
+        </exclusion>
+      </exclusions>
       <type>tar.gz</type>
       <scope>provided</scope>
     </dependency>

--- a/inlong-agent/agent-plugins/pom.xml
+++ b/inlong-agent/agent-plugins/pom.xml
@@ -96,6 +96,12 @@
             <groupId>org.apache.inlong</groupId>
             <artifactId>dataproxy-sdk</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <artifactId>slf4j-log4j12</artifactId>

--- a/inlong-agent/pom.xml
+++ b/inlong-agent/pom.xml
@@ -50,7 +50,7 @@
         <gson.version>2.8.5</gson.version>
         <guava.version>12.0.1</guava.version>
         <jdk.version>1.8</jdk.version>
-        <log4j2.version>2.17.1</log4j2.version>
+        <log4j2.version>1.2.17</log4j2.version>
         <mockito.version>3.3.3</mockito.version>
         <plugin.assembly.version>3.2.0</plugin.assembly.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
### [INLONG-2790][Agent] [Bug] Agent log4j cannot be output due to jar conflict #2790

Fixes #2790 

### Motivation

Agent log4j cannot be output due to jar conflict #2790

### Modifications

Agent log4j cannot be output due to jar conflict #2790

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (no)
