### PR TITLE
[INLONG-3547][TubeMQ] Fix curl and ps commands not found bug in docker container 

### DIFF
--- a/inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile
+++ b/inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile
@@ -17,7 +17,7 @@
 FROM zookeeper:3.4
 # install tools for debug
 RUN apt-get update \
-    && apt-get install -y net-tools vim \
+    && apt-get install -y net-tools vim curl procps \
     && rm -rf /var/lib/apt/lists/*
 # add tarball from target output
 ARG TUBEMQ_TARBALL


### PR DESCRIPTION
fixes: #3547

### Motivation

Install `curl` and `procps` packages in tubemq docker container.

### Modifications

- `inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
