### PR TITLE
[INLONG-3328][Sort-Standalone] Support to load sort-sdk configuration from file in Sort-standalone

### DIFF
--- a/inlong-sort-standalone/sort-standalone-common/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-common/pom.xml
@@ -37,5 +37,10 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-sdk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/ManagerUrlHandler.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/ManagerUrlHandler.java
@@ -19,7 +19,7 @@ package org.apache.inlong.sort.standalone.config.holder;
 
 import org.apache.commons.lang.ClassUtils;
 import org.apache.flume.Context;
-import org.apache.inlong.sort.standalone.config.loader.ClassResourceManagerUrlLoader;
+import org.apache.inlong.sort.standalone.config.loader.CommonPropertiesManagerUrlLoader;
 import org.apache.inlong.sort.standalone.config.loader.ManagerUrlLoader;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 import org.slf4j.Logger;
@@ -30,7 +30,7 @@ import java.util.Optional;
  * Manager address get handler.
  *
  * <p> Used to acquire the ip and port of manager, which sort sdk and sort-standalone request config from. </p>
- * <p> The default implementation {@link ClassResourceManagerUrlLoader}
+ * <p> The default implementation {@link CommonPropertiesManagerUrlLoader}
  * is base on {@link CommonPropertiesHolder} to acquire properties. </p>
  */
 public class ManagerUrlHandler {
@@ -71,7 +71,7 @@ public class ManagerUrlHandler {
         }
         synchronized (ManagerUrlLoader.class) {
             String loaderType = CommonPropertiesHolder
-                    .getString(KEY_MANAGER_URL_LOADER_TYPE, ClassResourceManagerUrlLoader.class.getName());
+                    .getString(KEY_MANAGER_URL_LOADER_TYPE, CommonPropertiesManagerUrlLoader.class.getName());
             LOG.info("Start to load ManagerUrlLoader, type is {}.", loaderType);
             try {
                 Class<?> handlerClass = ClassUtils.getClass(loaderType);

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigHolder.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigHolder.java
@@ -90,11 +90,15 @@ public final class SortClusterConfigHolder {
                 }
             }
             if (instance.loader == null) {
-                instance.loader = new ManagerSortClusterConfigLoader();
+                instance.loader = new ClassResourceSortClusterConfigLoader();
             }
-            instance.loader.configure(new Context(CommonPropertiesHolder.get()));
-            instance.reload();
-            instance.setReloadTimer();
+            try {
+                instance.loader.configure(new Context(CommonPropertiesHolder.get()));
+                instance.reload();
+                instance.setReloadTimer();
+            } catch (Exception e) {
+                LOG.error(e.getMessage(), e);
+            }
         }
         return instance;
     }

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigHolder.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigHolder.java
@@ -83,13 +83,14 @@ public final class SortClusterConfigHolder {
                     Class<?> loaderClass = ClassUtils.getClass(loaderType);
                     Object loaderObject = loaderClass.getDeclaredConstructor().newInstance();
                     if (loaderObject instanceof SortClusterConfigLoader) {
+                        instance.loader = (SortClusterConfigLoader) loaderObject;
                     }
                 } catch (Throwable t) {
                     LOG.error("Fail to init loader,loaderType:{},error:{}", loaderType, t.getMessage());
                 }
             }
             if (instance.loader == null) {
-                instance.loader = new ClassResourceSortClusterConfigLoader();
+                instance.loader = new ManagerSortClusterConfigLoader();
             }
             try {
                 instance.loader.configure(new Context(CommonPropertiesHolder.get()));

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigHolder.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigHolder.java
@@ -17,10 +17,10 @@
 
 package org.apache.inlong.sort.standalone.config.holder;
 
-import static org.apache.inlong.sort.standalone.config.loader.SortClusterConfigLoader.SORT_CLUSTER_CONFIG_TYPE;
 import static org.apache.inlong.sort.standalone.utils.Constants.RELOAD_INTERVAL;
 
 import java.util.Date;
+import java.util.Locale;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -30,6 +30,7 @@ import org.apache.flume.Context;
 import org.apache.inlong.common.pojo.sortstandalone.SortClusterConfig;
 import org.apache.inlong.common.pojo.sortstandalone.SortTaskConfig;
 import org.apache.inlong.sort.standalone.config.loader.ClassResourceSortClusterConfigLoader;
+import org.apache.inlong.sort.standalone.config.loader.ManagerSortClusterConfigLoader;
 import org.apache.inlong.sort.standalone.config.loader.SortClusterConfigLoader;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 import org.slf4j.Logger;
@@ -68,16 +69,24 @@ public final class SortClusterConfigHolder {
         synchronized (SortClusterConfigHolder.class) {
             instance = new SortClusterConfigHolder();
             instance.reloadInterval = CommonPropertiesHolder.getLong(RELOAD_INTERVAL, 60000L);
-            String loaderType = CommonPropertiesHolder.getString(SORT_CLUSTER_CONFIG_TYPE,
-                    ClassResourceSortClusterConfigLoader.class.getName());
-            try {
-                Class<?> loaderClass = ClassUtils.getClass(loaderType);
-                Object loaderObject = loaderClass.getDeclaredConstructor().newInstance();
-                if (loaderObject instanceof SortClusterConfigLoader) {
-                    instance.loader = (SortClusterConfigLoader) loaderObject;
+            String loaderType = CommonPropertiesHolder
+                    .getString(SortClusterConfigType.KEY_TYPE, SortClusterConfigType.MANAGER.name())
+                    .toUpperCase(Locale.getDefault());
+
+            if (SortClusterConfigType.FILE.name().equals(loaderType)) {
+                instance.loader = new ClassResourceSortClusterConfigLoader();
+            } else if (SortClusterConfigType.MANAGER.name().equals(loaderType)) {
+                instance.loader = new ManagerSortClusterConfigLoader();
+            } else {
+                // user-defined
+                try {
+                    Class<?> loaderClass = ClassUtils.getClass(loaderType);
+                    Object loaderObject = loaderClass.getDeclaredConstructor().newInstance();
+                    if (loaderObject instanceof SortClusterConfigLoader) {
+                    }
+                } catch (Throwable t) {
+                    LOG.error("Fail to init loader,loaderType:{},error:{}", loaderType, t.getMessage());
                 }
-            } catch (Throwable t) {
-                LOG.error("Fail to init loader,loaderType:{},error:{}", loaderType, t.getMessage());
             }
             if (instance.loader == null) {
                 instance.loader = new ClassResourceSortClusterConfigLoader();

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigHolder.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigHolder.java
@@ -92,13 +92,9 @@ public final class SortClusterConfigHolder {
             if (instance.loader == null) {
                 instance.loader = new ManagerSortClusterConfigLoader();
             }
-            try {
-                instance.loader.configure(new Context(CommonPropertiesHolder.get()));
-                instance.reload();
-                instance.setReloadTimer();
-            } catch (Exception e) {
-                LOG.error(e.getMessage(), e);
-            }
+            instance.loader.configure(new Context(CommonPropertiesHolder.get()));
+            instance.reload();
+            instance.setReloadTimer();
         }
         return instance;
     }

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigType.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigType.java
@@ -15,21 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.sort.standalone.config.loader;
-
-import org.apache.flume.conf.Configurable;
-import org.apache.inlong.common.pojo.sortstandalone.SortClusterConfig;
+package org.apache.inlong.sort.standalone.config.holder;
 
 /**
  * 
- * SortClusterConfigLoader
+ * SortClusterConfigType
  */
-public interface SortClusterConfigLoader extends Configurable {
+public enum SortClusterConfigType {
 
-    /**
-     * load
-     * 
-     * @return
-     */
-    SortClusterConfig load();
+    FILE, MANAGER, USER_DEFINED;
+
+    public static final String KEY_TYPE = "sortClusterConfig.type";
+    public static final String KEY_FILE = "sortClusterConfig.file";
+    public static final String DEFAULT_FILE = "SortClusterConfig.conf";
 }

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortSourceConfigType.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortSourceConfigType.java
@@ -15,21 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.sort.standalone.config.loader;
-
-import org.apache.flume.conf.Configurable;
-import org.apache.inlong.common.pojo.sortstandalone.SortClusterConfig;
+package org.apache.inlong.sort.standalone.config.holder;
 
 /**
  * 
- * SortClusterConfigLoader
+ * SortSourceConfigType<br>
+ * default file name: ${taskName}Source.conf in class resource.<br>
  */
-public interface SortClusterConfigLoader extends Configurable {
+public enum SortSourceConfigType {
 
-    /**
-     * load
-     * 
-     * @return
-     */
-    SortClusterConfig load();
+    FILE, MANAGER, USER_DEFINED;
+
+    public static final String KEY_TYPE = "sortSourceConfig.QueryConsumeConfigType";
 }

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/loader/ClassResourceQueryConsumeConfig.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/loader/ClassResourceQueryConsumeConfig.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.config.loader;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.inlong.common.pojo.sdk.CacheZone;
+import org.apache.inlong.common.pojo.sdk.CacheZoneConfig;
+import org.apache.inlong.common.pojo.sdk.Topic;
+import org.apache.inlong.sdk.sort.api.QueryConsumeConfig;
+import org.apache.inlong.sdk.sort.entity.CacheZoneCluster;
+import org.apache.inlong.sdk.sort.entity.ConsumeConfig;
+import org.apache.inlong.sdk.sort.entity.InLongTopic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+/**
+ * 
+ * ClassResourceQueryConsumeConfig
+ */
+public class ClassResourceQueryConsumeConfig implements QueryConsumeConfig {
+
+    public static final Logger LOG = LoggerFactory.getLogger(ClassResourceQueryConsumeConfig.class);
+
+    /**
+     * queryCurrentConsumeConfig
+     * 
+     * @param  sortTaskId
+     * @return
+     */
+    @Override
+    public ConsumeConfig queryCurrentConsumeConfig(String sortTaskId) {
+        String fileName = sortTaskId + ".conf";
+        try {
+            String confString = IOUtils.toString(getClass().getClassLoader().getResource(fileName));
+            Gson gson = new Gson();
+            CacheZoneConfig cacheZoneConfig = gson.fromJson(confString, CacheZoneConfig.class);
+            //
+            Map<String, List<InLongTopic>> newGroupTopicsMap = new HashMap<>();
+            for (Map.Entry<String, CacheZone> entry : cacheZoneConfig.getCacheZones().entrySet()) {
+                CacheZone cacheZone = entry.getValue();
+
+                List<InLongTopic> topics = newGroupTopicsMap.computeIfAbsent(cacheZoneConfig.getSortTaskId(),
+                        k -> new ArrayList<>());
+                CacheZoneCluster cacheZoneCluster = new CacheZoneCluster(cacheZone.getZoneName(),
+                        cacheZone.getServiceUrl(), cacheZone.getAuthentication());
+                for (Topic topicInfo : cacheZone.getTopics()) {
+                    InLongTopic topic = new InLongTopic();
+                    topic.setInLongCluster(cacheZoneCluster);
+                    topic.setTopic(topicInfo.getTopic());
+                    topic.setTopicType(cacheZone.getZoneType());
+                    topics.add(topic);
+                }
+            }
+            return new ConsumeConfig(newGroupTopicsMap.get(sortTaskId));
+        } catch (UnsupportedEncodingException e) {
+            LOG.error("fail to load properties, file ={}, and e= {}", fileName, e);
+        } catch (Exception e) {
+            LOG.error("fail to load properties, file ={}, and e= {}", fileName, e);
+        }
+        return null;
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/loader/ClassResourceSortClusterConfigLoader.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/loader/ClassResourceSortClusterConfigLoader.java
@@ -22,6 +22,7 @@ import java.io.UnsupportedEncodingException;
 import org.apache.commons.io.IOUtils;
 import org.apache.flume.Context;
 import org.apache.inlong.common.pojo.sortstandalone.SortClusterConfig;
+import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigType;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 import org.slf4j.Logger;
 
@@ -34,7 +35,8 @@ import com.google.gson.Gson;
 public class ClassResourceSortClusterConfigLoader implements SortClusterConfigLoader {
 
     public static final Logger LOG = InlongLoggerFactory.getLogger(ClassResourceSortClusterConfigLoader.class);
-    public static final String FILENAME = "SortClusterConfig.conf";
+
+    private Context context;
 
     /**
      * load
@@ -43,15 +45,19 @@ public class ClassResourceSortClusterConfigLoader implements SortClusterConfigLo
      */
     @Override
     public SortClusterConfig load() {
+        String fileName = SortClusterConfigType.DEFAULT_FILE;
         try {
-            String confString = IOUtils.toString(getClass().getClassLoader().getResource(FILENAME));
+            if (context != null) {
+                fileName = context.getString(SortClusterConfigType.KEY_FILE, SortClusterConfigType.DEFAULT_FILE);
+            }
+            String confString = IOUtils.toString(getClass().getClassLoader().getResource(fileName));
             Gson gson = new Gson();
             SortClusterConfig config = gson.fromJson(confString, SortClusterConfig.class);
             return config;
         } catch (UnsupportedEncodingException e) {
-            LOG.error("fail to load properties, file ={}, and e= {}", FILENAME, e);
+            LOG.error("fail to load properties, file ={}, and e= {}", fileName, e);
         } catch (Exception e) {
-            LOG.error("fail to load properties, file ={}, and e= {}", FILENAME, e);
+            LOG.error("fail to load properties, file ={}, and e= {}", fileName, e);
         }
         return SortClusterConfig.builder().build();
     }
@@ -63,5 +69,6 @@ public class ClassResourceSortClusterConfigLoader implements SortClusterConfigLo
      */
     @Override
     public void configure(Context context) {
+        this.context = context;
     }
 }

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/loader/CommonPropertiesManagerUrlLoader.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/loader/CommonPropertiesManagerUrlLoader.java
@@ -27,9 +27,9 @@ import java.util.Optional;
 /**
  * Default ManagerUrlLoader. acquire URLs from common.properties.
  */
-public class ClassResourceManagerUrlLoader implements ManagerUrlLoader {
+public class CommonPropertiesManagerUrlLoader implements ManagerUrlLoader {
 
-    private static final Logger LOG = InlongLoggerFactory.getLogger(ClassResourceManagerUrlLoader.class);
+    private static final Logger LOG = InlongLoggerFactory.getLogger(CommonPropertiesManagerUrlLoader.class);
     private static final String KEY_SORT_CLUSTER_CONFIG_MANAGER_URL = "sortClusterConfig.managerUrl";
     private static final String KEY_SORT_SOURCE_CONFIG_MANAGER_URL = "sortSourceConfig.managerUrl";
 

--- a/inlong-sort-standalone/sort-standalone-source/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-source/pom.xml
@@ -44,11 +44,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-sdk</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.inlong</groupId>
             <artifactId>audit-sdk</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSinkContext.java
@@ -137,6 +137,7 @@ public class EsSinkContext extends SinkContext {
                 String uid = InlongId.generateUid(inlongGroupId, inlongStreamId);
                 String jsonIdConfig = JSON.toJSONString(idParam);
                 EsIdConfig idConfig = JSON.parseObject(jsonIdConfig, EsIdConfig.class);
+                idConfig.getFieldList();
                 newIdConfigMap.put(uid, idConfig);
             }
             // change current config


### PR DESCRIPTION
### Title Name: [INLONG-3328][Sort-Standalone] Support to load sort-sdk configuration from file in Sort-standalone

Fixes #3328 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
