### PR TITLE
[INLONG-3363][TubeMQ]Added how to use optional BDB components and documentation

### DIFF
--- a/inlong-tubemq/conf/master.ini
+++ b/inlong-tubemq/conf/master.ini
@@ -38,28 +38,39 @@ webResourcePath=resources
 ; configure useWebProxy
 useWebProxy=false
 
+[meta_zookeeper]
+; root path of TubeMQ znodes on ZK
+zkNodeRoot=/tubemq
+; connect string of ZK servers
+zkServerAddr=localhost:2181
+; timeout of ZK heartbeat; default is 30000ms
+zkSessionTimeoutMs=30000
+; timeout of ZK connection; default is 30000ms
+zkConnectionTimeoutMs=30000
+; sync time on ZK; default is 5000ms
+zkSyncTimeMs=5000
+; interval to commits data on ZK; default is 5000ms
+zkCommitPeriodMs=5000
+; Master Select status check duration, default is 5000ms
+zkMasterCheckPeriodMs=5000
 
-[meta_bdb]
+
+;[meta_bdb]
 ; name of replication group, default is `tubemqMasterGroup`, you'd better set individual value for every tubeMQ cluster
 ;repGroupName=tubemqMasterGroup
-
 ; name of current node; MUST BE DIFFERENT for every node in the same group
-repNodeName=tubemqMasterGroupNode1
-
+;repNodeName=tubemqMasterGroupNode1
 ; port for node to communicate to other nodes in replication group, default is 9001
 ;repNodePort=9001
-
 ; bdb meta data path; can be absolute, or relative to TubeMQ base directory ($BASE_DIR)
 ;   optional, default is "var/meta_data"
 ;   should be the same to `[bdbStore].bdbEnvHome` if upgrade from version prior 0.5.0
 ;   or `[master].metaDataPath` if upgrade from version prior 1.0.0
 ;metaDataPath=var/meta_data
-
 ; helperHost(and port) for node to join master cluster and the port should keep consistent with `repNodePort`; for the
 ; first time of starting, this value for every node in master cluster should keep same
 ; the default is 127.0.0.1:9001
 ;repHelperHost=masterHostName:9001
-
 ; meta data disk sync policy
 ;   the overall durability is a function of metaLocalSyncPolicy plus the repReplicaAckPolicy used by the master,
 ;     and the metaReplicaSyncPolicy in effect at each Replica
@@ -70,34 +81,12 @@ repNodeName=tubemqMasterGroupNode1
 ;     actually forced to disk(if the system fails,data may lost)
 ; sync policy for "local", optional; default is 1(SYNC)
 ;metaLocalSyncPolicy=1
-
 ; sync policy for "replica", optional; default is 3(WRITE_NO_SYNC)
 ;metaReplicaSyncPolicy=3
-
 ; replication acknowledge policy, optional; default is 1(SIMPLE_MAJORITY)
 ;   1 for SIMPLE_MAJORITY
 ;   2 for ALL
 ;   3 for NONE
 ;repReplicaAckPolicy=1
-
 ; interval for node status check task, optional; default is 10000(ms)
 ;repStatusCheckTimeoutMs=10000
-
-
-;[meta_zookeeper]
-; root path of TubeMQ znodes on ZK
-;zkNodeRoot=/tubemq
-; connect string of ZK servers
-;zkServerAddr=localhost:2181
-; timeout of ZK heartbeat; default is 30000ms
-;zkSessionTimeoutMs=30000
-; timeout of ZK connection; default is 30000ms
-;zkConnectionTimeoutMs=30000
-; sync time on ZK; default is 5000ms
-;zkSyncTimeMs=5000
-; interval to commits data on ZK; default is 5000ms
-;zkCommitPeriodMs=5000
-; Master Select status check duration, default is 5000ms
-;zkMasterCheckPeriodMs=5000
-
-

--- a/inlong-tubemq/pom.xml
+++ b/inlong-tubemq/pom.xml
@@ -231,6 +231,7 @@
                 <groupId>com.sleepycat</groupId>
                 <artifactId>je</artifactId>
                 <version>${je.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Fixes #3363

1. Modify master.ini to use ZooKeeper as the default storage component;
2. Modify the BDB dependency scope in pom.xml to provided