### PR TITLE
[INLONG-3480][Manager] Fix null pointer exception when calling sink method in manager client

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongStreamSinkTransfer.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongStreamSinkTransfer.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.client.api.util;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.compress.utils.Lists;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.client.api.DataFormat;
 import org.apache.inlong.manager.client.api.DataSeparator;
 import org.apache.inlong.manager.client.api.SinkField;
@@ -152,7 +153,8 @@ public class InlongStreamSinkTransfer {
                 sinkFieldResponse.getFieldName(),
                 sinkFieldResponse.getFieldComment(),
                 null, sinkFieldResponse.getSourceFieldName(),
-                FieldType.forName(sinkFieldResponse.getSourceFieldType()),
+                StringUtils.isBlank(sinkFieldResponse.getSourceFieldType()) ? null :
+                        FieldType.forName(sinkFieldResponse.getSourceFieldType()),
                 sinkFieldResponse.getIsMetaField(),
                 sinkFieldResponse.getFieldFormat())).collect(Collectors.toList());
 
@@ -238,7 +240,8 @@ public class InlongStreamSinkTransfer {
             request.setFieldType(sinkField.getFieldType().toString());
             request.setFieldComment(sinkField.getFieldComment());
             request.setSourceFieldName(sinkField.getSourceFieldName());
-            request.setSourceFieldType(sinkField.getSourceFieldType().toString());
+            request.setSourceFieldType(
+                    sinkField.getSourceFieldType() == null ? null : sinkField.getSourceFieldType().toString());
             request.setIsMetaField(sinkField.getIsMetaField());
             request.setFieldFormat(sinkField.getFieldFormat());
             fieldRequestList.add(request);


### PR DESCRIPTION
### Title Name: [INLONG-3480][Manager] Fix null pointer exception when calling sink method in manager client

Fixes #3480 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
