### PR TITLE
[INLONG-3274][Agent]  Change the task status to failed when the Kafka topic was deleted

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/Reader.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/Reader.java
@@ -65,7 +65,7 @@ public interface Reader extends Stage {
     void finishRead();
 
     /**
-     * source deleted
+     * source is exist
      * @return
      */
     boolean isSourceExist();

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/Reader.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/Reader.java
@@ -63,4 +63,10 @@ public interface Reader extends Stage {
      * finish read
      */
     void finishRead();
+
+    /**
+     * source deleted
+     * @return
+     */
+    boolean isSourceExist();
 }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskWrapper.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskWrapper.java
@@ -28,10 +28,13 @@ import org.apache.inlong.agent.common.AgentThreadFactory;
 import org.apache.inlong.agent.conf.AgentConfiguration;
 import org.apache.inlong.agent.constant.AgentConstants;
 import org.apache.inlong.agent.core.AgentManager;
+import org.apache.inlong.agent.db.CommandDb;
 import org.apache.inlong.agent.message.EndMessage;
 import org.apache.inlong.agent.plugin.Message;
 import org.apache.inlong.agent.state.AbstractStateWrapper;
 import org.apache.inlong.agent.state.State;
+import org.apache.inlong.common.constant.Constants;
+import org.apache.inlong.common.db.CommandEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,6 +55,7 @@ public class TaskWrapper extends AbstractStateWrapper {
     private final int pushMaxWaitTime;
     private final int pullMaxWaitTime;
     private ExecutorService executorService;
+    private CommandDb db;
 
     public TaskWrapper(AgentManager manager, Task task) {
         super();
@@ -71,6 +75,7 @@ public class TaskWrapper extends AbstractStateWrapper {
                     new AgentThreadFactory("task-reader-writer"));
         }
         doChangeState(State.ACCEPTED);
+        this.db = manager.getCommandDb();
     }
 
     /**
@@ -79,20 +84,29 @@ public class TaskWrapper extends AbstractStateWrapper {
      * @return CompletableFuture
      */
     private CompletableFuture<?> submitReadThread() {
-        return CompletableFuture.runAsync(() -> {
-            Message message = null;
-            while (!isException() && !task.isReadFinished()) {
-                if (message == null || task.getChannel()
-                        .push(message, pushMaxWaitTime, TimeUnit.SECONDS)) {
-                    message = task.getReader().read();
-                }
+    return CompletableFuture.runAsync(
+        () -> {
+          Message message = null;
+          while (!isException() && !task.isReadFinished()) {
+            // if source deleted,then failed
+            if (!task.getReader().isSourceExist()) {
+              doChangeState(State.FAILED);
+            } else {
+              if (message == null
+                  || task.getChannel().push(message, pushMaxWaitTime, TimeUnit.SECONDS)) {
+                message = task.getReader().read();
+              }
             }
-            LOGGER.info("read end, task exception status is {}, read finish status is {}",
-                    isException(), task.isReadFinished());
-            // write end message
-            task.getChannel().push(new EndMessage());
-            task.getReader().destroy();
-        }, executorService);
+          }
+          LOGGER.info(
+              "read end, task exception status is {}, read finish status is {}",
+              isException(),
+              task.isReadFinished());
+          // write end message
+          task.getChannel().push(new EndMessage());
+          task.getReader().destroy();
+        },
+        executorService);
     }
 
     /**
@@ -197,6 +211,11 @@ public class TaskWrapper extends AbstractStateWrapper {
             submitThreadsAndWait();
             if (!isException()) {
                 doChangeState(State.SUCCEEDED);
+            } else {
+                CommandEntity command = new CommandEntity();
+                command.setTaskId(Integer.valueOf(task.getTaskId()));
+                command.setCommandResult(Constants.RESULT_FAIL);
+                db.storeCommand(command);
             }
             LOGGER.info("start to destroy task {}", task.getTaskId());
             task.destroy();

--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/task/TestTaskWrapper.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/task/TestTaskWrapper.java
@@ -88,7 +88,7 @@ public class TestTaskWrapper {
         manager = new AgentManager();
         reader = new ReaderImpl();
         writer = new WriterImpl();
-        task = new Task("test", reader, writer,
+        task = new Task("11111", reader, writer,
             new MockChannel(), JobProfile.parseJsonStr(""));
     }
 
@@ -101,7 +101,7 @@ public class TestTaskWrapper {
     @Test
     public void testTaskRunning() throws Exception {
         manager.getTaskManager().submitTask(task);
-        String jobId = "test";
+        String jobId = "111";
         TaskWrapper wrapper = manager.getTaskManager().getTaskWrapper(jobId);
         assert wrapper != null;
         while (!wrapper.isSuccess()) {
@@ -156,7 +156,7 @@ public class TestTaskWrapper {
 
         @Override
         public boolean isSourceExist() {
-            return false;
+            return true;
         }
 
         public int getCount() {

--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/task/TestTaskWrapper.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/task/TestTaskWrapper.java
@@ -154,6 +154,11 @@ public class TestTaskWrapper {
 
         }
 
+        @Override
+        public boolean isSourceExist() {
+            return false;
+        }
+
         public int getCount() {
             return count;
         }

--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/task/TestTaskWrapper.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/task/TestTaskWrapper.java
@@ -88,7 +88,7 @@ public class TestTaskWrapper {
         manager = new AgentManager();
         reader = new ReaderImpl();
         writer = new WriterImpl();
-        task = new Task("11111", reader, writer,
+        task = new Task("111", reader, writer,
             new MockChannel(), JobProfile.parseJsonStr(""));
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/KafkaSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/KafkaSource.java
@@ -105,7 +105,7 @@ public class KafkaSource implements Source {
             // example:0#110_1#666_2#222
             partitionOffsets = allPartitionOffsets.split(JOB_OFFSET_DELIMITER);
         }
-        //
+        // set consumer session timeout
         props.put(KAFKA_SESSION_TIMEOUT, 30000);
         // spilt reader reduce to partition
         if (null != partitionInfoList) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/BinlogReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/BinlogReader.java
@@ -289,6 +289,11 @@ public class BinlogReader implements Reader {
         finished = true;
     }
 
+    @Override
+    public boolean isSourceExist() {
+        return true;
+    }
+
     private String tryToInitAndGetHistoryPath() {
         String historyPath = agentConf.get(
             AgentConstants.AGENT_HISTORY_PATH, AgentConstants.DEFAULT_AGENT_HISTORY_PATH);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/KafkaReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/KafkaReader.java
@@ -25,6 +25,8 @@ import static org.apache.inlong.agent.constant.JobConstants.JOB_KAFKA_BYTE_SPEED
 import static org.apache.inlong.agent.constant.JobConstants.JOB_KAFKA_OFFSET;
 import static org.apache.inlong.agent.constant.JobConstants.JOB_KAFKA_PARTITION_OFFSET_DELIMITER;
 import static org.apache.inlong.agent.constant.JobConstants.JOB_KAFKA_RECORD_SPEED_LIMIT;
+import static org.apache.inlong.agent.constant.JobConstants.JOB_KAFKA_TOPIC;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.agent.conf.JobProfile;
 import org.apache.inlong.agent.message.DefaultMessage;
@@ -89,6 +92,7 @@ public class KafkaReader<K, V> implements Reader {
     private String snapshot;
     private boolean isFinished = false;
     private boolean destroyed = false;
+    private String topic;
 
     /**
      * init attribute
@@ -111,6 +115,7 @@ public class KafkaReader<K, V> implements Reader {
         this.byteSpeed = Long.valueOf(paraMap.getOrDefault(JOB_KAFKA_BYTE_SPEED_LIMIT, String.valueOf(1024 * 1024)));
         this.flowControlInterval = Long.valueOf(paraMap.getOrDefault(KAFKA_SOURCE_READ_MIN_INTERVAL, "1000"));
         this.lastTimestamp = System.currentTimeMillis();
+        this.topic = paraMap.get(JOB_KAFKA_TOPIC);
 
         LOGGER.info("KAFKA_SOURCE_READ_RECORD_SPEED = {}", this.recordSpeed);
         LOGGER.info("KAFKA_SOURCE_READ_BYTE_SPEED = {}", this.byteSpeed);
@@ -143,7 +148,9 @@ public class KafkaReader<K, V> implements Reader {
             }
         } else {
             // commit offset
-            consumer.commitAsync();
+            if (!isSourceExist()) {
+                consumer.commitAsync();
+            }
             fetchData(5000);
         }
         AgentUtils.silenceSleepInMs(waitTimeout);
@@ -230,6 +237,11 @@ public class KafkaReader<K, V> implements Reader {
     @Override
     public void finishRead() {
         isFinished = true;
+    }
+
+    @Override
+    public boolean isSourceExist() {
+        return !CollectionUtils.isEmpty(consumer.partitionsFor(topic));
     }
 
     private boolean fetchData(long fetchDataTimeout) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/KafkaReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/KafkaReader.java
@@ -148,7 +148,7 @@ public class KafkaReader<K, V> implements Reader {
             }
         } else {
             // commit offset
-            if (!isSourceExist()) {
+            if (isSourceExist()) {
                 consumer.commitAsync();
             }
             fetchData(5000);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/SqlReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/SqlReader.java
@@ -168,6 +168,11 @@ public class SqlReader extends AbstractReader {
         destroy();
     }
 
+    @Override
+    public boolean isSourceExist() {
+        return true;
+    }
+
     /**
      * Init column meta data.
      *

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/TextFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/TextFileReader.java
@@ -150,6 +150,11 @@ public class TextFileReader extends AbstractReader {
         destroy();
     }
 
+    @Override
+    public boolean isSourceExist() {
+        return true;
+    }
+
     public void addPatternValidator(String pattern) {
         if (pattern.isEmpty()) {
             return;

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestKafkaReader.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestKafkaReader.java
@@ -39,7 +39,7 @@ public class TestKafkaReader {
         conf.set("job.kafkaJob.recordspeed.limit", "1");
         conf.set("job.kafkaJob.bytespeed.limit", "1");
         conf.set("job.kafkaJob.partition.offset", "0#0");
-        conf.set("job.kafkaJob.auto.offsetReset", "latest");
+        conf.set("job.kafkaJob.autoOffsetReset", "latest");
         conf.set("proxy.inlongGroupId", "");
         conf.set("proxy.inlongStreamId", "");
 


### PR DESCRIPTION
### Title Name: [INLONG-3274][Agent] Fix change task status failed when the Kafka topic was deleted

Fixes #3274

### Motivation

When Kafka topic is deleted, then change task status to failed.

### Modifications

When Kafka topic is deleted, then change task status to failed.
