### PR TITLE
[INLONG-2888][Manager] Stream source was not deleted when calling delete operate

### DIFF
--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSourceEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSourceEntityMapper.java
@@ -80,6 +80,11 @@ public interface StreamSourceEntityMapper {
      */
     List<String> selectSourceType(@Param("groupId") String groupId, @Param("streamId") String streamId);
 
+    /**
+     * Get all sources in temporary status.
+     *
+     * @apiNote Do not need to filter sources that is_deleted > 0.
+     */
     List<StreamSourceEntity> selectTempStatusSource();
 
     int updateByPrimaryKeySelective(StreamSourceEntity record);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/AbstractStreamSourceOperation.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/AbstractStreamSourceOperation.java
@@ -142,16 +142,18 @@ public abstract class AbstractStreamSourceOperation implements StreamSourceOpera
 
     @Override
     public void deleteOpt(SourceRequest request, String operator) {
-        StreamSourceEntity snapshot = sourceMapper.selectByPrimaryKey(request.getId());
-        SourceState curState = SourceState.forCode(snapshot.getStatus());
+        Integer id = request.getId();
+        StreamSourceEntity existEntity = sourceMapper.selectByPrimaryKey(id);
+        SourceState curState = SourceState.forCode(existEntity.getStatus());
         SourceState nextState = SourceState.TO_BE_ISSUED_DELETE;
         if (!SourceState.isAllowedTransition(curState, nextState)) {
-            throw new RuntimeException(String.format("Source=%s is not allowed to delete", snapshot));
+            throw new RuntimeException(String.format("Source=%s is not allowed to delete", existEntity));
         }
         StreamSourceEntity curEntity = CommonBeanUtils.copyProperties(request, StreamSourceEntity::new);
         curEntity.setModifyTime(new Date());
         curEntity.setPreviousStatus(curState.getCode());
         curEntity.setStatus(nextState.getCode());
+        curEntity.setIsDeleted(id);
         sourceMapper.updateByPrimaryKeySelective(curEntity);
     }
 }


### PR DESCRIPTION
### Title Name: [INLONG-2888][Manager] Stream source was not deleted when calling delete operate

Fixes #2888

### Motivation

[INLONG-2888][Manager] Stream source was not deleted when calling delete operate.

### Verifying this change

- [X] Make sure that the change passes the CI checks.