### PR TITLE
[INLONG-3237][Sort-Standalone] SdkSource support periodiclly update sdk config and remove expire client.

### DIFF
--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/SortClient.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/SortClient.java
@@ -25,4 +25,6 @@ public abstract class SortClient {
             throws Exception;
 
     public abstract boolean close();
+
+    public abstract SortClientConfig getConfig();
 }

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/SortClientImpl.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/SortClientImpl.java
@@ -123,6 +123,11 @@ public class SortClientImpl extends SortClient {
         return (cleanInLongTopicManager && cleanContext);
     }
 
+    @Override
+    public SortClientConfig getConfig() {
+        return this.sortClientConfig;
+    }
+
     private InLongTopicFetcher getFetcher(String msgKey) throws NotExistException {
         InLongTopicFetcher inLongTopicFetcher = inLongTopicManager.getFetcher(msgKey);
         if (inLongTopicFetcher == null) {

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -207,7 +207,7 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
      * @param config The config to be updated.
      */
     private void updateClientConfig(SortClientConfig config) {
-        config.setManagerApiUrl(CommonPropertiesHolder.getManagerUrl());
+        config.setManagerApiUrl(CommonPropertiesHolder.getSourceConfigManagerUrl());
     }
 
     /**

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -22,10 +22,14 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import org.apache.flume.Context;
 import org.apache.flume.EventDrivenSource;
 import org.apache.flume.conf.Configurable;
@@ -83,7 +87,7 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
      */
     @Override
     public synchronized void start() {
-        this.reload();
+        this.reloadAll();
     }
 
     /**
@@ -100,7 +104,7 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
      */
     @Override
     public void run() {
-        this.reload();
+        this.reloadAll();
     }
 
     /**
@@ -132,30 +136,78 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
      * <p> Create new clients with new sort task id, and remove the finished or scheduled ones. </p>
      *
      * <p> Current version of SortSdk <b>DO NOT</b> support to get the corresponding sort id of {@link SortClient}.
-     * Hence, the maintenance of mapping of {@literal sortId, SortClient} should be done by Source itself. Which
-     * is not elegant, the <b>REMOVE</b> of expire clients will <b>NOT</b> be supported right now. </p>
+     * Hence, the maintenance of mapping of {@literal sortId, SortClient} should be done by Source itself.
      */
-    private void reload() {
+    private void reloadAll() {
 
         final List<SortTaskConfig> configs = SortClusterConfigHolder.getClusterConfig().getSortTasks();
         LOG.info("start to reload SortSdkSource");
+        this.startNewClients(configs);
+        this.stopExpiryClients(configs);
+        this.updateAllClientConfig();
+    }
 
-        // Start new clients
-        for (SortTaskConfig taskConfig : configs) {
+    /**
+     * Start a new client from SortTaskConfig.
+     * <p>
+     *     If the sortId is in configs, but not in active clients, start it.
+     * </p>
+     *
+     * @param configs Updated SortTaskConfig
+     */
+    private void startNewClients(final List<SortTaskConfig> configs) {
+        configs.stream()
+                .map(SortTaskConfig::getName)
+                .filter(sortId -> !clients.containsKey(sortId))
+                .forEach(sortId -> {
+                    final SortClient client = this.newClient(sortId);
+                    Optional.ofNullable(client)
+                            .ifPresent(c -> clients.put(sortId, c));
+                });
+    }
 
-            // If exits, skip.
-            final String sortId = taskConfig.getName();
-            SortClient client = this.clients.get(sortId);
-            if (client != null) {
-                continue;
-            }
+    /**
+     * Stop an expiry client from SortTaskConfig.
+     * <p>
+     *     If the sortId is not in active clients, but not in configs, stop it.
+     * </p>
+     *
+     * @param configs Updated SortTaskConfig
+     */
+    private void stopExpiryClients(final List<SortTaskConfig> configs) {
+        Set<String> updatedSortIds = configs.stream()
+                .map(SortTaskConfig::getName)
+                .collect(Collectors.toSet());
 
-            // Otherwise, new one client.
-            client = this.newClient(sortId);
-            if (client != null) {
-                this.clients.put(sortId, client);
-            }
-        }
+        clients.keySet().stream()
+                .filter(updatedSortIds::contains)
+                .forEach(sortId -> {
+                    final SortClient client = clients.get(sortId);
+                    try {
+                        client.close();
+                    } catch (Throwable th) {
+                        LOG.error("Got a throwable when close client {}, {}", sortId, th.getMessage());
+                    }
+                    clients.remove(sortId);
+                });
+    }
+
+    /**
+     * Update all client config.
+     */
+    private void updateAllClientConfig() {
+        clients.values().stream()
+                .map(SortClient::getConfig)
+                .forEach(this::updateClientConfig);
+    }
+
+    /**
+     * Update one client config.
+     *
+     * @param config The config to be updated.
+     */
+    private void updateClientConfig(SortClientConfig config) {
+        config.setManagerApiUrl(CommonPropertiesHolder.getManagerUrl());
     }
 
     /**
@@ -175,7 +227,7 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
                             SortSdkSource.defaultStrategy, InetAddress.getLocalHost().getHostAddress());
             final FetchCallback callback = FetchCallback.Factory.create(sortId, getChannelProcessor(), context);
             clientConfig.setCallback(callback);
-            clientConfig.setManagerApiUrl(CommonPropertiesHolder.getManagerUrl());
+            this.updateClientConfig(clientConfig);
             SortClient client = SortClientFactory.createSortClient(clientConfig);
             client.init();
             // temporary use to ACK fetched msg.


### PR DESCRIPTION
### Title Name: [INLONG-3237][Sort-Standalone] SdkSource support periodiclly update sdk config and remove expire client.

Fixes #3237 

### Motivation

1. update sdk config periodiclly, to avoid the case that the init manager node offline and sdk cannot request config.
2. remove expire client, if the task has been removed from SortClusterConfig.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
