### PR TITLE
[INLONG-3117][Sort-Standalone] Fix parameter error when invoking SortSdk ack method

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
@@ -113,7 +113,7 @@ public class FetchCallback implements ReadCallback {
                 context.reportToMetric(profileEvent, sortId, "-", SortSdkSourceContext.FetchResult.SUCCESS);
             }
 
-            client.ack(messageRecord.getMsgKey(), messageRecord.getMsgKey());
+            client.ack(messageRecord.getMsgKey(), messageRecord.getOffset());
         } catch (NullPointerException npe) {
             LOG.error("Got a null pointer exception for sortId " + sortId, npe);
             context.reportToMetric(null, sortId, "-", SortSdkSourceContext.FetchResult.FAILURE);


### PR DESCRIPTION
### Title Name: [INLONG-3117][Bug] Fix bug of parameter error when invoking SortSdk ack method

Fixes #3117

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
