### PR TITLE
[INLONG-3434][Sort] Optimize the automatic splicing of database after hive jdbc url

### DIFF
--- a/inlong-sort/sort-connectors/src/test/java/org/apache/inlong/sort/flink/hive/partition/JdbcHivePartitionCommitPolicyTest.java
+++ b/inlong-sort/sort-connectors/src/test/java/org/apache/inlong/sort/flink/hive/partition/JdbcHivePartitionCommitPolicyTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.flink.hive.partition;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JdbcHivePartitionCommitPolicyTest {
+
+    @Test
+    public void testGetHiveConnStr1() {
+        String hiveJdbcUrl = "jdbc:hive2://127.0.0.1:10000";
+        String database = "test666";
+        String expectValue = "jdbc:hive2://127.0.0.1:10000/test666";
+        Assert.assertEquals(JdbcHivePartitionCommitPolicy.getHiveConnStr(hiveJdbcUrl, database), expectValue);
+    }
+
+    @Test
+    public void testGetHiveConnStr2() {
+        String hiveJdbcUrl = "jdbc:hive2://127.0.0.1:10000/";
+        String database = "test666";
+        String expectValue = "jdbc:hive2://127.0.0.1:10000/test666";
+        Assert.assertEquals(JdbcHivePartitionCommitPolicy.getHiveConnStr(hiveJdbcUrl, database), expectValue);
+    }
+
+    @Test
+    public void testGetHiveConnStr3() {
+        String hiveJdbcUrl = "jdbc:hive2://127.0.0.1:10000/test888";
+        String database = "test666";
+        String expectValue = "jdbc:hive2://127.0.0.1:10000/test666";
+        Assert.assertEquals(JdbcHivePartitionCommitPolicy.getHiveConnStr(hiveJdbcUrl, database), expectValue);
+    }
+
+    @Test
+    public void testGetHiveConnStr4() {
+        String hiveJdbcUrl = "jdbc:hive2://127.0.0.1:10000/test888/;principal=hive/127.0.0.1@TEST.COM";
+        String database = "test666";
+        String expectValue = "jdbc:hive2://127.0.0.1:10000/test666/;principal=hive/127.0.0.1@TEST.COM";
+        Assert.assertEquals(JdbcHivePartitionCommitPolicy.getHiveConnStr(hiveJdbcUrl, database), expectValue);
+    }
+
+    @Test
+    public void testGetHiveConnStr5() {
+        String hiveJdbcUrl = "jdbc:hive2://127.0.0.1:10000/test888/test888;principal=hive/127.0.0.1@TEST.COM";
+        String database = "test666";
+        String expectValue = "jdbc:hive2://127.0.0.1:10000/test666/;principal=hive/127.0.0.1@TEST.COM";
+        Assert.assertEquals(JdbcHivePartitionCommitPolicy.getHiveConnStr(hiveJdbcUrl, database), expectValue);
+    }
+
+}


### PR DESCRIPTION
### Title Name: [INLONG-3434][Sort] Optimize the automatic splicing of database after hive jdbc url

Fixes #3434 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
