### PR TITLE
[INLONG-3077][Agent] FileNotFoundException occurred in unit tests #3077

### DIFF
--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestBinlogOffsetManager.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestBinlogOffsetManager.java
@@ -30,13 +30,13 @@ import org.slf4j.LoggerFactory;
 
 public class TestBinlogOffsetManager {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TestTextFileReader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestBinlogOffsetManager.class);
     private static Path testDir;
     private static AgentBaseTestsHelper helper;
 
     @BeforeClass
     public static void setup() {
-        helper = new AgentBaseTestsHelper(TestTextFileReader.class.getName()).setupAgentHome();
+        helper = new AgentBaseTestsHelper(TestBinlogOffsetManager.class.getName()).setupAgentHome();
         testDir = helper.getTestRootDir();
     }
 


### PR DESCRIPTION
### Title Name: [INLONG-3077][Agent] FileNotFoundException occurred in unit tests 

Fixes #3077

### Motivation

FileNotFoundException occurred in unit tests

### Modifications

change test base to TestBinlogOffsetManager 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.