### PR TITLE
[INLONG-3121][SDK] Fix parameters error when SortSdk request getSortSource 

### DIFF
--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/QueryConsumeConfigImpl.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/QueryConsumeConfigImpl.java
@@ -62,8 +62,8 @@ public class QueryConsumeConfigImpl implements QueryConsumeConfig {
 
     private String getRequestUrlWithParam() {
         return clientContext.getConfig().getManagerApiUrl() + "?sortClusterName=" + clientContext.getConfig()
-                .getSortClusterName() + "&sortId=" + clientContext.getConfig().getSortTaskId() + "&md5=" + md5
-                + "&apiVersioin=" + clientContext.getConfig().getManagerApiVersion();
+                .getSortClusterName() + "&sortTaskId=" + clientContext.getConfig().getSortTaskId() + "&md5=" + md5
+                + "&apiVersion=" + clientContext.getConfig().getManagerApiVersion();
     }
 
     // HTTP GET


### PR DESCRIPTION
### Title Name: [INLONG-3121][Bug] Fix bug of parameters error when SortSdk request getSortSource 

Fixes #3121

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
