### PR TITLE
[INLONG-3271][Agent] Agent docker.sh cannot get localip

### DIFF
--- a/inlong-agent/agent-docker/agent-docker.sh
+++ b/inlong-agent/agent-docker/agent-docker.sh
@@ -17,7 +17,7 @@
 #
 
 file_path=$(cd "$(dirname "$0")"/../;pwd)
-local_ip=$(ifconfig $ETH_NETWORK | grep "inet addr" | awk '{ print $2}' | awk -F: '{print $2}')
+local_ip=$(ifconfig $ETH_NETWORK | grep "inet" | grep -v "inet6" | awk '{print $2}')
 # config
 cat <<EOF > ${file_path}/conf/agent.properties
 agent.fetcher.classname=org.apache.inlong.agent.plugin.fetcher.ManagerFetcher


### PR DESCRIPTION
### Title Name: [INLONG-3271][Agent] Agent docker.sh cannot get localip

Fixes #3271 

### Motivation

Agent docker.sh cannot get localip

### Modifications

Agent docker.sh  get localip use correct linux cmd

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (no)