### PR TITLE
[INLONG-3387][SDK] Strengthen the strategy of heartbeat and channel update for dataproxy

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/example/TcpClientExample.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/example/TcpClientExample.java
@@ -18,8 +18,6 @@
 
 package org.apache.inlong.sdk.dataproxy.example;
 
-import java.io.UnsupportedEncodingException;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.StringUtils;
 import org.apache.inlong.sdk.dataproxy.DefaultMessageSender;
 import org.apache.inlong.sdk.dataproxy.ProxyClientConfig;
@@ -27,13 +25,16 @@ import org.apache.inlong.sdk.dataproxy.SendResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.TimeUnit;
+
 public class TcpClientExample {
 
     private static final Logger logger = LoggerFactory.getLogger(TcpClientExample.class);
 
     public static String localIP = "127.0.0.1";
 
-    public static void main() {
+    public static void main(String[] args) throws InterruptedException {
 
         String dataProxyGroup = "test_test";
         String inlongGroupId = "test_test";

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/ClientMgr.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/ClientMgr.java
@@ -23,6 +23,17 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import org.apache.inlong.sdk.dataproxy.ConfigConstants;
+import org.apache.inlong.sdk.dataproxy.ProxyClientConfig;
+import org.apache.inlong.sdk.dataproxy.codec.EncodeObject;
+import org.apache.inlong.sdk.dataproxy.config.EncryptConfigEntry;
+import org.apache.inlong.sdk.dataproxy.config.HostInfo;
+import org.apache.inlong.sdk.dataproxy.config.ProxyConfigEntry;
+import org.apache.inlong.sdk.dataproxy.config.ProxyConfigManager;
+import org.apache.inlong.sdk.dataproxy.utils.EventLoopUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -37,35 +48,24 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.apache.inlong.sdk.dataproxy.ProxyClientConfig;
-import org.apache.inlong.sdk.dataproxy.ConfigConstants;
-import org.apache.inlong.sdk.dataproxy.codec.EncodeObject;
-import org.apache.inlong.sdk.dataproxy.config.ProxyConfigEntry;
-import org.apache.inlong.sdk.dataproxy.config.ProxyConfigManager;
-import org.apache.inlong.sdk.dataproxy.config.EncryptConfigEntry;
-import org.apache.inlong.sdk.dataproxy.config.HostInfo;
-import org.apache.inlong.sdk.dataproxy.utils.EventLoopUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class ClientMgr {
     private static final Logger logger = LoggerFactory
             .getLogger(ClientMgr.class);
 
-    private final Map<HostInfo, NettyClient> clientMapData = new ConcurrentHashMap<HostInfo, NettyClient>();
+    private final Map<HostInfo, NettyClient> clientMapData = new ConcurrentHashMap<>();
 
-    private final ConcurrentHashMap<HostInfo, NettyClient> clientMapHB = new ConcurrentHashMap<HostInfo, NettyClient>();
+    private final ConcurrentHashMap<HostInfo, NettyClient> clientMapHB = new ConcurrentHashMap<>();
     // clientMapData + clientMapHB = clientMap
-    private final ConcurrentHashMap<HostInfo, NettyClient> clientMap = new ConcurrentHashMap<HostInfo, NettyClient>();
+    private final ConcurrentHashMap<HostInfo, NettyClient> clientMap = new ConcurrentHashMap<>();
 
     private final ConcurrentHashMap<HostInfo, AtomicLong> lastBadHostMap = new ConcurrentHashMap<>();
 
-    private final ArrayList<NettyClient> clientList = new ArrayList<NettyClient>();
-    private List<HostInfo> proxyInfoList = new ArrayList<HostInfo>();
+    // clientList is the valueSet of clientMapData
+    private final ArrayList<NettyClient> clientList = new ArrayList<>();
+    private List<HostInfo> proxyInfoList = new ArrayList<>();
 
-    //    private final Map<HostInfo, Integer> channelLoadMap = new ConcurrentHashMap<HostInfo, Integer>();
-    private final Map<HostInfo, int[]> channelLoadMapData = new ConcurrentHashMap<HostInfo, int[]>();
-    private final Map<HostInfo, int[]> channelLoadMapHB = new ConcurrentHashMap<HostInfo, int[]>();
+    private final Map<HostInfo, int[]> channelLoadMapData = new ConcurrentHashMap<>();
+    private final Map<HostInfo, int[]> channelLoadMapHB = new ConcurrentHashMap<>();
 
     private Bootstrap bootstrap;
     private int currentIndex = 0;
@@ -73,7 +73,6 @@ public class ClientMgr {
     private Sender sender;
     private int aliveConnections;
     private int realSize;
-    //    private ConnectionCheckThread connectionCheckThread;
     private SendHBThread sendHBThread;
     private ProxyConfigManager ipManager;
 
@@ -231,6 +230,12 @@ public class ClientMgr {
         return ipManager.getGroupIdConfigure();
     }
 
+    /**
+     * create conn, as DataConn or HBConn
+     *
+     * @param host
+     * @return
+     */
     private boolean initConnection(HostInfo host) {
         NettyClient client = clientMap.get(host);
         if (client != null && client.isActive()) {
@@ -243,7 +248,7 @@ public class ClientMgr {
         boolean bSuccess = client.connect();
 
         if (clientMapData.size() < aliveConnections) {
-
+            // create data channel
             if (bSuccess) {
                 clientMapData.put(host, client);
                 clientList.add(client);
@@ -254,7 +259,7 @@ public class ClientMgr {
             }
             logger.info("client map size {},client list size {}", clientMapData.size(), clientList.size());
         } else {
-
+            // data channel list is enough, create hb channel
             if (bSuccess) {
                 clientMapHB.put(host, client);
                 clientMap.put(host, client);
@@ -572,29 +577,40 @@ public class ClientMgr {
     }
 
     private void sendHeartBeat() {
-        for (HostInfo hostInfo : clientMap.keySet()) {
-            if (hostInfo == null) {
+        // all hbChannels need hb
+        for (Map.Entry<HostInfo, NettyClient> clientEntry : clientMapHB.entrySet()) {
+            if (clientEntry.getKey() != null && clientEntry.getValue() != null) {
+                sendHeartBeat(clientEntry.getKey(), clientEntry.getValue());
+            }
+        }
+
+        // only idle dataChannels need hb
+        for (Map.Entry<HostInfo, NettyClient> clientEntry : clientMapData.entrySet()) {
+            if (clientEntry.getKey() == null || clientEntry.getValue() == null) {
                 continue;
             }
-            NettyClient client = clientMap.get(hostInfo);
-            if (client == null) {
-                continue;
+            if (sender.isIdleClient(clientEntry.getValue())) {
+                sendHeartBeat(clientEntry.getKey(), clientEntry.getValue());
             }
-            try {
-                if (client.isActive()) {
-                    //logger.info("active host to send heartbeat! {}", entry.getKey().getHostName());
-                    EncodeObject encodeObject = new EncodeObject("heartbeat".getBytes(StandardCharsets.UTF_8),
-                            8, false, false, false, System.currentTimeMillis() / 1000, 1, "", "", "");
-                    if (configure.isNeedAuthentication()) {
-                        encodeObject.setAuth(configure.isNeedAuthentication(),
-                                configure.getUserName(), configure.getSecretKey());
-                    }
-                    client.write(encodeObject);
+        }
+
+    }
+
+    private void sendHeartBeat(HostInfo hostInfo, NettyClient client) {
+        try {
+            if (client.isActive()) {
+                logger.debug("active host to send heartbeat! {}", hostInfo.getReferenceName());
+                EncodeObject encodeObject = new EncodeObject("heartbeat".getBytes(StandardCharsets.UTF_8),
+                        8, false, false, false, System.currentTimeMillis() / 1000, 1, "", "", "");
+                if (configure.isNeedAuthentication()) {
+                    encodeObject.setAuth(configure.isNeedAuthentication(),
+                            configure.getUserName(), configure.getSecretKey());
                 }
-            } catch (Throwable e) {
-                logger.error("sendHeartBeat to " + hostInfo.getReferenceName()
-                        + " exception {}, {}", e.toString(), e.getStackTrace());
+                client.write(encodeObject);
             }
+        } catch (Throwable e) {
+            logger.error("sendHeartBeat to " + hostInfo.getReferenceName()
+                    + " exception {}, {}", e.toString(), e.getStackTrace());
         }
     }
 
@@ -646,6 +662,25 @@ public class ClientMgr {
 
             if (isSuccess) {
                 lastBadHostMap.remove(hostInfo);
+            }
+        }
+    }
+
+    private void fillUpWorkClientWithBadClient(List<HostInfo> badHostLists) {
+        if (badHostLists.isEmpty()) {
+            logger.warn("badHostLists is empty, current hostList size {}, dataClient size {}, hbClient size {}",
+                    proxyInfoList.size(), clientMapData.size(), clientMapHB.size());
+            return;
+        }
+        logger.info("all hosts are bad, dataClient is empty, reuse them, badHostLists size {}, "
+                        + "proxyInfoList size {}", badHostLists.size(), proxyInfoList.size());
+
+        List<HostInfo> replaceHostLists = getRealHosts(badHostLists, aliveConnections);
+        boolean isSuccess = false;
+        for (HostInfo hostInfo : replaceHostLists) {
+            isSuccess = initConnection(hostInfo);
+            if (isSuccess) {
+                badHostLists.remove(hostInfo);
             }
         }
     }
@@ -710,6 +745,14 @@ public class ClientMgr {
         }
     }
 
+    /**
+     * 1. check all inactive conn, including dataConn and HBConn
+     * 2.1. if there is no any bad conn, do dataConn<->hbConn balance every ConfigConstants.CYCLE, according to load
+     * 2.2. close and remove all inactive conn
+     * 3. fillUp dataConn and HBConn using remaining hosts(excludes lastBadHostMap)
+     * 4. if dataConns are still not full, try to using HBConns (then lastBadHostMap) to fillUp
+     * 5. update lastBadHostMap, including increase, remove and update badValue
+     */
     public void replaceBadConnectionHB() {
         try {
             writeLock();
@@ -753,7 +796,7 @@ public class ClientMgr {
             List<HostInfo> hostLists = new ArrayList<HostInfo>(this.proxyInfoList);
             hostLists.removeAll(badHostLists);
             hostLists.removeAll(lastBadHostMap.keySet());
-            hostLists.removeAll(normalHostLists);
+            hostLists.removeAll(normalHostLists); // now, all hosts in this hostLists are not built conn
 
             int realSize = this.realSize - clientMap.size();
             if (realSize > hostLists.size()) {
@@ -774,6 +817,11 @@ public class ClientMgr {
 
             if (clientMapData.size() < aliveConnections) {
                 fillUpWorkClientWithLastBadClient();
+            }
+
+            // when all hosts are bad, reuse them to avoid clientMapData is empty in this round
+            if (clientMapData.isEmpty()) {
+                fillUpWorkClientWithBadClient(badHostLists);
             }
 
             for (HostInfo hostInfo : badHostLists) {
@@ -877,9 +925,7 @@ public class ClientMgr {
             while (!bShutDown) {
                 try {
                     loadCycle++;
-                    if (!clientMapHB.isEmpty()) {
-                        sendHeartBeat();
-                    }
+                    sendHeartBeat();
                     replaceBadConnectionHB();
                     try {
                         int index = (int) (Math.random() * random.length);

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/threads/IndexCollectThread.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/threads/IndexCollectThread.java
@@ -18,22 +18,22 @@
 
 package org.apache.inlong.sdk.dataproxy.threads;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
- * index collector
+ * index collector, print the num of receive messages of one DefaultMessageSender in every one minute
  */
 public class IndexCollectThread extends Thread {
-    private static final Logger logger = LoggerFactory.getLogger(IndexCollectThread.class);
 
-    private volatile boolean bShutDown;
+    private static final Logger logger = LoggerFactory.getLogger(IndexCollectThread.class);
     private final Map<String, Long> storeIndex;
+    private volatile boolean bShutDown;
 
     public IndexCollectThread(Map<String, Long> storeIndex) {
         bShutDown = false;


### PR DESCRIPTION

### Title Name: [INLONG-3387][dataproxy-sdk] Strengthen the strategy of heartbeat and channel update

where *XYZ* should be replaced by the actual issue number.

Fixes #3387 

### Modifications

- send heartbeat for idle dataChannel to keep alive
- reuse bad host while dataproxy hosts are rare, avoid there is no dataChannel
- improve code style


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
