### PR TITLE
[INLONG-3332][Sort-Standalone] Fix NP and data race in ClsSink

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsIdConfig.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsIdConfig.java
@@ -46,10 +46,12 @@ public class ClsIdConfig {
      */
     public List<String> getFieldList() {
         if (fieldList == null) {
-            this.fieldList = new ArrayList<>();
-            if (fieldNames != null) {
-                String[] fieldNameArray = fieldNames.split("\\s+");
-                this.fieldList.addAll(Arrays.asList(fieldNameArray));
+            synchronized (fieldNames) {
+                this.fieldList = new ArrayList<>();
+                if (fieldNames != null) {
+                    String[] fieldNameArray = fieldNames.split("\\s+");
+                    this.fieldList.addAll(Arrays.asList(fieldNameArray));
+                }
             }
         }
         return fieldList;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsIdConfig.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsIdConfig.java
@@ -46,12 +46,10 @@ public class ClsIdConfig {
      */
     public List<String> getFieldList() {
         if (fieldList == null) {
-            synchronized (fieldNames) {
-                this.fieldList = new ArrayList<>();
-                if (fieldNames != null) {
-                    String[] fieldNameArray = fieldNames.split("\\s+");
-                    this.fieldList.addAll(Arrays.asList(fieldNameArray));
-                }
+            this.fieldList = new ArrayList<>();
+            if (fieldNames != null) {
+                String[] fieldNameArray = fieldNames.split("\\s+");
+                this.fieldList.addAll(Arrays.asList(fieldNameArray));
             }
         }
         return fieldList;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSink.java
@@ -24,6 +24,7 @@ import org.apache.flume.sink.AbstractSink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -38,7 +39,7 @@ public class ClsSink extends AbstractSink implements Configurable {
 
     private Context parentContext;
     private ClsSinkContext context;
-    private List<ClsChannelWorker> workers;
+    private List<ClsChannelWorker> workers = new ArrayList<>();
 
     /**
      * Start {@link ClsChannelWorker}.

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSinkContext.java
@@ -148,6 +148,7 @@ public class ClsSinkContext extends SinkContext {
             String uid = InlongId.generateUid(inlongGroupId, inlongStreamId);
             String jsonIdConfig = JSON.toJSONString(idParam);
             ClsIdConfig idConfig = JSON.parseObject(jsonIdConfig, ClsIdConfig.class);
+            idConfig.getFieldList();
             newIdConfigMap.put(uid, idConfig);
         }
         this.idConfigMap = newIdConfigMap;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSinkContext.java
@@ -38,6 +38,7 @@ import org.apache.inlong.sort.standalone.utils.Constants;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 import org.slf4j.Logger;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,7 +72,7 @@ public class ClsSinkContext extends SinkContext {
     private int keywordMaxLength = DEFAULT_KEYWORD_MAX_LENGTH;
 
     private final Map<String, AsyncProducerClient> clientMap;
-    private List<AsyncProducerClient> deletingClients;
+    private List<AsyncProducerClient> deletingClients = new ArrayList<>();
     private Context sinkContext;
     private Map<String, ClsIdConfig> idConfigMap = new ConcurrentHashMap<>();
     private IEvent2LogItemHandler event2LogItemHandler;


### PR DESCRIPTION
### Title Name: [INLONG-3332][Sort-Standalone] Fix NP and data race in ClsSink

Fixes #3332

### Motivation

NP when init deletingClients and ClsWorkers
data race in ClsIdConfig, result in unexpected keyList

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
