### PR TITLE
[INLONG-3243][Manager] Fix ConsumptionMqExtBase cannot be cast to ConsumptionPulsarInfo

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/ConsumptionServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/ConsumptionServiceImpl.java
@@ -164,7 +164,14 @@ public class ConsumptionServiceImpl implements ConsumptionService {
      */
     private void savePulsarInfo(ConsumptionMqExtBase mqExtBase, ConsumptionEntity entity) {
         Preconditions.checkNotNull(mqExtBase, "Pulsar info cannot be empty, as the middleware is Pulsar");
-        ConsumptionPulsarInfo pulsarInfo = (ConsumptionPulsarInfo) mqExtBase;
+        // If it is transmitted from the web without specifying consumptionpulsarinfo,
+        // the mqextbase is not consumptionpulsarinfo and cannot be converted directly
+        ConsumptionPulsarInfo pulsarInfo;
+        if (mqExtBase instanceof ConsumptionPulsarInfo) {
+            pulsarInfo = (ConsumptionPulsarInfo) mqExtBase;
+        } else {
+            pulsarInfo = new ConsumptionPulsarInfo();
+        }
 
         // Prerequisite for RLQ to be turned on: DLQ must be turned on
         boolean dlqEnable = (pulsarInfo.getIsDlq() != null && pulsarInfo.getIsDlq() == 1);
@@ -444,6 +451,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
                 Preconditions.checkEmpty(topicSet, "topic [" + topicSet + "] not belong to inlong group " + groupId);
             }
         }
+        info.setMiddlewareType(mqType);
     }
 
 }


### PR DESCRIPTION
### Title Name: [INLONG-XYZ][component] Title of the pull request

where *XYZ* should be replaced by the actual issue number.

Fixes #3242 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

When submitting data consumption, set pulsar middleware_type, and solve the problem of class conversion.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
