### PR TITLE
[INLONG-3476][Agent] debezium 1.8.1 has npe, fall back to 1.8.0

### DIFF
--- a/inlong-agent/agent-plugins/pom.xml
+++ b/inlong-agent/agent-plugins/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <powermock.version>2.0.2</powermock.version>
-        <version.debezium>1.8.1.Final</version.debezium>
+        <version.debezium>1.8.0.Final</version.debezium>
     </properties>
 
     <dependencies>

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/BinlogTimeConverter.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/BinlogTimeConverter.java
@@ -102,7 +102,7 @@ public class BinlogTimeConverter implements CustomConverter<SchemaBuilder, Relat
             LocalDate date = LocalDate.ofEpochDay((Integer) input);
             return dateFormatter.format(date);
         }
-        return input.toString();
+        return input == null ? null : input.toString();
     }
 
     private String convertTime(Object input) {
@@ -113,14 +113,14 @@ public class BinlogTimeConverter implements CustomConverter<SchemaBuilder, Relat
             LocalTime time = LocalTime.ofSecondOfDay(seconds).withNano(nano);
             return timeFormatter.format(time);
         }
-        return input.toString();
+        return input == null ? null : input.toString();
     }
 
     private String convertDateTime(Object input) {
         if (input instanceof LocalDateTime) {
             return datetimeFormatter.format((LocalDateTime) input);
         }
-        return input.toString();
+        return input == null ? null : input.toString();
     }
 
     private String convertTimestamp(Object input) {
@@ -129,7 +129,7 @@ public class BinlogTimeConverter implements CustomConverter<SchemaBuilder, Relat
             LocalDateTime localDateTime = zonedDateTime.withZoneSameInstant(timestampZoneId).toLocalDateTime();
             return timestampFormatter.format(localDateTime);
         }
-        return input.toString();
+        return input == null ? null : input.toString();
     }
 
 }


### PR DESCRIPTION
### Title Name: [INLONG-3476][Agent] debezium 1.8.1 has npe, fall back to 1.8.0

Fixes #3476 

### Motivation

[INLONG-3476][Agent] debezium 1.8.1 has npe, fall back to 1.8.0

### Modifications

[INLONG-3476][Agent] debezium 1.8.1 has npe, fall back to 1.8.0

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (no)