### PR TITLE
[INLONG-3199][Agent] Two binlog task running at the same time may have data loss

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/BinlogReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/BinlogReader.java
@@ -77,7 +77,7 @@ public class BinlogReader implements Reader {
      * pair.left: table name
      * pair.right: actual data
      */
-    private static LinkedBlockingQueue<Pair<String, String>> binlogMessagesQueue =
+    private LinkedBlockingQueue<Pair<String, String>> binlogMessagesQueue =
         new LinkedBlockingQueue<>();
 
     private boolean finished = false;


### PR DESCRIPTION
### Title Name: [INLONG-3199][Agent] Two binlog task running at the same time may have data loss

Fixes #3199 

### Motivation

[INLONG-3199][Agent] Two binlog task running at the same time may have data loss

### Modifications

make message queue local private vaiable rather than static 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (no)