### PR TITLE
[INLONG-3152][Manager] Throw exception when group is in initialization

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongGroupImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongGroupImpl.java
@@ -126,6 +126,11 @@ public class InlongGroupImpl implements InlongGroup {
         } else {
             conf = this.groupConf;
         }
+        final String groupId = "b_" + conf.getGroupName();
+        InlongGroupResponse groupResponse = managerClient.getGroupInfo(groupId);
+        InlongGroupState state = InlongGroupState.parseByBizStatus(groupResponse.getStatus());
+        AssertUtil.isTrue(state != InlongGroupState.INITIALIZING,
+                "Inlong Group is in init state, should not be updated");
         InlongGroupInfo groupInfo = InlongGroupTransfer.createGroupInfo(conf);
         InlongGroupRequest groupRequest = groupInfo.genRequest();
         Pair<String, String> idAndErr = managerClient.updateGroup(groupRequest);


### PR DESCRIPTION
### Title Name: [INLONG-3152]Throw exception when group is in initialization

where *XYZ* should be replaced by the actual issue number.

Fixes #3152 

### Motivation

### Modifications

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
