### PR TITLE
[INLONG-2830][Manager] Support more than one source for a pair of groups and streams

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/StreamSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/StreamSourceServiceImpl.java
@@ -78,13 +78,8 @@ public class StreamSourceServiceImpl implements StreamSourceService {
         String groupId = request.getInlongGroupId();
         commonOperateService.checkGroupStatus(groupId, operator);
 
-        // Make sure that there is no source info with the current groupId and streamId
-        String streamId = request.getInlongStreamId();
-        String sourceType = request.getSourceType();
-        List<StreamSourceEntity> sourceExist = sourceMapper.selectByIdAndType(groupId, streamId, sourceType);
-        Preconditions.checkEmpty(sourceExist, ErrorCodeEnum.SOURCE_ALREADY_EXISTS.getMessage());
-
         // According to the source type, save source information
+        String sourceType = request.getSourceType();
         StreamSourceOperation operation = operationFactory.getInstance(SourceType.forType(sourceType));
         int id = operation.saveOpt(request, operator);
 


### PR DESCRIPTION
### Title Name: [INLONG-2830][Manager] Support more than one source for a pair of groups and streams

Fixes #2830 

### Motivation

Support more than one source for a pair of groups and streams.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduces a new feature? (no)