### PR TITLE
[INLONG-3359][Agent] Add semaphore for each proxy sink to prevent oom

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
@@ -145,7 +145,7 @@ public class AgentConstants {
     public static final int DEFAULT_TASK_PULL_MAX_SECOND = 2;
 
     public static final String CHANNEL_MEMORY_CAPACITY = "channel.memory.capacity";
-    public static final int DEFAULT_CHANNEL_MEMORY_CAPACITY = 10000;
+    public static final int DEFAULT_CHANNEL_MEMORY_CAPACITY = 1000;
 
     public static final String TRIGGER_CHECK_INTERVAL = "trigger.check.interval";
     public static final int DEFAULT_TRIGGER_CHECK_INTERVAL = 2;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
@@ -61,6 +61,9 @@ public class CommonConstants {
     // max size of single batch in bytes, default is 200KB.
     public static final int DEFAULT_PROXY_PACKAGE_MAX_SIZE = 200000;
 
+    public static final String PROXY_MESSAGE_SEMAPHORE = "proxy.semaphore";
+    public static final int DEFAULT_PROXY_MESSAGE_SEMAPHORE = 10000;
+
     public static final String PROXY_INLONG_STREAM_ID_QUEUE_MAX_NUMBER = "proxy.group.queue.maxNumber";
     public static final int DEFAULT_PROXY_INLONG_STREAM_ID_QUEUE_MAX_NUMBER = 10000;
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/BinlogReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/BinlogReader.java
@@ -147,7 +147,7 @@ public class BinlogReader implements Reader {
         snapshotMode = jobConf.get(JOB_DATABASE_SNAPSHOT_MODE, "");
         includeSchemaChanges = jobConf.get(JOB_DATABASE_INCLUDE_SCHEMA_CHANGES, "false");
         historyMonitorDdl = jobConf.get(JOB_DATABASE_HISTORY_MONITOR_DDL, "false");
-        binlogMessagesQueue = new LinkedBlockingQueue<>(jobConf.getInt(JOB_DATABASE_QUEUE_SIZE, 10000));
+        binlogMessagesQueue = new LinkedBlockingQueue<>(jobConf.getInt(JOB_DATABASE_QUEUE_SIZE, 1000));
         instanceId = jobConf.getInstanceId();
         finished = false;
 


### PR DESCRIPTION
### Title Name: [INLONG-3359][Agent] Add semaphore for each proxy sink to prevent oom

Fixes #3359 

### Motivation

[INLONG-3359][Agent] Add semaphore for each proxy sink to prevent oom
the channel for limiting size is job-wise, we need a semaphore for all sinks

### Modifications

[INLONG-3359][Agent] Add semaphore for each proxy sink to prevent oom

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (no)