### PR TITLE
[INLONG-2877][Agent] Task position manager throws NPE when send dataproxy ack success 

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
@@ -206,7 +206,13 @@ public class SenderManager {
                 return;
             }
             metric.incSendSuccessNum(bodyList.size());
-            taskPositionManager.updateSinkPosition(jobId, sourcePath, bodyList.size());
+            /**
+             * when there is no source, the position should not be stored locally
+             * since we report snapshot to manager already
+             */
+            if (sourcePath != null) {
+                taskPositionManager.updateSinkPosition(jobId, sourcePath, bodyList.size());
+            }
         }
 
         @Override


### PR DESCRIPTION
### [INLONG-2877][Agent] Task position manager throws NPE when sending dataproxy ack success 

Fixes #2877 

### Motivation

Agent task position manager throws NPE when sending dataproxy ack success 

### Modifications

Agent task position manager throws NPE when sending dataproxy ack success when there is no source, the position should not be stored locally since we report snapshot to the manager-module already.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (no)