### PR TITLE
[INLONG-3116][Sort-Standalone] Fix SortSdkSource does not specify the manager url

### DIFF
--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/CommonPropertiesHolder.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/CommonPropertiesHolder.java
@@ -38,6 +38,7 @@ public class CommonPropertiesHolder {
     public static final String KEY_COMMON_PROPERTIES = "common-properties-loader";
     public static final String DEFAULT_LOADER = ClassResourceCommonPropertiesLoader.class.getName();
     public static final String KEY_CLUSTER_ID = "clusterId";
+    public static final String KEY_MANAGER_URL = "sortClusterConfig.managerUrl";
 
     private static Map<String, String> props;
     private static Context context;
@@ -194,6 +195,15 @@ public class CommonPropertiesHolder {
      */
     public static String getClusterId() {
         return getString(KEY_CLUSTER_ID);
+    }
+
+    /**
+     * Get manager URL
+     *
+     * @return Manager URL
+     */
+    public static String getManagerUrl() {
+        return getString(KEY_MANAGER_URL);
     }
 
     /**

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -33,6 +33,7 @@ import org.apache.flume.source.AbstractSource;
 import org.apache.inlong.sdk.sort.api.SortClient;
 import org.apache.inlong.sdk.sort.api.SortClientConfig;
 import org.apache.inlong.sdk.sort.api.SortClientFactory;
+import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
 import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
 import org.apache.inlong.sort.standalone.config.pojo.SortTaskConfig;
 import org.slf4j.Logger;
@@ -161,7 +162,7 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
      * Create one {@link SortClient} with specific sort id.
      *
      * <p> In current version, the {@link FetchCallback} will hold the client to ACK.
-     * For more details see {@link FetchCallback#onFinished(MessageRecord)}</p>
+     * For more details see {@link FetchCallback#onFinished}</p>
      *
      * @param sortId Sort in of new client.
      * @return New sort client.
@@ -174,6 +175,7 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
                             SortSdkSource.defaultStrategy, InetAddress.getLocalHost().getHostAddress());
             final FetchCallback callback = FetchCallback.Factory.create(sortId, getChannelProcessor(), context);
             clientConfig.setCallback(callback);
+            clientConfig.setManagerApiUrl(CommonPropertiesHolder.getManagerUrl());
             SortClient client = SortClientFactory.createSortClient(clientConfig);
             client.init();
             // temporary use to ACK fetched msg.


### PR DESCRIPTION
### Title Name: [INLONG-3116][Bug] Fix bug that SortSdkSource does not specify the manager url to SortSdk

Fixes #3116

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
