### PR TITLE
[INLONG-2908][Agent] Remove the space before the UUID

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -347,7 +347,7 @@ public class AgentUtils {
         String uuid = "";
         try {
             String localUuid = AgentConfiguration.getAgentConf().get(AGENT_LOCAL_UUID);
-            if (!StringUtils.isEmpty(localUuid)) {
+            if (StringUtils.isNotEmpty(localUuid)) {
                 uuid = localUuid;
                 return uuid;
             }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -344,8 +344,19 @@ public class AgentUtils {
      * check agent uuid from manager
      */
     public static String  fetchLocalUuid() {
-        String result = ExcuteLinux.exeCmd("dmidecode | grep UUID");
-        return AgentConfiguration.getAgentConf().get(AGENT_LOCAL_UUID, result);
+        String uuid = null;
+        try {
+            String result = ExcuteLinux.exeCmd("dmidecode | grep UUID");
+            if (!StringUtils.isEmpty(result) && StringUtils.containsIgnoreCase(result,"UUID")) {
+                String uuidResult = result.split(":")[1].trim();
+                 uuid = AgentConfiguration.getAgentConf().get(AGENT_LOCAL_UUID, uuidResult);
+                return uuid;
+            }
+        } catch (Exception e) {
+            LOGGER.error("fetch uuid  error");
+            e.printStackTrace();
+        }
+        return uuid;
     }
 
     /**

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -344,16 +344,21 @@ public class AgentUtils {
      * check agent uuid from manager
      */
     public static String  fetchLocalUuid() {
-        String uuid = null;
+        String uuid = "";
         try {
-            String result = ExcuteLinux.exeCmd("dmidecode | grep UUID");
-            if (!StringUtils.isEmpty(result) && StringUtils.containsIgnoreCase(result,"UUID")) {
-                String uuidResult = result.split(":")[1].trim();
-                 uuid = AgentConfiguration.getAgentConf().get(AGENT_LOCAL_UUID, uuidResult);
+            String localUuid = AgentConfiguration.getAgentConf().get(AGENT_LOCAL_UUID);
+            if (!StringUtils.isEmpty(localUuid)) {
+                uuid = localUuid;
                 return uuid;
             }
+            String result = ExcuteLinux.exeCmd("dmidecode | grep UUID");
+            if (!StringUtils.isEmpty(result)
+                    && StringUtils.containsIgnoreCase(result,"UUID")) {
+                    uuid = result.split(":")[1].trim();
+                    return uuid;
+                }
         } catch (Exception e) {
-            LOGGER.error("fetch uuid  error");
+            LOGGER.error("fetch uuid  error", e);
             e.printStackTrace();
         }
         return uuid;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -352,14 +352,13 @@ public class AgentUtils {
                 return uuid;
             }
             String result = ExcuteLinux.exeCmd("dmidecode | grep UUID");
-            if (!StringUtils.isEmpty(result)
-                    && StringUtils.containsIgnoreCase(result,"UUID")) {
-                    uuid = result.split(":")[1].trim();
-                    return uuid;
-                }
+            if (StringUtils.isNotEmpty(result)
+                    && StringUtils.containsIgnoreCase(result, "UUID")) {
+                uuid = result.split(":")[1].trim();
+                return uuid;
+            }
         } catch (Exception e) {
             LOGGER.error("fetch uuid  error", e);
-            e.printStackTrace();
         }
         return uuid;
     }

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -54,7 +54,6 @@ agent.local.ip=127.0.0.1
 agent.local.uuid=
 
 
-
 ###########################
 #   job/job manager config
 ###########################

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -51,6 +51,8 @@ agent.fetcher.classname=org.apache.inlong.agent.plugin.fetcher.ManagerFetcher
 # max wait time(s) for thread pool to terminate running
 thread.pool.await.time=30
 agent.local.ip=127.0.0.1
+agent.local.uuid=
+
 
 
 ###########################


### PR DESCRIPTION
### Title Name: [INLONG-2908][agent] fix uuid blank space

where *XYZ* should be replaced by the actual issue number.

Fixes #2908

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
