### PR TITLE
[INLONG-3316][Sort] Change target sort jar from sort-dist to sort-single-tenant in inlong-distribution module

### DIFF
--- a/inlong-distribution/distribution.xml
+++ b/inlong-distribution/distribution.xml
@@ -63,10 +63,10 @@
 
         <!-- package InLong-Sort-->
         <fileSet>
-            <directory>../inlong-sort/sort-dist/target</directory>
+            <directory>../inlong-sort/sort-single-tenant/target</directory>
             <outputDirectory>inlong-sort</outputDirectory>
             <includes>
-                <include>sort-dist-${project.version}.jar</include>
+                <include>sort-single-tenant-${project.version}.jar</include>
             </includes>
         </fileSet>
 


### PR DESCRIPTION
### Title Name: [INLONG-3316][Sort] Change target sort jar from sort-dist to sort-single-tenant in inlong-distribution module

Fixes #3316

### Motivation

Change target sort jar from sort-dist to sort-single-tenant in inlong-distribution module

### Verifying this change

- [ ] Make sure that the change passes the CI checks.