### PR TITLE
[INLONG-3306][Agent] Use rocksdb as default db

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
@@ -47,7 +47,7 @@ public class AgentConstants {
     public static final String DEFAULT_AGENT_DB_INSTANCE_NAME = "agent";
 
     public static final String AGENT_DB_CLASSNAME = "agent.db.classname";
-    public static final String DEFAULT_AGENT_DB_CLASSNAME = "org.apache.inlong.agent.db.BerkeleyDbImp";
+    public static final String DEFAULT_AGENT_DB_CLASSNAME = "org.apache.inlong.agent.db.RocksDbImp";
 
     // default is empty.
     public static final String AGENT_FETCHER_CLASSNAME = "agent.fetcher.classname";


### PR DESCRIPTION
### [INLONG-3306][Feature] use rocksdb as default db in agent

Fixes #3306 

### Motivation

use rocksdb as default db in agent

### Modifications

use rocksdb as default db in agent

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (no)