### PR TITLE
[INLONG-2820] Improve the deserialization processing of the update event in DebeziumDeserializationSchema

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/deserialization/DebeziumDeserializationInfo.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/deserialization/DebeziumDeserializationInfo.java
@@ -20,6 +20,8 @@ package org.apache.inlong.sort.protocol.deserialization;
 
 import java.util.Objects;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 public class DebeziumDeserializationInfo implements DeserializationInfo {
@@ -32,12 +34,24 @@ public class DebeziumDeserializationInfo implements DeserializationInfo {
     @JsonProperty("timestamp_format_standard")
     private final String timestampFormatStandard;
 
+    @JsonInclude(Include.NON_NULL)
+    @JsonProperty("update_before_include")
+    private final boolean updateBeforeInclude;
+
     @JsonCreator
     public DebeziumDeserializationInfo(
             @JsonProperty("ignore_parse_errors") boolean ignoreParseErrors,
-            @JsonProperty("timestamp_format_standard") String timestampFormatStandard) {
+            @JsonProperty("timestamp_format_standard") String timestampFormatStandard,
+            @JsonProperty("update_before_include") boolean updateBeforeInclude) {
         this.ignoreParseErrors = ignoreParseErrors;
         this.timestampFormatStandard = timestampFormatStandard;
+        this.updateBeforeInclude = updateBeforeInclude;
+    }
+
+    public DebeziumDeserializationInfo(boolean ignoreParseErrors, String timestampFormatStandard) {
+        this.ignoreParseErrors = ignoreParseErrors;
+        this.timestampFormatStandard = timestampFormatStandard;
+        this.updateBeforeInclude = false;
     }
 
     @JsonProperty("ignore_parse_errors")
@@ -50,6 +64,11 @@ public class DebeziumDeserializationInfo implements DeserializationInfo {
         return timestampFormatStandard;
     }
 
+    @JsonProperty("update_before_include")
+    public boolean isUpdateBeforeInclude() {
+        return updateBeforeInclude;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -59,20 +78,21 @@ public class DebeziumDeserializationInfo implements DeserializationInfo {
             return false;
         }
         DebeziumDeserializationInfo that = (DebeziumDeserializationInfo) o;
-        return ignoreParseErrors == that.ignoreParseErrors
+        return ignoreParseErrors == that.ignoreParseErrors && updateBeforeInclude == that.updateBeforeInclude
                 && Objects.equals(timestampFormatStandard, that.timestampFormatStandard);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ignoreParseErrors, timestampFormatStandard);
+        return Objects.hash(ignoreParseErrors, timestampFormatStandard, updateBeforeInclude);
     }
 
     @Override
     public String toString() {
         return "DebeziumDeserializationInfo{"
-                + ", ignoreParseErrors=" + ignoreParseErrors
+                + "ignoreParseErrors=" + ignoreParseErrors
                 + ", timestampFormatStandard='" + timestampFormatStandard + '\''
+                + ", updateBeforeInclude=" + updateBeforeInclude
                 + '}';
     }
 }

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/deserialization/DebeziumDeserializationInfoTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/deserialization/DebeziumDeserializationInfoTest.java
@@ -1,0 +1,17 @@
+package org.apache.inlong.sort.protocol.deserialization;
+
+import org.apache.inlong.sort.protocol.ProtocolBaseTest;
+
+public class DebeziumDeserializationInfoTest extends ProtocolBaseTest {
+
+    @Override
+    public void init() {
+        expectedObject = new DebeziumDeserializationInfo(true, "SQL", false);
+        expectedJson = "{\"type\":\"debezium_json\", \"ignore_parse_errors\":\"true\",\"timestamp_format_standard\":\"SQL\",\"update_before_include\":\"false\"}";
+        equalObj1 = expectedObject;
+        equalObj2 = new DebeziumDeserializationInfo(true, "SQL");
+        unequalObj = "";
+
+
+    }
+}

--- a/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/debezium/DebeziumJsonDecodingFormat.java
+++ b/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/debezium/DebeziumJsonDecodingFormat.java
@@ -60,13 +60,19 @@ public class DebeziumJsonDecodingFormat implements DecodingFormat<Deserializatio
 
     private final boolean schemaInclude;
 
+    private final boolean updateBeforeInclude;
+
     private final boolean ignoreParseErrors;
 
     private final TimestampFormat timestampFormat;
 
     public DebeziumJsonDecodingFormat(
-            boolean schemaInclude, boolean ignoreParseErrors, TimestampFormat timestampFormat) {
+            boolean schemaInclude,
+            boolean updateBeforeInclude,
+            boolean ignoreParseErrors,
+            TimestampFormat timestampFormat) {
         this.schemaInclude = schemaInclude;
+        this.updateBeforeInclude = updateBeforeInclude;
         this.ignoreParseErrors = ignoreParseErrors;
         this.timestampFormat = timestampFormat;
         this.metadataKeys = Collections.emptyList();
@@ -102,6 +108,7 @@ public class DebeziumJsonDecodingFormat implements DecodingFormat<Deserializatio
                 readableMetadata,
                 producedTypeInfo,
                 schemaInclude,
+                updateBeforeInclude,
                 ignoreParseErrors,
                 timestampFormat);
     }
@@ -133,7 +140,9 @@ public class DebeziumJsonDecodingFormat implements DecodingFormat<Deserializatio
     // Metadata handling
     // --------------------------------------------------------------------------------------------
 
-    /** List of metadata that can be read with this format. */
+    /**
+     * List of metadata that can be read with this format.
+     */
     public enum ReadableMetadata {
         SCHEMA(
                 "schema",

--- a/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/deserialization/DebeziumDeserializationSchemaBuilder.java
+++ b/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/deserialization/DebeziumDeserializationSchemaBuilder.java
@@ -56,7 +56,8 @@ public class DebeziumDeserializationSchemaBuilder {
     ) throws IOException, ClassNotFoundException {
         TimestampFormat timestampFormat = getTimestampFormatStandard(deserializationInfo.getTimestampFormatStandard());
         DebeziumJsonDecodingFormat debeziumJsonDecodingFormat = new DebeziumJsonDecodingFormat(
-                false, deserializationInfo.isIgnoreParseErrors(), timestampFormat);
+                false, deserializationInfo.isUpdateBeforeInclude(), deserializationInfo.isIgnoreParseErrors(),
+                timestampFormat);
 
         // Extract required metadata
         FieldInfo[] metadataFieldInfos = getMetadataFieldInfos(fieldInfos);

--- a/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/deserialization/FieldMappingTransformer.java
+++ b/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/deserialization/FieldMappingTransformer.java
@@ -19,6 +19,7 @@
 package org.apache.inlong.sort.singletenant.flink.deserialization;
 
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 import org.apache.inlong.sort.configuration.Configuration;
 import org.apache.inlong.sort.formats.common.BooleanFormatInfo;
 import org.apache.inlong.sort.formats.common.FormatInfo;
@@ -67,7 +68,7 @@ public class FieldMappingTransformer implements Serializable {
             Object fieldValue = null;
             if (outputFieldInfos[i] instanceof BuiltInFieldInfo) {
                 BuiltInFieldInfo builtInFieldInfo = (BuiltInFieldInfo) outputFieldInfos[i];
-                fieldValue = transformBuiltInField(builtInFieldInfo, attributes, dt);
+                fieldValue = transformBuiltInField(builtInFieldInfo, attributes, dt, sourceRow.getKind());
             } else if (sourceRowIndex < sourceRow.getArity()) {
                 fieldValue = sourceRow.getField(sourceRowIndex);
                 sourceRowIndex++;
@@ -84,7 +85,8 @@ public class FieldMappingTransformer implements Serializable {
     private static Object transformBuiltInField(
             BuiltInFieldInfo builtInFieldInfo,
             Map<String, String> attributes,
-            long dataTimestamp) {
+            long dataTimestamp,
+            RowKind kind) {
         switch (builtInFieldInfo.getBuiltInField()) {
             case DATA_TIME:
                 return inferDataTimeValue(builtInFieldInfo.getFormatInfo(), dataTimestamp);
@@ -97,7 +99,7 @@ public class FieldMappingTransformer implements Serializable {
             case MYSQL_METADATA_EVENT_TIME:
                 return LongFormatInfo.INSTANCE.deserialize(attributes.get(MysqlBinLogData.MYSQL_METADATA_EVENT_TIME));
             case MYSQL_METADATA_EVENT_TYPE:
-                return attributes.get(MysqlBinLogData.MYSQL_METADATA_EVENT_TYPE);
+                return kind.shortString();
         }
 
         return null;

--- a/inlong-sort/sort-single-tenant/src/test/java/org/apache/inlong/sort/singletenant/flink/deserialization/DebeziumDeserializationTest.java
+++ b/inlong-sort/sort-single-tenant/src/test/java/org/apache/inlong/sort/singletenant/flink/deserialization/DebeziumDeserializationTest.java
@@ -68,7 +68,6 @@ public class DebeziumDeserializationTest {
         testRow.setField(0, new HashMap<String, String>() {
             {
                 put(MysqlBinLogData.MYSQL_METADATA_IS_DDL, "false");
-                put(MysqlBinLogData.MYSQL_METADATA_EVENT_TYPE, "c");
                 put(MysqlBinLogData.MYSQL_METADATA_DATABASE, "test");
                 put(MysqlBinLogData.MYSQL_METADATA_TABLE, "test");
                 put(MysqlBinLogData.MYSQL_METADATA_EVENT_TIME, "1644896917208");

--- a/inlong-sort/sort-single-tenant/src/test/java/org/apache/inlong/sort/singletenant/flink/deserialization/FieldMappingTransformerTest.java
+++ b/inlong-sort/sort-single-tenant/src/test/java/org/apache/inlong/sort/singletenant/flink/deserialization/FieldMappingTransformerTest.java
@@ -26,6 +26,7 @@ import org.apache.inlong.sort.formats.common.ShortFormatInfo;
 import org.apache.inlong.sort.formats.common.StringFormatInfo;
 import org.apache.inlong.sort.formats.common.TimestampFormatInfo;
 import org.apache.inlong.sort.protocol.BuiltInFieldInfo;
+import org.apache.inlong.sort.protocol.BuiltInFieldInfo.BuiltInField;
 import org.apache.inlong.sort.protocol.FieldInfo;
 import org.junit.Test;
 
@@ -46,7 +47,8 @@ public class FieldMappingTransformerTest {
                 new FieldInfo("f2", StringFormatInfo.INSTANCE),
                 new FieldInfo("f3", IntFormatInfo.INSTANCE),
                 new FieldInfo("f4", ShortFormatInfo.INSTANCE),
-                new FieldInfo("f5", LongFormatInfo.INSTANCE)
+                new FieldInfo("f5", LongFormatInfo.INSTANCE),
+                new BuiltInFieldInfo("event_type", new StringFormatInfo(), BuiltInField.MYSQL_METADATA_EVENT_TYPE)
         };
         final long ms = 10000000000L;
         final Configuration configuration = new Configuration();
@@ -56,12 +58,13 @@ public class FieldMappingTransformerTest {
         FieldMappingTransformer transformer = new FieldMappingTransformer(configuration, fieldInfos);
         Row resultRow = transformer.transform(Row.of(new HashMap<>(), 1), ms);
 
-        assertEquals(6, resultRow.getArity());
+        assertEquals(7, resultRow.getArity());
         assertEquals(new Timestamp(ms), resultRow.getField(0));
         assertEquals(1, resultRow.getField(1));
         assertEquals("", resultRow.getField(2));
         assertEquals(0, resultRow.getField(3));
         assertEquals(0, resultRow.getField(4));
         assertEquals(0L, resultRow.getField(5));
+        assertEquals("+I", resultRow.getField(6));
     }
 }


### PR DESCRIPTION
### Title Name: [INLONG-2820][Sort] Improve the deserialization processing of the update event in DebeziumDeserializationSchema

where *XYZ* should be replaced by the actual issue number.

Fixes #<2820>

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
