### PR TITLE
[INLONG-3490][InLong] Make service types and ports configurable

### DIFF
--- a/docker/kubernetes/templates/agent-service.yaml
+++ b/docker/kubernetes/templates/agent-service.yaml
@@ -29,7 +29,7 @@ spec:
     - name: {{ .Values.agent.component }}-port
       protocol: TCP
       port: {{ .Values.agent.port }}
-      targetPort: {{ .Values.agent.component }}-port
+      targetPort: 8008
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.agent.component }}

--- a/docker/kubernetes/templates/agent-service.yaml
+++ b/docker/kubernetes/templates/agent-service.yaml
@@ -24,10 +24,12 @@ metadata:
     {{- include "inlong.commonLabels" . | nindent 4 }}
     component: {{ .Values.agent.component }}
 spec:
+  type: ClusterIP
   ports:
     - name: {{ .Values.agent.component }}-port
-      port: {{ .Values.agent.containerPort }}
-  type: ClusterIP
+      protocol: TCP
+      port: {{ .Values.agent.port }}
+      targetPort: {{ .Values.agent.component }}-port
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.agent.component }}

--- a/docker/kubernetes/templates/agent-statefulset.yaml
+++ b/docker/kubernetes/templates/agent-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
             do
               replica="{{ template "inlong.fullname" . }}-{{ .Values.dashboard.component }}-$i"
               host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.dashboard.component }}.{{ .Release.Namespace }}.svc.cluster.local"
-              port={{ .Values.dashboard.ports.webPort }}
+              port={{ .Values.dashboard.port }}
               until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
               do
                 echo "waiting for $replica to be ready"
@@ -66,7 +66,7 @@ spec:
             do
               replica="{{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}-$i"
               host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}.{{ .Release.Namespace }}.svc.cluster.local"
-              port={{ .Values.dataproxy.containerPort }}
+              port={{ .Values.dataproxy.port }}
               until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
               do
                 echo "waiting for $replica to be ready"
@@ -85,13 +85,13 @@ spec:
             - name: MANAGER_OPENAPI_IP
               value: {{ include "inlong.manager.hostname" . | quote }}
             - name: MANAGER_OPENAPI_PORT
-              value: {{ .Values.manager.containerPort | quote }}
+              value: {{ .Values.manager.port | quote }}
             - name: DATAPROXY_IP
               value: {{ include "inlong.dataproxy.hostname" . | quote }}
             - name: DATAPROXY_PORT
-              value: {{ .Values.dataproxy.containerPort | quote }}
+              value: {{ .Values.dataproxy.port | quote }}
             - name: AUDIT_PROXY_URL
-              value: "{{ template "inlong.audit.hostname" . }}:{{ .Values.audit.ports.webPort }}"
+              value: "{{ template "inlong.audit.hostname" . }}:{{ .Values.audit.port }}"
             {{- range $key, $value := .Values.agent.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/docker/kubernetes/templates/audit-service.yaml
+++ b/docker/kubernetes/templates/audit-service.yaml
@@ -29,7 +29,7 @@ spec:
     - name: {{ .Values.audit.component }}-port
       protocol: TCP
       port: {{ .Values.audit.port }}
-      targetPort: {{ .Values.audit.component }}-port
+      targetPort: 10081
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.audit.component }}

--- a/docker/kubernetes/templates/audit-service.yaml
+++ b/docker/kubernetes/templates/audit-service.yaml
@@ -24,10 +24,12 @@ metadata:
     {{- include "inlong.commonLabels" . | nindent 4 }}
     component: {{ .Values.audit.component }}
 spec:
-  ports:
-    - name: {{ .Values.audit.component}}-port
-      port: {{ .Values.audit.ports.webPort }}
   type: ClusterIP
+  ports:
+    - name: {{ .Values.audit.component }}-port
+      protocol: TCP
+      port: {{ .Values.audit.port }}
+      targetPort: {{ .Values.audit.component }}-port
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.audit.component }}

--- a/docker/kubernetes/templates/audit-statefulset.yaml
+++ b/docker/kubernetes/templates/audit-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
               do
                 replica="{{ template "inlong.fullname" . }}-{{ .Values.manager.component }}-$i"
                 host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.manager.component }}.{{ .Release.Namespace }}.svc.cluster.local"
-                port={{ .Values.manager.containerPort }}
+                port={{ .Values.manager.port }}
                 until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
                 do
                   echo "waiting for $replica to be ready"
@@ -94,7 +94,7 @@ spec:
             - name: MANAGER_OPENAPI_IP
               value: {{ include "inlong.manager.hostname" . | quote }}
             - name: MANAGER_OPENAPI_PORT
-              value: {{ .Values.manager.containerPort | quote }}
+              value: {{ .Values.manager.port | quote }}
             - name: PULSAR_BROKER_LIST
               value: {{ .Values.external.pulsar.serviceUrl | quote }}
             - name: TUBE_MASTER_LIST

--- a/docker/kubernetes/templates/audit-statefulset.yaml
+++ b/docker/kubernetes/templates/audit-statefulset.yaml
@@ -105,7 +105,7 @@ spec:
             {{- end }}
           ports:
             - name: {{ .Values.audit.component }}-port
-              containerPort: 8008
+              containerPort: 10081
           volumeMounts:
             - name: data
               mountPath: /data/collect-data

--- a/docker/kubernetes/templates/dashboard-service.yaml
+++ b/docker/kubernetes/templates/dashboard-service.yaml
@@ -25,10 +25,27 @@ metadata:
     component: {{ .Values.dashboard.component }}
 spec:
   type: {{ .Values.dashboard.service.type }}
+  {{- if and (eq .Values.dashboard.service.type "ClusterIP") .Values.dashboard.service.clusterIP }}
+  clusterIP: {{ .Values.dashboard.service.clusterIP }}
+  {{- end }}
   ports:
     - name: {{ .Values.dashboard.component }}-port
-      port: {{ .Values.dashboard.ports.webPort }}
-      nodePort: {{ .Values.dashboard.ports.webNodePort }}
+      protocol: TCP
+      port: {{ .Values.dashboard.port }}
+      targetPort: {{ .Values.dashboard.component }}-port
+      {{- if and (eq .Values.dashboard.service.type "NodePort") .Values.dashboard.service.nodePort }}
+      nodePort: {{ .Values.dashboard.service.nodePort }}
+      {{- end }}
+  {{- if and (eq .Values.dashboard.service.type "LoadBalancer") .Values.dashboard.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.dashboard.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.dashboard.service.type "ExternalName") .Values.dashboard.service.externalName }}
+  externalName: {{ .Values.dashboard.service.externalName }}
+  {{- end }}
+  {{- if .Values.dashboard.service.externalIPs }}
+  externalIPs:
+    {{- toYaml .Values.dashboard.service.externalIPs | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.dashboard.component }}

--- a/docker/kubernetes/templates/dashboard-service.yaml
+++ b/docker/kubernetes/templates/dashboard-service.yaml
@@ -32,7 +32,7 @@ spec:
     - name: {{ .Values.dashboard.component }}-port
       protocol: TCP
       port: {{ .Values.dashboard.port }}
-      targetPort: {{ .Values.dashboard.component }}-port
+      targetPort: 80
       {{- if and (eq .Values.dashboard.service.type "NodePort") .Values.dashboard.service.nodePort }}
       nodePort: {{ .Values.dashboard.service.nodePort }}
       {{- end }}

--- a/docker/kubernetes/templates/dashboard-statefulset.yaml
+++ b/docker/kubernetes/templates/dashboard-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
             do
               replica="{{ template "inlong.fullname" . }}-{{ .Values.manager.component }}-$i"
               host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.manager.component }}.{{ .Release.Namespace }}.svc.cluster.local"
-              port={{ .Values.manager.containerPort }}
+              port={{ .Values.manager.port }}
               until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
               do
                 echo "waiting for $replica to be ready"
@@ -65,7 +65,7 @@ spec:
           {{- end }}
           env:
             - name: MANAGER_API_ADDRESS
-              value: "{{ template "inlong.tubemqManager.hostname" .}}:{{ .Values.tubemqManager.containerPort }}"
+              value: "{{ template "inlong.tubemqManager.hostname" .}}:{{ .Values.tubemqManager.port }}"
           ports:
             - name: {{ .Values.dashboard.component }}-port
               containerPort: 80

--- a/docker/kubernetes/templates/dataproxy-service.yaml
+++ b/docker/kubernetes/templates/dataproxy-service.yaml
@@ -24,10 +24,28 @@ metadata:
     {{- include "inlong.commonLabels" . | nindent 4 }}
     component: {{ .Values.dataproxy.component }}
 spec:
+  type: {{ .Values.dataproxy.service.type }}
+  {{- if and (eq .Values.dataproxy.service.type "ClusterIP") .Values.dataproxy.service.clusterIP }}
+  clusterIP: {{ .Values.dataproxy.service.clusterIP }}
+  {{- end }}
   ports:
     - name: {{ .Values.dataproxy.component }}-port
-      port: {{ .Values.dataproxy.containerPort }}
-  type: ClusterIP
+      protocol: TCP
+      port: {{ .Values.dataproxy.port }}
+      targetPort: {{ .Values.dataproxy.component }}-port
+      {{- if and (eq .Values.dataproxy.service.type "NodePort") .Values.dataproxy.service.nodePort }}
+      nodePort: {{ .Values.dataproxy.service.nodePort }}
+      {{- end }}
+  {{- if and (eq .Values.dataproxy.service.type "LoadBalancer") .Values.dataproxy.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.dataproxy.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.dataproxy.service.type "ExternalName") .Values.dataproxy.service.externalName }}
+  externalName: {{ .Values.dataproxy.service.externalName }}
+  {{- end }}
+  {{- if .Values.dataproxy.service.externalIPs }}
+  externalIPs:
+    {{- toYaml .Values.dataproxy.service.externalIPs | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.dataproxy.component }}

--- a/docker/kubernetes/templates/dataproxy-service.yaml
+++ b/docker/kubernetes/templates/dataproxy-service.yaml
@@ -32,7 +32,7 @@ spec:
     - name: {{ .Values.dataproxy.component }}-port
       protocol: TCP
       port: {{ .Values.dataproxy.port }}
-      targetPort: {{ .Values.dataproxy.component }}-port
+      targetPort: 46801
       {{- if and (eq .Values.dataproxy.service.type "NodePort") .Values.dataproxy.service.nodePort }}
       nodePort: {{ .Values.dataproxy.service.nodePort }}
       {{- end }}

--- a/docker/kubernetes/templates/dataproxy-statefulset.yaml
+++ b/docker/kubernetes/templates/dataproxy-statefulset.yaml
@@ -18,7 +18,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component}}
+  name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "inlong.commonLabels" . | nindent 4 }}
@@ -48,7 +48,7 @@ spec:
             do
               replica="{{ template "inlong.fullname" . }}-{{ .Values.manager.component }}-$i"
               host="$replica.{{ template "inlong.fullname" . }}-{{ .Values.manager.component }}.{{ .Release.Namespace }}.svc.cluster.local"
-              port={{ .Values.manager.containerPort }}
+              port={{ .Values.manager.port }}
               until [ $(nc -z -w 5 $host $port; echo $?) -eq 0 ]
               do
                 echo "waiting for $replica to be ready"
@@ -56,7 +56,7 @@ spec:
               done
             done
       containers:
-        - name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component}}
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}
           image: {{ .Values.images.dataproxy.repository }}:{{ .Values.images.dataproxy.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- if .Values.dataproxy.resources }}
@@ -67,9 +67,9 @@ spec:
             - name: MANAGER_OPENAPI_IP
               value: {{ include "inlong.manager.hostname" . | quote }}
             - name: MANAGER_OPENAPI_PORT
-              value: {{ .Values.manager.containerPort | quote }}
+              value: {{ .Values.manager.port | quote }}
             - name: AUDIT_PROXY_URL
-              value: "{{ template "inlong.audit.hostname" . }}:{{ .Values.audit.ports.webPort }}"
+              value: "{{ template "inlong.audit.hostname" . }}:{{ .Values.audit.port }}"
             {{- range $key, $value := .Values.dataproxy.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/docker/kubernetes/templates/manager-service.yaml
+++ b/docker/kubernetes/templates/manager-service.yaml
@@ -24,10 +24,28 @@ metadata:
     {{- include "inlong.commonLabels" . | nindent 4 }}
     component: {{ .Values.manager.component }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.manager.service.type }}
+  {{- if and (eq .Values.manager.service.type "ClusterIP") .Values.manager.service.clusterIP }}
+  clusterIP: {{ .Values.manager.service.clusterIP }}
+  {{- end }}
   ports:
     - name: {{ .Values.manager.component }}-port
-      port: {{ .Values.manager.containerPort }}
+      protocol: TCP
+      port: {{ .Values.manager.port }}
+      targetPort: {{ .Values.manager.component }}-port
+      {{- if and (eq .Values.manager.service.type "NodePort") .Values.manager.service.nodePort }}
+      nodePort: {{ .Values.manager.service.nodePort }}
+      {{- end }}
+  {{- if and (eq .Values.manager.service.type "LoadBalancer") .Values.manager.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.manager.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.manager.service.type "ExternalName") .Values.manager.service.externalName }}
+  externalName: {{ .Values.manager.service.externalName }}
+  {{- end }}
+  {{- if .Values.manager.service.externalIPs }}
+  externalIPs:
+    {{- toYaml .Values.manager.service.externalIPs | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.manager.component }}

--- a/docker/kubernetes/templates/manager-service.yaml
+++ b/docker/kubernetes/templates/manager-service.yaml
@@ -32,7 +32,7 @@ spec:
     - name: {{ .Values.manager.component }}-port
       protocol: TCP
       port: {{ .Values.manager.port }}
-      targetPort: {{ .Values.manager.component }}-port
+      targetPort: 8083
       {{- if and (eq .Values.manager.service.type "NodePort") .Values.manager.service.nodePort }}
       nodePort: {{ .Values.manager.service.nodePort }}
       {{- end }}

--- a/docker/kubernetes/templates/mysql-service.yaml
+++ b/docker/kubernetes/templates/mysql-service.yaml
@@ -30,7 +30,7 @@ spec:
     - name: {{ .Values.mysql.component }}-port
       protocol: TCP
       port: {{ .Values.mysql.ports.server }}
-      targetPort: {{ .Values.mysql.component }}-port
+      targetPort: 3306
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.mysql.component }}

--- a/docker/kubernetes/templates/mysql-service.yaml
+++ b/docker/kubernetes/templates/mysql-service.yaml
@@ -25,10 +25,12 @@ metadata:
     {{- include "inlong.commonLabels" . | nindent 4 }}
     component: {{ .Values.mysql.component }}
 spec:
-  ports:
-    - name: {{ .Values.mysql.component }}-server-port
-      port: {{ .Values.mysql.ports.server }}
   clusterIP: None
+  ports:
+    - name: {{ .Values.mysql.component }}-port
+      protocol: TCP
+      port: {{ .Values.mysql.ports.server }}
+      targetPort: {{ .Values.mysql.component }}-port
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.mysql.component }}

--- a/docker/kubernetes/templates/tubemq-broker-service.yaml
+++ b/docker/kubernetes/templates/tubemq-broker-service.yaml
@@ -28,10 +28,14 @@ metadata:
 spec:
   type: {{ .Values.tubemqBroker.service.type }}
   ports:
-    - name: web-port
+    - name: {{ .Values.tubemqBroker.component }}-web-port
+      protocol: TCP
       port: {{ .Values.tubemqBroker.ports.webPort }}
-    - name: rpc-port
+      targetPort: 8081
+    - name: {{ .Values.tubemqBroker.component }}-rpc-port
+      protocol: TCP
       port: {{ .Values.tubemqBroker.ports.rpcPort }}
+      targetPort: 8123
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.tubemqBroker.component }}

--- a/docker/kubernetes/templates/tubemq-broker-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-broker-statefulset.yaml
@@ -102,10 +102,10 @@ spec:
             - >
               /config-scripts/run
           ports:
-            - name: web-port
-              containerPort: {{ .Values.tubemqBroker.ports.webPort }}
-            - name: rpc-port
-              containerPort: {{ .Values.tubemqBroker.ports.rpcPort }}
+            - name: {{ .Values.tubemqBroker.component }}-web-port
+              containerPort: 8081
+            - name: {{ .Values.tubemqBroker.component }}-rpc-port
+              containerPort: 8123
           env:
             - name: MY_POD_IP
               valueFrom:

--- a/docker/kubernetes/templates/tubemq-manager-service.yaml
+++ b/docker/kubernetes/templates/tubemq-manager-service.yaml
@@ -29,7 +29,7 @@ spec:
     - name: {{ .Values.tubemqManager.component }}-port
       protocol: TCP
       port: {{ .Values.tubemqManager.port }}
-      targetPort: {{ .Values.tubemqManager.component }}-port
+      targetPort: 8089
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.tubemqManager.component }}

--- a/docker/kubernetes/templates/tubemq-manager-service.yaml
+++ b/docker/kubernetes/templates/tubemq-manager-service.yaml
@@ -24,10 +24,12 @@ metadata:
     {{- include "inlong.commonLabels" . | nindent 4 }}
     component: {{ .Values.tubemqManager.component }}
 spec:
+  type: ClusterIP
   ports:
     - name: {{ .Values.tubemqManager.component }}-port
-      port: {{ .Values.tubemqManager.containerPort }}
-  type: ClusterIP
+      protocol: TCP
+      port: {{ .Values.tubemqManager.port }}
+      targetPort: {{ .Values.tubemqManager.component }}-port
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.tubemqManager.component }}

--- a/docker/kubernetes/templates/tubemq-master-service.yaml
+++ b/docker/kubernetes/templates/tubemq-master-service.yaml
@@ -28,12 +28,18 @@ metadata:
 spec:
   type: {{ .Values.tubemqMaster.service.type }}
   ports:
-    - name: web-port
+    - name: {{ .Values.tubemqMaster.component }}-web-port
+      protocol: TCP
       port: {{ .Values.tubemqMaster.ports.webPort }}
-    - name: help-port
+      targetPort: 8080
+    - name: {{ .Values.tubemqMaster.component }}-help-port
+      protocol: TCP
       port: {{ .Values.tubemqMaster.ports.helpPort }}
-    - name: rpc-port
+      targetPort: 9001
+    - name: {{ .Values.tubemqMaster.component }}-rpc-port
+      protocol: TCP
       port: {{ .Values.tubemqMaster.ports.rpcPort }}
+      targetPort: 8715
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.tubemqMaster.component }}

--- a/docker/kubernetes/templates/tubemq-master-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-master-statefulset.yaml
@@ -102,12 +102,12 @@ spec:
             - >
               /config-scripts/run
           ports:
-            - name: web-port
-              containerPort: {{ .Values.tubemqMaster.ports.webPort }}
-            - name: help-port
-              containerPort: {{ .Values.tubemqMaster.ports.helpPort }}
-            - name: rpc-port
-              containerPort: {{ .Values.tubemqMaster.ports.rpcPort }}
+            - name: {{ .Values.tubemqMaster.component }}-web-port
+              containerPort: 8080
+            - name: {{ .Values.tubemqMaster.component }}-help-port
+              containerPort: 9001
+            - name: {{ .Values.tubemqMaster.component }}-rpc-port
+              containerPort: 8715
           env:
             - name: MY_POD_IP
               valueFrom:

--- a/docker/kubernetes/templates/zookeeper-service.yaml
+++ b/docker/kubernetes/templates/zookeeper-service.yaml
@@ -26,14 +26,20 @@ metadata:
   annotations:
 {{ toYaml .Values.zookeeper.service.annotations | indent 4 }}
 spec:
-  ports:
-    - name: follower
-      port: {{ .Values.zookeeper.ports.follower }}
-    - name: leader-election
-      port: {{ .Values.zookeeper.ports.leaderElection }}
-    - name: client
-      port: {{ .Values.zookeeper.ports.client }}
   clusterIP: None
+  ports:
+    - name: {{ .Values.zookeeper.component }}-client-port
+      protocol: TCP
+      port: {{ .Values.zookeeper.ports.client }}
+      targetPort: 2181
+    - name: {{ .Values.zookeeper.component }}-follower-port
+      protocol: TCP
+      port: {{ .Values.zookeeper.ports.follower }}
+      targetPort: 2888
+    - name: {{ .Values.zookeeper.component }}-leader-election-port
+      protocol: TCP
+      port: {{ .Values.zookeeper.ports.leaderElection }}
+      targetPort: 3888
   selector:
     {{- include "inlong.matchLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}

--- a/docker/kubernetes/templates/zookeeper-statefulset.yaml
+++ b/docker/kubernetes/templates/zookeeper-statefulset.yaml
@@ -83,12 +83,12 @@ spec:
             - >
               /config-scripts/run
           ports:
-            - name: client
-              containerPort: {{ .Values.zookeeper.ports.client }}
-            - name: follower
-              containerPort: {{ .Values.zookeeper.ports.follower }}
-            - name: leader-election
-              containerPort: {{ .Values.zookeeper.ports.leaderElection }}
+            - name: {{ .Values.zookeeper.component }}-client-port
+              containerPort: 2181
+            - name: {{ .Values.zookeeper.component }}-follower-port
+              containerPort: 2888
+            - name: {{ .Values.zookeeper.component }}-leader-election-port
+              containerPort: 3888
           env:
             - name: ZOOKEEPER_SERVERS
               value:

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -92,6 +92,7 @@ dashboard:
     # clusterIP is the IP address of the service and is usually assigned randomly by the master when service type is ClusterIP
     clusterIP:
     # nodePort is the port on each node on which this service is exposed when service type is NodePort
+    # the range of valid ports is 30000-32767
     nodePort: 30080
     # when service type is LoadBalancer, LoadBalancer will get created with the IP specified in this field
     loadBalancerIP:
@@ -114,7 +115,8 @@ dataproxy:
     # clusterIP is the IP address of the service and is usually assigned randomly by the master when service type is ClusterIP
     clusterIP:
     # nodePort is the port on each node on which this service is exposed when service type is NodePort
-    nodePort: 46801
+    # the range of valid ports is 30000-32767
+    nodePort: 30801
     # when service type is LoadBalancer, LoadBalancer will get created with the IP specified in this field
     loadBalancerIP:
     # externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service, requires service type to be ExternalName
@@ -158,7 +160,8 @@ manager:
     # clusterIP is the IP address of the service and is usually assigned randomly by the master when service type is ClusterIP
     clusterIP:
     # nodePort is the port on each node on which this service is exposed when service type is NodePort
-    nodePort: 38083
+    # the range of valid ports is 30000-32767
+    nodePort: 30083
     # when service type is LoadBalancer, LoadBalancer will get created with the IP specified in this field
     loadBalancerIP:
     # externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service, requires service type to be ExternalName

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -68,7 +68,7 @@ agent:
     requests:
       cpu: 1
       memory: "1Gi"
-  containerPort: 8008
+  port: 8008
   env:
     AGENT_JVM_HEAP_OPTS: >-
       -XX:+UseContainerSupport
@@ -85,11 +85,20 @@ dashboard:
     requests:
       cpu: 1
       memory: "1Gi"
-  ports:
-    webPort: 80
-    webNodePort: 30080
+  port: 80
   service:
-    type: LoadBalancer
+    # type determines how the service is exposed. Defaults to NodePort. Valid options are ClusterIP, NodePort, LoadBalancer, and ExternalName
+    type: NodePort
+    # clusterIP is the IP address of the service and is usually assigned randomly by the master when service type is ClusterIP
+    clusterIP:
+    # nodePort is the port on each node on which this service is exposed when service type is NodePort
+    nodePort: 30080
+    # when service type is LoadBalancer, LoadBalancer will get created with the IP specified in this field
+    loadBalancerIP:
+    # externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service, requires service type to be ExternalName
+    externalName:
+    # externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service
+    externalIPs:
 
 dataproxy:
   component: "dataproxy"
@@ -98,7 +107,20 @@ dataproxy:
     requests:
       cpu: 1
       memory: "1Gi"
-  containerPort: 46801
+  port: 46801
+  service:
+    # type determines how the service is exposed. Defaults to NodePort. Valid options are ClusterIP, NodePort, LoadBalancer, and ExternalName
+    type: NodePort
+    # clusterIP is the IP address of the service and is usually assigned randomly by the master when service type is ClusterIP
+    clusterIP:
+    # nodePort is the port on each node on which this service is exposed when service type is NodePort
+    nodePort: 46801
+    # when service type is LoadBalancer, LoadBalancer will get created with the IP specified in this field
+    loadBalancerIP:
+    # externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service, requires service type to be ExternalName
+    externalName:
+    # externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service
+    externalIPs:
   env:
     DATAPROXY_JVM_HEAP_OPTS: >-
       -XX:+UseContainerSupport
@@ -113,7 +135,7 @@ tubemqManager:
     requests:
       cpu: 1
       memory: "1Gi"
-  containerPort: 8089
+  port: 8089
   env:
     TUBE_MANAGER_JVM_HEAP_OPTS: >-
       -XX:+UseContainerSupport
@@ -129,9 +151,20 @@ manager:
     requests:
       cpu: 1
       memory: "1Gi"
-  containerPort: 8083
-  username: "root"
-  password: "inlong"
+  port: 8083
+  service:
+    # type determines how the service is exposed. Defaults to NodePort. Valid options are ClusterIP, NodePort, LoadBalancer, and ExternalName
+    type: NodePort
+    # clusterIP is the IP address of the service and is usually assigned randomly by the master when service type is ClusterIP
+    clusterIP:
+    # nodePort is the port on each node on which this service is exposed when service type is NodePort
+    nodePort: 38083
+    # when service type is LoadBalancer, LoadBalancer will get created with the IP specified in this field
+    loadBalancerIP:
+    # externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service, requires service type to be ExternalName
+    externalName:
+    # externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service
+    externalIPs:
   env:
     MANAGER_JVM_HEAP_OPTS: >-
       -XX:+UseContainerSupport
@@ -148,8 +181,7 @@ audit:
     requests:
       cpu: 1
       memory: "1Gi"
-  ports:
-    webPort: 10081
+  port: 10081
   env:
     AUDIT_JVM_HEAP_OPTS: >-
       -XX:+UseContainerSupport


### PR DESCRIPTION
Fixes: #3490

### Motivation

Make `dashboard`, `dataproxy` and `manager` service types and ports configurable. Like this:

```yaml
service:
  # type determines how the service is exposed. Defaults to NodePort. Valid options are ClusterIP, NodePort, LoadBalancer, and ExternalName
  type: NodePort
  # clusterIP is the IP address of the service and is usually assigned randomly by the master when service type is ClusterIP
  clusterIP:
  # nodePort is the port on each node on which this service is exposed when service type is NodePort
  # the range of valid ports is 30000-32767
  nodePort: 30801
  # when service type is LoadBalancer, LoadBalancer will get created with the IP specified in this field
  loadBalancerIP:
  # externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service, requires service type to be ExternalName
  externalName:
  # externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service
  externalIPs:
```

### Modifications

- `docker/kubernetes`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
