### PR TITLE
[INLONG-2870][Agent] Use base64 to encode snapshot instead of using iso-8859-1

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobManager.java
@@ -179,6 +179,7 @@ public class JobManager extends AbstractDaemon {
      */
     public boolean deleteJob(String jobInstancId) {
         JobWrapper jobWrapper = jobs.remove(jobInstancId);
+        LOGGER.info("start to delete job, job id set {}", jobs.keySet());
         if (jobWrapper != null) {
             LOGGER.info("delete job instance with job id {}", jobInstancId);
             jobWrapper.cleanup();

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
@@ -126,6 +126,8 @@ public class TaskManager extends AbstractDaemon {
                 }
             }
             taskMetrics.incRunningTaskCount();
+        } else {
+            LOGGER.warn("task cannot be repeated added taskId {}", wrapper.getTask().getTaskId());
         }
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/BinlogReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/BinlogReader.java
@@ -169,6 +169,9 @@ public class BinlogReader implements Reader {
 
         executor = Executors.newSingleThreadExecutor();
         executor.execute(engine);
+
+        LOGGER.info("get initial snapshot of job {}, snapshot {}",
+            jobConf.getInstanceId(), getSnapshot());
     }
 
     private Properties getEngineProps() {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/snapshot/BinlogSnapshotBase.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/snapshot/BinlogSnapshotBase.java
@@ -23,7 +23,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Base64.Decoder;
+import java.util.Base64.Encoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +35,8 @@ public class BinlogSnapshotBase implements SnapshotBase {
     public static final int START_OFFSET = 0;
     private static final Logger log = LoggerFactory.getLogger(BinlogSnapshotBase.class);
     private File file;
+    private final Decoder decoder = Base64.getDecoder();
+    private final Encoder encoder = Base64.getEncoder();
 
     private byte[] offset;
 
@@ -43,7 +47,7 @@ public class BinlogSnapshotBase implements SnapshotBase {
     @Override
     public String getSnapshot() {
         load();
-        return new String(offset, StandardCharsets.ISO_8859_1);
+        return encoder.encodeToString(offset);
     }
 
     @Override
@@ -72,7 +76,7 @@ public class BinlogSnapshotBase implements SnapshotBase {
     }
 
     public void save(String snapshot) {
-        byte[] bytes = snapshot.getBytes(StandardCharsets.ISO_8859_1);
+        byte[] bytes = decoder.decode(snapshot);
         if (bytes.length != 0) {
             offset = bytes;
             try (OutputStream output = new FileOutputStream(file)) {

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestBinlogOffsetManager.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestBinlogOffsetManager.java
@@ -17,8 +17,8 @@
 
 package org.apache.inlong.agent.plugin.sources;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.inlong.agent.plugin.AgentBaseTestsHelper;
 import org.apache.inlong.agent.plugin.sources.snapshot.BinlogSnapshotBase;
 import org.junit.AfterClass;
@@ -49,9 +49,10 @@ public class TestBinlogOffsetManager {
     public void testOffset() {
         BinlogSnapshotBase snapshotManager = new BinlogSnapshotBase(testDir.toString());
         byte[] snapshotBytes = new byte[]{-65, -14, -23};
-        String snapshotString = new String(snapshotBytes, StandardCharsets.ISO_8859_1);
-        snapshotManager.save(snapshotString);
-        Assert.assertEquals(snapshotManager.getSnapshot(), snapshotString);
+        final Base64 base64 = new Base64();
+        String encodeSnapshot = base64.encodeAsString(snapshotBytes);
+        snapshotManager.save(encodeSnapshot);
+        Assert.assertEquals(snapshotManager.getSnapshot(), encodeSnapshot);
     }
 
 }


### PR DESCRIPTION
### TitleName: [INLONG-2870][Agent] Use base64 to encode snapshot instead of using iso-8859-1

Fixes #2870 

### Motivation

Agent should use base64 to encode offset since iso-8859-1 is not supported by manager

### Modifications

Agent should use base64 to encode offset since iso-8859-1 is not supported by manager

### Verifying this change

- [X] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (no)