### PR TITLE
[INLONG-2694][Manager] Implement services of getSortSource Interface and add UT

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sort/SortSourceConfigResponse.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sort/SortSourceConfigResponse.java
@@ -37,7 +37,7 @@ public class SortSourceConfigResponse {
     @Builder
     public static class SortSourceConfig {
         String sortClusterName;
-        String zoneName;
+        String sortTaskId;
         Map<String, CacheZone> cacheZones;
     }
 

--- a/inlong-manager/manager-dao/src/main/resources/mappers/SortSourceConfigEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/SortSourceConfigEntityMapper.xml
@@ -140,8 +140,10 @@
   <select id="selectByClusterAndTask" resultMap="ResultMapWithBLOBs">
     select
     <include refid="Base_Column_List" />
+    ,
+    <include refid="Blob_Column_List" />
     from sort_source_config
-    where cluster_name = #{clusterName,jdbcType=INTEGER}
+    where cluster_name = #{clusterName,jdbcType=VARCHAR}
     AND task_name = #{taskName,jdbcType=VARCHAR}
   </select>
 </mapper>

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/SortSourceService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/SortSourceService.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.core;
+
+import org.apache.inlong.manager.common.pojo.sort.SortSourceConfigResponse.CacheZone;
+
+import java.util.Map;
+
+/**
+ * Sort source service.
+ */
+public interface SortSourceService {
+
+    /**
+     * Get cache zones by cluster name and task name.
+     * @param clusterName Target cluster name.
+     * @param taskName Target task name.
+     * @return SortSourceConfigResponse
+     */
+    Map<String, CacheZone> getCacheZones(String clusterName, String taskName);
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
@@ -159,6 +159,7 @@ public class SortServiceImpl implements SortService {
             return SortSourceConfigResponse.builder()
                     .msg(msg)
                     .code(RESPONSE_CODE_NO_UPDATE)
+                    .md5(md5)
                     .build();
         }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
@@ -17,16 +17,21 @@
 
 package org.apache.inlong.manager.service.core.impl;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.pojo.sort.SortClusterConfigResponse;
 import org.apache.inlong.manager.common.pojo.sort.SortSourceConfigResponse;
+import org.apache.inlong.manager.common.pojo.sort.SortSourceConfigResponse.CacheZone;
+import org.apache.inlong.manager.common.pojo.sort.SortSourceConfigResponse.SortSourceConfig;
 import org.apache.inlong.manager.dao.entity.SortClusterConfigEntity;
 import org.apache.inlong.manager.common.pojo.sort.SortClusterConfigResponse.SinkType;
 import org.apache.inlong.manager.common.pojo.sort.SortClusterConfigResponse.SortTaskConfig;
 import org.apache.inlong.manager.service.core.SortClusterConfigService;
+import org.apache.inlong.manager.service.core.SortSourceService;
 import org.apache.inlong.manager.service.core.SortTaskIdParamService;
 import org.apache.inlong.manager.service.core.SortService;
 import org.apache.inlong.manager.service.core.SortTaskSinkParamService;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,11 +47,18 @@ public class SortServiceImpl implements SortService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SortServiceImpl.class);
 
+    private static final int RESPONSE_CODE_SUCCESS = 0;
+    private static final int RESPONSE_CODE_NO_UPDATE = 1;
+    private static final int RESPONSE_CODE_FAIL = -1;
+    private static final int RESPONSE_CODE_REQ_PARAMS_ERROR = -101;
+
     @Autowired private SortClusterConfigService sortClusterConfigService;
 
     @Autowired private SortTaskIdParamService sortTaskIdParamService;
 
     @Autowired private SortTaskSinkParamService sortTaskSinkParamService;
+
+    @Autowired private SortSourceService sortSourceService;
 
     @Override
     public SortClusterConfigResponse getClusterConfig(String clusterName, String md5) {
@@ -81,11 +93,6 @@ public class SortServiceImpl implements SortService {
         return SortClusterConfigResponse.builder().tasks(taskConfigs).msg("success").build();
     }
 
-    @Override
-    public SortSourceConfigResponse getSourceConfig(String clusterName, String sortTaskId, String md5) {
-        return null;
-    }
-
     private SortTaskConfig getTaskConfig(SortClusterConfigEntity clusterConfig) {
         SinkType sinkType = SinkType.valueOf(clusterConfig.getSinkType().toUpperCase());
         List<Map<String, String>> idParams =
@@ -98,6 +105,69 @@ public class SortServiceImpl implements SortService {
                 .sinkType(sinkType)
                 .idParams(idParams)
                 .sinkParams(sinkParams)
+                .build();
+    }
+
+    @Override
+    public SortSourceConfigResponse getSourceConfig(String clusterName, String sortTaskId, String md5) {
+
+        // check if clusterName and sortTaskId are null.
+        if (StringUtils.isBlank(clusterName) || StringUtils.isBlank(sortTaskId)) {
+            String errMsg = "Blank cluster name or task id, return nothing";
+            return SortSourceConfigResponse.builder()
+                    .msg(errMsg)
+                    .code(RESPONSE_CODE_REQ_PARAMS_ERROR)
+                    .build();
+        }
+
+        // get cacheZones
+        Map<String, CacheZone> cacheZones;
+        try {
+            cacheZones = sortSourceService.getCacheZones(clusterName, sortTaskId);
+        } catch (Exception e) {
+            String errMsg = "Got exception when get cache zones. " + e.getMessage();
+            LOGGER.error(errMsg, e);
+            return SortSourceConfigResponse.builder()
+                    .msg(errMsg)
+                    .code(RESPONSE_CODE_FAIL)
+                    .build();
+        }
+
+        // if there is not any cacheZones;
+        if (cacheZones.isEmpty()) {
+            String errMsg = "There is not any cacheZones of cluster: " + clusterName
+                    + " , task: " + sortTaskId
+                    + " , please check the params";
+            LOGGER.error(errMsg);
+            return SortSourceConfigResponse.builder()
+                    .msg(errMsg)
+                    .code(RESPONSE_CODE_REQ_PARAMS_ERROR)
+                    .build();
+        }
+
+        SortSourceConfig data = SortSourceConfig.builder()
+                .sortClusterName(clusterName)
+                .sortTaskId(sortTaskId)
+                .cacheZones(cacheZones)
+                .build();
+
+        // no update
+        JSONObject jo = new JSONObject(data);
+        String localMd5 = DigestUtils.md5Hex(jo.toString());
+        if (md5.equals(localMd5)) {
+            String msg = "Same md5, no update";
+            return SortSourceConfigResponse.builder()
+                    .msg(msg)
+                    .code(RESPONSE_CODE_NO_UPDATE)
+                    .build();
+        }
+
+        // normal response.
+        return SortSourceConfigResponse.builder()
+                .msg("success")
+                .code(RESPONSE_CODE_SUCCESS)
+                .data(data)
+                .md5(localMd5)
                 .build();
     }
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.core.impl;
+
+
+import com.google.gson.Gson;
+import jodd.util.StringUtil;
+import org.apache.inlong.manager.common.pojo.sort.SortSourceConfigResponse.CacheZone;
+import org.apache.inlong.manager.common.pojo.sort.SortSourceConfigResponse.Topic;
+import org.apache.inlong.manager.dao.entity.SortSourceConfigEntity;
+import org.apache.inlong.manager.dao.mapper.SortSourceConfigEntityMapper;
+import org.apache.inlong.manager.service.core.SortSourceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link SortSourceService}.
+ */
+@Service
+public class SortSourceServiceImpl implements SortSourceService {
+
+    private static final String KEY_TOPIC_PARTITION_COUNT = "partitionCnt";
+    private static final String KEY_ZONE_SERVICE_URL = "serviceUrl";
+    private static final String KEY_ZONE_AUTHENTICATION = "authentication";
+    private static final String KEY_ZONE_TYPE = "zoneType";
+
+    @Autowired
+    private SortSourceConfigEntityMapper sortSourceConfigEntityMapper;
+
+    @Override
+    public Map<String, CacheZone> getCacheZones(String clusterName, String taskName) {
+        List<SortSourceConfigEntity> configList =
+                sortSourceConfigEntityMapper.selectByClusterAndTask(clusterName, taskName);
+
+        // group configs by zone name
+        Map<String, List<SortSourceConfigEntity>> zoneConfigMap =
+                configList.stream().collect(Collectors.groupingBy(SortSourceConfigEntity::getZoneName));
+
+        return zoneConfigMap.values()
+                .stream()
+                .map(this::toCacheZone)
+                .collect(Collectors.toMap(CacheZone::getZoneName, cacheZone -> cacheZone));
+    }
+
+    /**
+     * Build one {@link CacheZone} from list of configs including zone config and configs of each topic.
+     *
+     * <p>
+     *     The way we differ zone config and topic config is
+     *     if the params <b>topic</b> in {@link SortSourceConfigEntity} is blank.
+     *     If topic is blank, it's the <b>zone config</b>,
+     *     otherwise, it's <b>topic config</b>.
+     * </p>
+     *
+     * @param configList List of configs.
+     * @return CacheZone.
+     */
+    private CacheZone toCacheZone(List<SortSourceConfigEntity> configList) {
+        // get list of Topic
+        List<Topic> topicList
+                = configList.stream()
+                .filter(config -> StringUtil.isNotBlank(config.getTopic()))
+                .map(this::toTopic)
+                .collect(Collectors.toList());
+
+        // get zone config
+        List<SortSourceConfigEntity> zoneConfigs
+                = configList.stream()
+                .filter(config -> StringUtil.isBlank(config.getTopic()))
+                .collect(Collectors.toList());
+
+        if (zoneConfigs.size() != 1) {
+            throw new IllegalStateException("The size of zone config should be 1, but found " +  zoneConfigs.size());
+        }
+
+        SortSourceConfigEntity zoneConfig = zoneConfigs.get(0);
+        Map<String, String> zoneProperties = this.jsonProperty2Map(zoneConfig.getExtParams());
+
+        return CacheZone.builder()
+                .zoneName(zoneConfig.getZoneName())
+                .serviceUrl(zoneProperties.remove(KEY_ZONE_SERVICE_URL))
+                .authentication(zoneProperties.remove(KEY_ZONE_AUTHENTICATION))
+                .topics(topicList)
+                .zoneType(zoneProperties.remove(KEY_ZONE_TYPE))
+                .cacheZoneProperties(zoneProperties)
+                .build();
+    }
+
+    /**
+     * Build one {@link Topic} from the corresponding config.
+     *
+     * @param topicConfig Config of topic.
+     * @return Topic.
+     */
+    private Topic toTopic(SortSourceConfigEntity topicConfig) {
+        Map<String, String> topicProperties = this.jsonProperty2Map(topicConfig.getExtParams());
+        int partitionCnt = Integer.parseInt(topicProperties.remove(KEY_TOPIC_PARTITION_COUNT));
+        return Topic.builder()
+                .topic(topicConfig.getTopic())
+                .partitionCnt(partitionCnt)
+                .topicProperties(topicProperties)
+                .build();
+    }
+
+    /**
+     * Convert property json string to map format.
+     *
+     * @param jsonProperty Properties in json string format.
+     * @return Properties in map format.
+     */
+    private Map<String, String> jsonProperty2Map(String jsonProperty) {
+        return new Gson().fromJson(jsonProperty, Map.class);
+    }
+
+
+
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.manager.service.core.impl;
 
-
 import com.google.gson.Gson;
 import jodd.util.StringUtil;
 import org.apache.inlong.manager.common.pojo.sort.SortSourceConfigResponse.CacheZone;
@@ -130,8 +129,5 @@ public class SortSourceServiceImpl implements SortSourceService {
     private Map<String, String> jsonProperty2Map(String jsonProperty) {
         return new Gson().fromJson(jsonProperty, Map.class);
     }
-
-
-
 
 }

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/SortServiceImplTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/SortServiceImplTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.core.impl;
+
+import org.apache.inlong.manager.common.pojo.sort.SortSourceConfigResponse;
+import org.apache.inlong.manager.dao.entity.SortSourceConfigEntity;
+import org.apache.inlong.manager.dao.mapper.SortSourceConfigEntityMapper;
+import org.apache.inlong.manager.service.ServiceBaseTest;
+import org.apache.inlong.manager.service.core.SortService;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SortServiceImplTest extends ServiceBaseTest {
+
+    @Autowired
+    private SortService sortService;
+
+    @Autowired
+    SortSourceConfigEntityMapper sourceMapper;
+
+    private static final String TEST_CLUSTER = "testCluster";
+    private static final String TEST_TASK = "testTask";
+
+    @Test
+    @Transactional
+    public void testSourceEmptyParams() {
+        SortSourceConfigResponse response = sortService.getSourceConfig("", "", "");
+        System.out.println(response.toString());
+        Assert.assertEquals(response.getCode(), -101);
+        Assert.assertNull(response.getMd5());
+        Assert.assertNull(response.getData());
+        Assert.assertNotNull(response.getMsg());
+    }
+
+    @Test
+    @Transactional
+    public void testSourceCorrectParams() {
+        SortSourceConfigResponse response = sortService.getSourceConfig(TEST_CLUSTER, TEST_TASK, "");
+        JSONObject jo = new JSONObject(response);
+        System.out.println(jo);
+        Assert.assertEquals(0, response.getCode());
+        Assert.assertNotNull(response.getData());
+        Assert.assertNotNull(response.getMd5());
+        Assert.assertNotNull(response.getMsg());
+    }
+
+    @Test
+    @Transactional
+    public void testSourceSameMd5() {
+        SortSourceConfigResponse response = sortService.getSourceConfig(TEST_CLUSTER, TEST_TASK, "");
+        String md5 = response.getMd5();
+        response = sortService.getSourceConfig(TEST_CLUSTER, TEST_TASK, md5);
+        System.out.println(response);
+        Assert.assertEquals(1, response.getCode());
+        Assert.assertEquals(md5, response.getMd5());
+        Assert.assertNull(response.getData());
+        Assert.assertNotNull(response.getMsg());
+    }
+
+    @Test
+    @Transactional
+    public void testSourceErrorClusterName() {
+        SortSourceConfigResponse response = sortService.getSourceConfig("errCluster", "errTask", "");
+        System.out.println(response.toString());
+        Assert.assertEquals(response.getCode(), -101);
+        Assert.assertNull(response.getMd5());
+        Assert.assertNull(response.getData());
+        Assert.assertNotNull(response.getMsg());
+    }
+
+    @Test
+    @Transactional
+    public void testSourceDuplicatedZoneParam() {
+        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone1", null));
+        SortSourceConfigResponse response = sortService.getSourceConfig(TEST_CLUSTER, TEST_TASK, "");
+        System.out.println(response);
+        Assert.assertEquals(-1, response.getCode());
+        Assert.assertNull(response.getData());
+        Assert.assertNull(response.getMd5());
+        Assert.assertNotNull(response.getMsg());
+    }
+
+    @Before
+    public void prepareSourceProperties() {
+        String testZone = "testZone";
+        String testTopic = "testTopic";
+        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone1", "topic1"));
+        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone1", "topic2"));
+        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone1", null));
+        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone2", "topic1"));
+        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone2", "topic2"));
+        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone2", null));
+    }
+
+    private SortSourceConfigEntity prepareSourceEntity(
+            String clusterName,
+            String taskName,
+            String zone,
+            String topic) {
+
+        Map<String, String> extParamMap = new HashMap<>();
+        extParamMap.put("param key of " + zone + topic, "param value of " + zone + topic);
+
+        if (topic == null) {
+            extParamMap.put("zoneName", zone);
+            extParamMap.put("serviceUrl", "testUrl");
+            extParamMap.put("authentication", "testAuth");
+            extParamMap.put("zoneType", "testZoneType");
+        } else {
+            extParamMap.put("partitionCnt", "123");
+            extParamMap.put("topic", "testTopic");
+        }
+
+        JSONObject jo = new JSONObject(extParamMap);
+        return SortSourceConfigEntity.builder()
+                .clusterName(clusterName)
+                .taskName(taskName)
+                .zoneName(zone)
+                .topic(topic)
+                .extParams(jo.toString())
+                .build();
+    }
+
+}

--- a/inlong-manager/manager-test/src/main/resources/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-test/src/main/resources/sql/apache_inlong_manager.sql
@@ -1065,4 +1065,21 @@ CREATE TABLE `sort_task_sink_param`
     KEY `index_sort_task_sink_params` (`task_name`, `sink_type`)
 );
 
+-- ----------------------------
+-- Table structure for sort_source_config
+-- ----------------------------
+DROP TABLE IF EXISTS `sort_source_config`;
+CREATE TABLE `sort_source_config`
+(
+    `id`            int(11)       NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
+    `cluster_name`  varchar(128)  NOT NULL COMMENT 'Cluster name',
+    `task_name`     varchar(128)  NOT NULL COMMENT 'Task name',
+    `zone_name`     varchar(128)  NOT NULL COMMENT 'Cache zone name',
+    `topic`         varchar(128)  DEFAULT '' COMMENT 'Topic',
+    `ext_params`    text          DEFAULT NULL COMMENT 'Another fields, will saved as JSON type',
+    PRIMARY KEY (`id`),
+    KEY `index_sort_source_config` (`cluster_name`, `task_name`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='Sort source config table';
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -1133,7 +1133,7 @@ CREATE TABLE `sort_source_config`
     `cluster_name`  varchar(128)  NOT NULL COMMENT 'Cluster name',
     `task_name`     varchar(128)  NOT NULL COMMENT 'Task name',
     `zone_name`     varchar(128)  NOT NULL COMMENT 'Cache zone name',
-    `topic`         varchar(128)  DEFAULT NULL COMMENT 'Topic',
+    `topic`         varchar(128)  DEFAULT '' COMMENT 'Topic',
     `ext_params`    text          DEFAULT NULL COMMENT 'Another fields, will saved as JSON type',
     PRIMARY KEY (`id`),
     KEY `index_sort_source_config` (`cluster_name`, `task_name`)

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/SortController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/SortController.java
@@ -50,7 +50,7 @@ public class SortController {
             @RequestParam String clusterName,
             @RequestParam String sortTaskId,
             @RequestParam String md5) {
-        return null;
+        return sortService.getSourceConfig(clusterName, sortTaskId, md5);
     }
 
 }


### PR DESCRIPTION
### Title Name: [INLONG-2694][Manager] Implement services of getSortSource Interface and add UT

Fixes #2694
parent issue #2573 

### Motivation

The sturcture of table **sort_source_config** is 

    `id`            int(11)       NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
    `cluster_name`  varchar(128)  NOT NULL COMMENT 'Cluster name',
    `task_name`     varchar(128)  NOT NULL COMMENT 'Task name',
    `zone_name`     varchar(128)  NOT NULL COMMENT 'Cache zone name',
    `topic`         varchar(128)  DEFAULT NULL COMMENT 'Topic',
    `ext_params`    text          DEFAULT NULL COMMENT 'Another fields, will saved as JSON type'

One topic belongs to one zone,  while one zone has a few of topics.
The properties of zone or topic are in the field ext_params.
The way to  differ the proerties belongs to zone or topic, is that if the field **topic** is null.  If so, it's zone properties, otherwise, it's topic's


### Modifications

Add UT
Implement sortSource service

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
