### PR TITLE
[INLONG-3287] Fix heartbeat manager init in Manager Service

### DIFF
--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSourceEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSourceEntityMapper.java
@@ -37,6 +37,11 @@ public interface StreamSourceEntityMapper {
     StreamSourceEntity selectByIdForUpdate(Integer id);
 
     /**
+     * Query valid source list by the given agentIp
+     */
+    List<StreamSourceEntity> selectByAgentIp(@Param("agentIp") String agentIp);
+
+    /**
      * According to the inlong group id and inlong stream id, query the number of valid source
      */
     int selectCount(@Param("groupId") String groupId, @Param("streamId") String streamId);
@@ -73,13 +78,6 @@ public interface StreamSourceEntityMapper {
      * Get the distinct source type from the given groupId and streamId
      */
     List<String> selectSourceType(@Param("groupId") String groupId, @Param("streamId") String streamId);
-
-    /**
-     * Get all sources in temporary status.
-     *
-     * @apiNote Do not need to filter sources that is_deleted > 0.
-     */
-    List<StreamSourceEntity> selectTempStatusSource();
 
     int updateByPrimaryKeySelective(StreamSourceEntity record);
 

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
@@ -256,6 +256,16 @@
         </where>
     </select>
 
+    <select id="selectByAgentIp" resultType="org.apache.inlong.manager.dao.entity.StreamSourceEntity">
+        select
+        <include refid="Base_Column_List"/>
+        from stream_source
+        <where>
+            is_deleted = 0
+            and agent_ip = #{agentIp, jdbcType=VARCHAR}
+        </where>
+    </select>
+
     <select id="selectByRelatedId" resultType="org.apache.inlong.manager.dao.entity.StreamSourceEntity">
         select
         <include refid="Base_Column_List"/>
@@ -328,14 +338,6 @@
             <if test="streamId != null and streamId != ''">
                 and inlong_stream_id = #{streamId, jdbcType=VARCHAR}
             </if>
-            for update
-        </where>
-    </select>
-    <select id="selectTempStatusSource" resultType="org.apache.inlong.manager.dao.entity.StreamSourceEntity">
-        select id, agent_ip, uuid, status
-        from stream_source
-        <where>
-            status >= 200
             for update
         </where>
     </select>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
@@ -463,7 +463,8 @@
     <update id="updateSnapshot" parameterType="org.apache.inlong.manager.dao.entity.StreamSourceEntity">
         update stream_source
         set snapshot    = #{snapshot,jdbcType=LONGVARCHAR},
-            report_time = #{reportTime,jdbcType=TIMESTAMP}
+            report_time = #{reportTime,jdbcType=TIMESTAMP},
+            modify_time = modify_time
         where id = #{id,jdbcType=INTEGER}
     </update>
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/SourceSnapshotOperation.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/SourceSnapshotOperation.java
@@ -91,6 +91,7 @@ public class SourceSnapshotOperation implements AutoCloseable {
             snapshotQueue = new LinkedBlockingQueue<>(queueSize);
         }
         SaveSnapshotTaskRunnable taskRunnable = new SaveSnapshotTaskRunnable();
+        taskIpToIdAndStatusMap = getTaskIpAndStatusMap();
         this.executorService.execute(taskRunnable);
         LOGGER.info("source snapshot operate thread started successfully");
     }

--- a/inlong-manager/manager-test/src/main/resources/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-test/src/main/resources/sql/apache_inlong_manager.sql
@@ -582,7 +582,9 @@ CREATE TABLE `stream_source`
     `create_time`      timestamp    NULL     DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
     `modify_time`      timestamp    NULL     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `unique_source_name` (`inlong_group_id`, `inlong_stream_id`, `source_name`, `is_deleted`)
+    UNIQUE KEY `unique_source_name` (`inlong_group_id`, `inlong_stream_id`, `source_name`, `is_deleted`),
+    KEY `status` (`status`,`is_deleted`),
+    KEY `agent_ip` (`agent_ip`)
 );
 
 -- ----------------------------

--- a/inlong-manager/manager-test/src/main/resources/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-test/src/main/resources/sql/apache_inlong_manager.sql
@@ -584,7 +584,7 @@ CREATE TABLE `stream_source`
     PRIMARY KEY (`id`),
     UNIQUE KEY `unique_source_name` (`inlong_group_id`, `inlong_stream_id`, `source_name`, `is_deleted`),
     KEY `status_idx` (`status`,`is_deleted`),
-    KEY `agent_ip_idx` (`agent_ip`)
+    KEY `agent_ip_idx` (`agent_ip`,`is_deleted`)
 );
 
 -- ----------------------------

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -613,7 +613,7 @@ CREATE TABLE `stream_source`
     PRIMARY KEY (`id`),
     UNIQUE KEY `unique_source_name` (`inlong_group_id`, `inlong_stream_id`, `source_name`, `is_deleted`),
     KEY `status_idx` (`status`,`is_deleted`),
-    KEY `agent_ip_idx` (`agent_ip`)
+    KEY `agent_ip_idx` (`agent_ip`,`is_deleted`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='Stream source table';
 

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -611,7 +611,9 @@ CREATE TABLE `stream_source`
     `create_time`      timestamp    NULL     DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
     `modify_time`      timestamp    NULL     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `unique_source_name` (`inlong_group_id`, `inlong_stream_id`, `source_name`, `is_deleted`)
+    UNIQUE KEY `unique_source_name` (`inlong_group_id`, `inlong_stream_id`, `source_name`, `is_deleted`),
+    KEY `status` (`status`,`is_deleted`),
+    KEY `agent_ip` (`agent_ip`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='Stream source table';
 


### PR DESCRIPTION
### Title Name: [INLONG-3287] Fix heartbeat manager init in Manager Service
where *XYZ* should be replaced by the actual issue number.

Fixes #3287 

### Motivation

### Modifications

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
