### PR TITLE
[INLONG-3451][Manager] Got wrong results when querying tube cluster info

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/CommonOperateService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/CommonOperateService.java
@@ -113,7 +113,7 @@ public class CommonOperateService {
             case Constant.CLUSTER_TUBE_MANAGER:
             case Constant.CLUSTER_TUBE_CLUSTER_ID:
             case Constant.TUBE_MASTER_URL: {
-                clusterEntity = getMQCluster(MQType.PULSAR);
+                clusterEntity = getMQCluster(MQType.TUBE);
                 if (clusterEntity != null) {
                     if (key.equals(Constant.TUBE_MASTER_URL)) {
                         result = clusterEntity.getUrl();
@@ -132,9 +132,6 @@ public class CommonOperateService {
      * Get third party cluster by type.
      *
      * TODO Add data_proxy_cluster_name for query.
-     *
-     * @param type
-     * @return
      */
     private ThirdPartyClusterEntity getMQCluster(MQType type) {
         List<ThirdPartyClusterEntity> clusterList = thirdPartyClusterMapper.selectByType(Constant.CLUSTER_DATA_PROXY);


### PR DESCRIPTION
### Title Name: [INLONG-3451][Manager] Got wrong results when querying tube cluster info

Fixes #3451

### Motivation

Got wrong results when querying tube cluster info.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
