### PR TITLE
[INLONG-3131][Manager] Application start failed as the JdbcType was wrong

### DIFF
--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkFieldEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkFieldEntityMapper.xml
@@ -18,8 +18,7 @@
     under the License.
 -->
 
-<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.apache.inlong.manager.dao.mapper.StreamSinkFieldEntityMapper">
     <resultMap id="BaseResultMap" type="org.apache.inlong.manager.dao.entity.StreamSinkFieldEntity">
         <id column="id" jdbcType="INTEGER" property="id"/>
@@ -32,30 +31,26 @@
         <result column="field_comment" jdbcType="VARCHAR" property="fieldComment"/>
         <result column="source_field_name" jdbcType="VARCHAR" property="sourceFieldName"/>
         <result column="source_field_type" jdbcType="VARCHAR" property="sourceFieldType"/>
-        <result column="is_source_meta_field" jdbcType="INTEGER" property="isSourceMetaField"/>
+        <result column="is_source_meta_field" jdbcType="SMALLINT" property="isSourceMetaField"/>
         <result column="rank_num" jdbcType="SMALLINT" property="rankNum"/>
         <result column="is_deleted" jdbcType="INTEGER" property="isDeleted"/>
     </resultMap>
     <sql id="Base_Column_List">
-        id
-        , sink_id, field_name, field_type, field_comment,
+        id, sink_id, field_name, field_type, field_comment,
         source_field_name, source_field_type, is_source_meta_field, rank_num, is_deleted
     </sql>
 
     <insert id="insert" useGeneratedKeys="true" keyProperty="id"
             parameterType="org.apache.inlong.manager.dao.entity.StreamSinkFieldEntity">
         insert into stream_sink_field (id, inlong_group_id, inlong_stream_id,
-                                       sink_id, sink_type,
-                                       field_name, field_type, field_comment,
-                                       source_field_name, source_field_type, is_source_meta_field,
+                                       sink_id, sink_type, field_name,
+                                       field_type, field_comment, source_field_name,
+                                       source_field_type, is_source_meta_field,
                                        rank_num, is_deleted)
-        values (#{id,jdbcType=INTEGER}, #{inlongGroupId,jdbcType=VARCHAR},
-                #{inlongStreamId,jdbcType=VARCHAR},
-                #{sinkId,jdbcType=INTEGER}, #{sinkType,jdbcType=VARCHAR},
-                #{fieldName,jdbcType=VARCHAR}, #{fieldType,jdbcType=VARCHAR},
-                #{fieldComment,jdbcType=VARCHAR},
-                #{sourceFieldName,jdbcType=VARCHAR}, #{sourceFieldType,jdbcType=VARCHAR},
-                #{isSourceMetaField,jdbcType=Integer},
+        values (#{id,jdbcType=INTEGER}, #{inlongGroupId,jdbcType=VARCHAR}, #{inlongStreamId,jdbcType=VARCHAR},
+                #{sinkId,jdbcType=INTEGER}, #{sinkType,jdbcType=VARCHAR}, #{fieldName,jdbcType=VARCHAR},
+                #{fieldType,jdbcType=VARCHAR}, #{fieldComment,jdbcType=VARCHAR}, #{sourceFieldName,jdbcType=VARCHAR},
+                #{sourceFieldType,jdbcType=VARCHAR}, #{isSourceMetaField,jdbcType=SMALLINT},
                 #{rankNum,jdbcType=SMALLINT}, #{isDeleted,jdbcType=INTEGER})
     </insert>
     <insert id="insertAll">
@@ -64,7 +59,8 @@
         inlong_stream_id, sink_id,
         sink_type, field_name,
         field_type, field_comment,
-        source_field_name, source_field_type,is_source_meta_field,
+        source_field_name, source_field_type,
+        is_source_meta_field,
         rank_num, is_deleted
         )
         values
@@ -75,7 +71,7 @@
             #{item.sinkType,jdbcType=VARCHAR}, #{item.fieldName,jdbcType=VARCHAR},
             #{item.fieldType,jdbcType=VARCHAR}, #{item.fieldComment,jdbcType=VARCHAR},
             #{item.sourceFieldName,jdbcType=VARCHAR}, #{item.sourceFieldType,jdbcType=VARCHAR},
-            #{isSourceMetaField,jdbcType=Integer},
+            #{isSourceMetaField,jdbcType=SMALLINT},
             #{item.rankNum,jdbcType=SMALLINT}, #{item.isDeleted,jdbcType=INTEGER}
             )
         </foreach>

--- a/inlong-manager/manager-test/src/main/resources/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-test/src/main/resources/sql/apache_inlong_manager.sql
@@ -634,19 +634,19 @@ CREATE TABLE `stream_sink_ext`
 DROP TABLE IF EXISTS `stream_sink_field`;
 CREATE TABLE `stream_sink_field`
 (
-    `id`                int(11)      NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
-    `inlong_group_id`   varchar(256) NOT NULL COMMENT 'Inlong group id',
-    `inlong_stream_id`  varchar(256) NOT NULL COMMENT 'Inlong stream id',
-    `sink_id`           int(11)      NOT NULL COMMENT 'Sink id',
-    `sink_type`         varchar(15)  NOT NULL COMMENT 'Sink type',
-    `source_field_name` varchar(50)   DEFAULT NULL COMMENT 'Source field name',
-    `source_field_type` varchar(50)   DEFAULT NULL COMMENT 'Source field type',
-    `is_source_meta_field` int(3)     DEFAULT '0' COMMENT 'source field is meta field',
-    `field_name`        varchar(50)  NOT NULL COMMENT 'Field name',
-    `field_type`        varchar(50)  NOT NULL COMMENT 'Field type',
-    `field_comment`     varchar(2000) DEFAULT NULL COMMENT 'Field description',
-    `rank_num`          smallint(6)   DEFAULT '0' COMMENT 'Field order (front-end display field order)',
-    `is_deleted`        int(11)       DEFAULT '0' COMMENT 'Whether to delete, 0: not deleted, > 0: deleted',
+    `id`                   int(11)      NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
+    `inlong_group_id`      varchar(256) NOT NULL COMMENT 'Inlong group id',
+    `inlong_stream_id`     varchar(256) NOT NULL COMMENT 'Inlong stream id',
+    `sink_id`              int(11)      NOT NULL COMMENT 'Sink id',
+    `sink_type`            varchar(15)  NOT NULL COMMENT 'Sink type',
+    `source_field_name`    varchar(50)   DEFAULT NULL COMMENT 'Source field name',
+    `source_field_type`    varchar(50)   DEFAULT NULL COMMENT 'Source field type',
+    `is_source_meta_field` smallint(3)   DEFAULT '0' COMMENT 'Is this field a meta field? 0: no, 1: yes',
+    `field_name`           varchar(50)  NOT NULL COMMENT 'Field name',
+    `field_type`           varchar(50)  NOT NULL COMMENT 'Field type',
+    `field_comment`        varchar(2000) DEFAULT NULL COMMENT 'Field description',
+    `rank_num`             smallint(6)   DEFAULT '0' COMMENT 'Field order (front-end display field order)',
+    `is_deleted`           int(11)       DEFAULT '0' COMMENT 'Whether to delete, 0: not deleted, > 0: deleted',
     PRIMARY KEY (`id`)
 );
 

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -666,19 +666,19 @@ CREATE TABLE `stream_sink_ext`
 DROP TABLE IF EXISTS `stream_sink_field`;
 CREATE TABLE `stream_sink_field`
 (
-    `id`                int(11)      NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
-    `inlong_group_id`   varchar(256) NOT NULL COMMENT 'Inlong group id',
-    `inlong_stream_id`  varchar(256) NOT NULL COMMENT 'Inlong stream id',
-    `sink_id`           int(11)      NOT NULL COMMENT 'Sink id',
-    `sink_type`         varchar(15)  NOT NULL COMMENT 'Sink type',
-    `source_field_name` varchar(50)   DEFAULT NULL COMMENT 'Source field name',
-    `source_field_type` varchar(50)   DEFAULT NULL COMMENT 'Source field type',
-    `is_source_meta_field` int(3)     DEFAULT '0' COMMENT 'source field is meta field',
-    `field_name`        varchar(50)  NOT NULL COMMENT 'Field name',
-    `field_type`        varchar(50)  NOT NULL COMMENT 'Field type',
-    `field_comment`     varchar(2000) DEFAULT NULL COMMENT 'Field description',
-    `rank_num`          smallint(6)   DEFAULT '0' COMMENT 'Field order (front-end display field order)',
-    `is_deleted`        int(11)       DEFAULT '0' COMMENT 'Whether to delete, 0: not deleted, > 0: deleted',
+    `id`                   int(11)      NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
+    `inlong_group_id`      varchar(256) NOT NULL COMMENT 'Inlong group id',
+    `inlong_stream_id`     varchar(256) NOT NULL COMMENT 'Inlong stream id',
+    `sink_id`              int(11)      NOT NULL COMMENT 'Sink id',
+    `sink_type`            varchar(15)  NOT NULL COMMENT 'Sink type',
+    `source_field_name`    varchar(50)   DEFAULT NULL COMMENT 'Source field name',
+    `source_field_type`    varchar(50)   DEFAULT NULL COMMENT 'Source field type',
+    `is_source_meta_field` smallint(3)   DEFAULT '0' COMMENT 'Is this field a meta field? 0: no, 1: yes',
+    `field_name`           varchar(50)  NOT NULL COMMENT 'Field name',
+    `field_type`           varchar(50)  NOT NULL COMMENT 'Field type',
+    `field_comment`        varchar(2000) DEFAULT NULL COMMENT 'Field description',
+    `rank_num`             smallint(6)   DEFAULT '0' COMMENT 'Field order (front-end display field order)',
+    `is_deleted`           int(11)       DEFAULT '0' COMMENT 'Whether to delete, 0: not deleted, > 0: deleted',
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='Stream sink field table';


### PR DESCRIPTION
### Title Name: [INLONG-3131][Manager] Application start failed as the JdbcType was wrong

Fixes #3131 

### Motivation

Application start failed as the JdbcType was wrong.

### Modifications

Change the `Integer` to `INTEGER` as MyBatis only support the `INTEGER`. 

### Verifying this change

- [X] Make sure that the change passes the CI checks.
