### PR TITLE
[INLONG-3064][Manager] Unify field types of sink and source in manager client

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/SinkField.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/SinkField.java
@@ -34,10 +34,10 @@ public class SinkField extends StreamField {
     private String sourceFieldName;
 
     @ApiModelProperty("Source field type")
-    private String sourceFieldType;
+    private FieldType sourceFieldType;
 
     public SinkField(int index, FieldType fieldType, String fieldName, String fieldComment,
-            String fieldValue, String sourceFieldName, String sourceFieldType,
+            String fieldValue, String sourceFieldName, FieldType sourceFieldType,
             Integer isMetaField, String fieldFormat) {
         super(index, fieldType, fieldName, fieldComment, fieldValue, isMetaField, fieldFormat);
         this.sourceFieldName = sourceFieldName;

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongStreamSinkTransfer.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongStreamSinkTransfer.java
@@ -152,7 +152,7 @@ public class InlongStreamSinkTransfer {
                 sinkFieldResponse.getFieldName(),
                 sinkFieldResponse.getFieldComment(),
                 null, sinkFieldResponse.getSourceFieldName(),
-                sinkFieldResponse.getSourceFieldType(),
+                FieldType.forName(sinkFieldResponse.getSourceFieldType()),
                 sinkFieldResponse.getIsMetaField(),
                 sinkFieldResponse.getFieldFormat())).collect(Collectors.toList());
 
@@ -238,7 +238,7 @@ public class InlongStreamSinkTransfer {
             request.setFieldType(sinkField.getFieldType().toString());
             request.setFieldComment(sinkField.getFieldComment());
             request.setSourceFieldName(sinkField.getSourceFieldName());
-            request.setSourceFieldType(sinkField.getSourceFieldType());
+            request.setSourceFieldType(sinkField.getSourceFieldType().toString());
             request.setIsMetaField(sinkField.getIsMetaField());
             request.setFieldFormat(sinkField.getFieldFormat());
             fieldRequestList.add(request);


### PR DESCRIPTION
### Title Name: [INLONG-3064][Manager] Unify field types of sink and source in manager client

Fixes #3064

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
