### PR TITLE
[INLONG-2385][Sort] SortStandalone support sort sdk consume batch message

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
@@ -125,11 +125,11 @@ public class FetchCallback implements ReadCallback {
     /**
      * The callback function that SortSDK invoke when fetch messages batch
      *
-     * @param messageRecord {@link List<MessageRecord>}
+     * @param messageRecordList {@link List<MessageRecord>}
      */
     @Override
-    public void onFinishedBatch(List<MessageRecord> messageRecord) {
-        //TODO
+    public void onFinishedBatch(List<MessageRecord> messageRecordList) {
+        messageRecordList.forEach(this::onFinished);
     }
 
     /**

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SubscribeFetchResult.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SubscribeFetchResult.java
@@ -46,7 +46,7 @@ public class SubscribeFetchResult {
      * @param sortId The sortId of fetched message.
      * @param message Message that fetched from upstream data storage.
      */
-
+    @Deprecated
     private SubscribeFetchResult(
             final String sortId,
             final MessageRecord message) {
@@ -122,15 +122,30 @@ public class SubscribeFetchResult {
          * @param messageRecord Message that fetched from upstream data storage.
          * @return One SubscribeFetchResult.
          */
+        @Deprecated
         public static SubscribeFetchResult create(
                 @NotBlank(message = "SortId should not be null or empty.") final String sortId,
                 @NotNull(message = "MessageRecord should not be null.") final MessageRecord messageRecord) {
             return new SubscribeFetchResult(sortId, messageRecord);
         }
 
+        /**
+         * Create one {@link SubscribeFetchResult}.
+         *
+         * @param sortId The sortId of fetched message.
+         * @param msgKey The msgKey to ack.
+         * @param offset The offset of this message.
+         * @param headers Headers of message.
+         * @param recTime Receive time of message.
+         * @param body Data of message.
+         * @return One SubscribeFetchResult.
+         */
         public static SubscribeFetchResult create(
                 final String sortId,
-                final String msgKey, final String offset, final Map<String, String> headers, final long recTime,
+                final String msgKey,
+                final String offset,
+                final Map<String, String> headers,
+                final long recTime,
                 final byte[] body) {
             return new SubscribeFetchResult(sortId, msgKey, offset, headers, recTime, body);
         }


### PR DESCRIPTION
### Title Name: [INLONG-2385][Sort] SortStandalone support sort sdk consume batch message

Fixes #2385 

### Motivation

Support sort sdk  **onFinishedBatch** method, consume batch message from cache 

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
