### PR TITLE
[INLONG-2788][Agent] Support sync send data to dataproxy when needed

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
@@ -54,6 +54,10 @@ public class CommonConstants {
 
     // max size of message list
     public static final String PROXY_PACKAGE_MAX_SIZE = "proxy.package.maxSize";
+
+    // determine if the send method is sync or async
+    public static final String PROXY_SEND_SYNC = "proxy.sync";
+
     // max size of single batch in bytes, default is 200KB.
     public static final int DEFAULT_PROXY_PACKAGE_MAX_SIZE = 200000;
 
@@ -84,6 +88,7 @@ public class CommonConstants {
 
     public static final String PROXY_KEY_GROUP_ID = "inlongGroupId";
     public static final String PROXY_KEY_STREAM_ID = "inlongStreamId";
+    public static final String PROXY_KEY_DATA = "dataKey";
     public static final String PROXY_KEY_ID = "id";
     public static final String PROXY_KEY_AGENT_IP = "agentip";
     public static final String PROXY_OCEANUS_F = "f";
@@ -137,4 +142,7 @@ public class CommonConstants {
     public static final String AGENT_NIX_OS = "nix";
     public static final String AGENT_NUX_OS = "nux";
     public static final String AGENT_COLON = ":";
+
+    public static final Integer DEFAULT_MAP_CAPACITY = 16;
+
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/ProxyMessage.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/ProxyMessage.java
@@ -53,7 +53,6 @@ public class ProxyMessage implements Message {
         this.batchKey = dataKey + inlongStreamId;
     }
 
-
     public String getDataKey() {
         return dataKey;
     }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/ProxyMessage.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/ProxyMessage.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.agent.message;
 
+import static org.apache.inlong.agent.constant.CommonConstants.PROXY_KEY_DATA;
 import static org.apache.inlong.agent.constant.CommonConstants.PROXY_KEY_GROUP_ID;
 import static org.apache.inlong.agent.constant.CommonConstants.PROXY_KEY_STREAM_ID;
 
@@ -34,12 +35,27 @@ public class ProxyMessage implements Message {
     private final Map<String, String> header;
     private final String inlongGroupId;
     private final String inlongStreamId;
+    /**x
+     * determine the group key when making batch
+     */
+    private final String batchKey;
+    private String dataKey;
 
     public ProxyMessage(byte[] body, Map<String, String> header) {
         this.body = body;
         this.header = header;
         this.inlongGroupId = header.get(PROXY_KEY_GROUP_ID);
         this.inlongStreamId = header.getOrDefault(PROXY_KEY_STREAM_ID, DEFAULT_INLONG_STREAM_ID);
+        this.dataKey = header.getOrDefault(PROXY_KEY_DATA, "");
+        /**
+         * use the batch key of user and inlongStreamId to determine one batch
+         */
+        this.batchKey = dataKey + inlongStreamId;
+    }
+
+
+    public String getDataKey() {
+        return dataKey;
     }
 
     /**
@@ -68,6 +84,10 @@ public class ProxyMessage implements Message {
 
     public String getInlongStreamId() {
         return inlongStreamId;
+    }
+
+    public String getBatchKey() {
+        return batchKey;
     }
 
     public static ProxyMessage parse(Message message) {

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/DebeziumFormat.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/DebeziumFormat.java
@@ -15,26 +15,28 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.common.pojo.agent;
+package org.apache.inlong.agent.pojo;
 
+import java.util.Map;
 import lombok.Data;
 
 @Data
-public class DataConfig {
+public class DebeziumFormat {
 
-    private String inlongGroupId;
-    private String inlongStreamId;
-    private String deliveryTime;
-    private String uuid;
-    private String ip;
-    private String op;
-    private Integer jobId;
-    private Integer taskType;
-    private String snapshot;
-    private String syncSend;
-    private String extParams;
+    /**
+     * no need to deserialize
+     */
+    private Map<String, String> before;
 
-    public boolean isValid() {
-        return true;
-    }
+    /**
+     * no need to deserialize
+     */
+    private Map<String, String> after;
+
+
+    /**
+     * extra info about db
+     */
+    private DebeziumSourceFormat source;
+
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/DebeziumSourceFormat.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/DebeziumSourceFormat.java
@@ -15,26 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.common.pojo.agent;
+package org.apache.inlong.agent.pojo;
 
 import lombok.Data;
 
 @Data
-public class DataConfig {
+public class DebeziumSourceFormat {
 
-    private String inlongGroupId;
-    private String inlongStreamId;
-    private String deliveryTime;
-    private String uuid;
-    private String ip;
-    private String op;
-    private Integer jobId;
-    private Integer taskType;
+    private String version;
+
     private String snapshot;
-    private String syncSend;
-    private String extParams;
 
-    public boolean isValid() {
-        return true;
-    }
+    private String db;
+
+    private String table;
+
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/JobProfileDto.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/JobProfileDto.java
@@ -19,6 +19,7 @@ package org.apache.inlong.agent.pojo;
 
 import com.google.gson.Gson;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.agent.conf.AgentConfiguration;
 import org.apache.inlong.agent.conf.TriggerProfile;
 import org.apache.inlong.common.pojo.agent.DataConfig;
@@ -151,6 +152,9 @@ public class JobProfileDto {
         proxy.setInlongGroupId(dataConfigs.getInlongGroupId());
         proxy.setInlongStreamId(dataConfigs.getInlongStreamId());
         proxy.setManager(manager);
+        if (!StringUtils.isEmpty(dataConfigs.getSyncSend())) {
+            proxy.setSync(dataConfigs.getSyncSend());
+        }
         return proxy;
     }
 
@@ -230,6 +234,7 @@ public class JobProfileDto {
         private String inlongGroupId;
         private String inlongStreamId;
         private Manager manager;
+        private String sync;
     }
 
 }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskWrapper.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskWrapper.java
@@ -85,7 +85,6 @@ public class TaskWrapper extends AbstractStateWrapper {
                 if (message == null || task.getChannel()
                         .push(message, pushMaxWaitTime, TimeUnit.SECONDS)) {
                     message = task.getReader().read();
-                    LOGGER.debug("submitReadThread get message {}", message);
                 }
             }
             LOGGER.info("read end, task exception status is {}, read finish status is {}",

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/message/PackProxyMessage.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/message/PackProxyMessage.java
@@ -18,7 +18,9 @@
 package org.apache.inlong.agent.plugin.message;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.lang3.tuple.Pair;
@@ -43,6 +45,11 @@ public class PackProxyMessage {
     // ms
     private final int cacheTimeout;
 
+    /**
+     * extra map used when sending to dataproxy
+     */
+    private Map<String, String> extraMap = new HashMap<>();
+
     // streamId -> list of proxyMessage
     private final LinkedBlockingQueue<ProxyMessage> messageQueue;
 
@@ -63,6 +70,11 @@ public class PackProxyMessage {
         // double size of package
         this.messageQueue = new LinkedBlockingQueue<>(maxQueueNumber);
         this.streamId = streamId;
+    }
+
+    public void generateExtraMap(boolean syncSend, String dataKey) {
+        this.extraMap.put("syncSend", String.valueOf(syncSend));
+        this.extraMap.put("partitionKey", dataKey);
     }
 
     /**
@@ -138,4 +150,9 @@ public class PackProxyMessage {
         }
         return null;
     }
+
+    public Map<String, String> getExtraMap() {
+        return extraMap;
+    }
+
 }

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestBinlogReader.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestBinlogReader.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.plugin.sources;
+
+import com.google.gson.Gson;
+import org.apache.inlong.agent.pojo.DebeziumFormat;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestBinlogReader {
+
+    private static Gson gson = new Gson();
+
+    @Test
+    public void testDebeziumFormat() {
+        String debeziumJson = "{\n"
+            + "    \"before\": null,\n"
+            + "    \"after\": {\n"
+            + "      \"id\": 1004,\n"
+            + "      \"first_name\": \"Anne\",\n"
+            + "      \"last_name\": \"Kretchmar\",\n"
+            + "      \"email\": \"annek@noanswer.org\"\n"
+            + "    },\n"
+            + "    \"source\": {\n"
+            + "      \"version\": \"1.8.1.Final\",\n"
+            + "      \"name\": \"dbserver1\",\n"
+            + "      \"server_id\": 0,\n"
+            + "      \"ts_sec\": 0,\n"
+            + "      \"gtid\": null,\n"
+            + "      \"file\": \"mysql-bin.000003\",\n"
+            + "      \"pos\": 154,\n"
+            + "      \"row\": 0,\n"
+            + "      \"snapshot\": true,\n"
+            + "      \"thread\": null,\n"
+            + "      \"db\": \"inventory\",\n"
+            + "      \"table\": \"customers\"\n"
+            + "    },\n"
+            + "    \"op\": \"r\",\n"
+            + "    \"ts_ms\": 1486500577691\n"
+            + "  }";
+        DebeziumFormat debeziumFormat = gson
+            .fromJson(debeziumJson, DebeziumFormat.class);
+        Assert.assertEquals("customers", debeziumFormat.getSource().getTable());
+    }
+}


### PR DESCRIPTION
### [INLONG-2788][Agent] Support sync send data to dataproxy when needed.

Fixes #2788 

### Motivation

Agent support sync sends data to dataproxy when needed (binlog etc.)

### Modifications

Agent support sync sends data to dataproxy when needed (binlog etc.)

### Verifying this change

Agent support sync sends data to dataproxy when needed (binlog etc.)

### Documentation

  - Does this pull request introduce a new feature? (yes)
