### PR TITLE
[INLONG-3435][Sort-Standalone] Fix user-defined SortClusterConfigType problem in Sort-standalone.

### DIFF
--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigHolder.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/config/holder/SortClusterConfigHolder.java
@@ -20,7 +20,6 @@ package org.apache.inlong.sort.standalone.config.holder;
 import static org.apache.inlong.sort.standalone.utils.Constants.RELOAD_INTERVAL;
 
 import java.util.Date;
-import java.util.Locale;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -70,12 +69,11 @@ public final class SortClusterConfigHolder {
             instance = new SortClusterConfigHolder();
             instance.reloadInterval = CommonPropertiesHolder.getLong(RELOAD_INTERVAL, 60000L);
             String loaderType = CommonPropertiesHolder
-                    .getString(SortClusterConfigType.KEY_TYPE, SortClusterConfigType.MANAGER.name())
-                    .toUpperCase(Locale.getDefault());
+                    .getString(SortClusterConfigType.KEY_TYPE, SortClusterConfigType.MANAGER.name());
 
-            if (SortClusterConfigType.FILE.name().equals(loaderType)) {
+            if (SortClusterConfigType.FILE.name().equalsIgnoreCase(loaderType)) {
                 instance.loader = new ClassResourceSortClusterConfigLoader();
-            } else if (SortClusterConfigType.MANAGER.name().equals(loaderType)) {
+            } else if (SortClusterConfigType.MANAGER.name().equalsIgnoreCase(loaderType)) {
                 instance.loader = new ManagerSortClusterConfigLoader();
             } else {
                 // user-defined

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -20,7 +20,6 @@ package org.apache.inlong.sort.standalone.source.sortsdk;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -217,9 +216,8 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
      */
     private void updateAllClientConfig() {
         String configType = CommonPropertiesHolder
-                .getString(SortSourceConfigType.KEY_TYPE, SortSourceConfigType.MANAGER.name())
-                .toUpperCase(Locale.getDefault());
-        if (SortClusterConfigType.MANAGER.name().equals(configType)) {
+                .getString(SortSourceConfigType.KEY_TYPE, SortSourceConfigType.MANAGER.name());
+        if (SortClusterConfigType.MANAGER.name().equalsIgnoreCase(configType)) {
             clients.values().stream()
                     .map(SortClient::getConfig)
                     .forEach(this::updateClientConfig);
@@ -257,17 +255,16 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
 
             // create SortClient
             String configType = CommonPropertiesHolder
-                    .getString(SortSourceConfigType.KEY_TYPE, SortSourceConfigType.MANAGER.name())
-                    .toUpperCase(Locale.getDefault());
+                    .getString(SortSourceConfigType.KEY_TYPE, SortSourceConfigType.MANAGER.name());
             SortClient client = null;
-            if (SortClusterConfigType.FILE.name().equals(configType)) {
+            if (SortClusterConfigType.FILE.name().equalsIgnoreCase(configType)) {
                 LOG.info("Create sort sdk client in file way:{}", configType);
                 ClassResourceQueryConsumeConfig queryConfig = new ClassResourceQueryConsumeConfig();
                 client = SortClientFactory.createSortClient(clientConfig,
                         queryConfig,
                         new MetricReporterImpl(clientConfig),
                         new ManagerReportHandlerImpl());
-            } else if (SortClusterConfigType.MANAGER.name().equals(configType)) {
+            } else if (SortClusterConfigType.MANAGER.name().equalsIgnoreCase(configType)) {
                 LOG.info("Create sort sdk client in manager way:{}", configType);
                 this.updateClientConfig(clientConfig);
                 client = SortClientFactory.createSortClient(clientConfig);


### PR DESCRIPTION
### Title Name: [INLONG-3435][Sort-Standalone] Fix user-defined SortClusterConfigType problem in Sort-standalone.

Fixes #3435 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
