### PR TITLE
[INLONG-3560][TubeMQ] Fix invalid port names in tubemq pods

### DIFF
--- a/docker/kubernetes/templates/tubemq-broker-service.yaml
+++ b/docker/kubernetes/templates/tubemq-broker-service.yaml
@@ -28,11 +28,11 @@ metadata:
 spec:
   type: {{ .Values.tubemqBroker.service.type }}
   ports:
-    - name: {{ .Values.tubemqBroker.component }}-web-port
+    - name: broker-web-port
       protocol: TCP
       port: {{ .Values.tubemqBroker.ports.webPort }}
       targetPort: 8081
-    - name: {{ .Values.tubemqBroker.component }}-rpc-port
+    - name: broker-rpc-port
       protocol: TCP
       port: {{ .Values.tubemqBroker.ports.rpcPort }}
       targetPort: 8123

--- a/docker/kubernetes/templates/tubemq-broker-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-broker-statefulset.yaml
@@ -102,9 +102,9 @@ spec:
             - >
               /config-scripts/run
           ports:
-            - name: {{ .Values.tubemqBroker.component }}-web-port
+            - name: broker-web-port
               containerPort: 8081
-            - name: {{ .Values.tubemqBroker.component }}-rpc-port
+            - name: broker-rpc-port
               containerPort: 8123
           env:
             - name: MY_POD_IP

--- a/docker/kubernetes/templates/tubemq-manager-service.yaml
+++ b/docker/kubernetes/templates/tubemq-manager-service.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: {{ .Values.tubemqManager.component }}-port
+    - name: tubemq-mgr-port
       protocol: TCP
       port: {{ .Values.tubemqManager.port }}
       targetPort: 8089

--- a/docker/kubernetes/templates/tubemq-manager-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-manager-statefulset.yaml
@@ -98,6 +98,6 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           ports:
-            - name: {{ .Values.tubemqManager.component }}-port
+            - name: tubemq-mgr-port
               containerPort: 8089
       restartPolicy: Always

--- a/docker/kubernetes/templates/tubemq-master-service.yaml
+++ b/docker/kubernetes/templates/tubemq-master-service.yaml
@@ -28,15 +28,15 @@ metadata:
 spec:
   type: {{ .Values.tubemqMaster.service.type }}
   ports:
-    - name: {{ .Values.tubemqMaster.component }}-web-port
+    - name: mstr-web-port
       protocol: TCP
       port: {{ .Values.tubemqMaster.ports.webPort }}
       targetPort: 8080
-    - name: {{ .Values.tubemqMaster.component }}-help-port
+    - name: mstr-help-port
       protocol: TCP
       port: {{ .Values.tubemqMaster.ports.helpPort }}
       targetPort: 9001
-    - name: {{ .Values.tubemqMaster.component }}-rpc-port
+    - name: mstr-rpc-port
       protocol: TCP
       port: {{ .Values.tubemqMaster.ports.rpcPort }}
       targetPort: 8715

--- a/docker/kubernetes/templates/tubemq-master-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-master-statefulset.yaml
@@ -102,11 +102,11 @@ spec:
             - >
               /config-scripts/run
           ports:
-            - name: {{ .Values.tubemqMaster.component }}-web-port
+            - name: mstr-web-port
               containerPort: 8080
-            - name: {{ .Values.tubemqMaster.component }}-help-port
+            - name: mstr-help-port
               containerPort: 9001
-            - name: {{ .Values.tubemqMaster.component }}-rpc-port
+            - name: mstr-rpc-port
               containerPort: 8715
           env:
             - name: MY_POD_IP

--- a/docker/kubernetes/templates/zookeeper-service.yaml
+++ b/docker/kubernetes/templates/zookeeper-service.yaml
@@ -28,15 +28,15 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - name: {{ .Values.zookeeper.component }}-client-port
+    - name: zk-client-port
       protocol: TCP
       port: {{ .Values.zookeeper.ports.client }}
       targetPort: 2181
-    - name: {{ .Values.zookeeper.component }}-follower-port
+    - name: zk-comm-port
       protocol: TCP
       port: {{ .Values.zookeeper.ports.follower }}
       targetPort: 2888
-    - name: {{ .Values.zookeeper.component }}-leader-election-port
+    - name: zk-elect-port
       protocol: TCP
       port: {{ .Values.zookeeper.ports.leaderElection }}
       targetPort: 3888

--- a/docker/kubernetes/templates/zookeeper-statefulset.yaml
+++ b/docker/kubernetes/templates/zookeeper-statefulset.yaml
@@ -83,11 +83,11 @@ spec:
             - >
               /config-scripts/run
           ports:
-            - name: {{ .Values.zookeeper.component }}-client-port
+            - name: zk-client-port
               containerPort: 2181
-            - name: {{ .Values.zookeeper.component }}-follower-port
+            - name: zk-comm-port
               containerPort: 2888
-            - name: {{ .Values.zookeeper.component }}-leader-election-port
+            - name: zk-elect-port
               containerPort: 3888
           env:
             - name: ZOOKEEPER_SERVERS


### PR DESCRIPTION
Fixes: #3560

### Motivation

Fix invalid port names in tubemq pods.
**The port name should be no more than 15 characters.**

All pods can be started correctly by command:

```
sudo kubectl get pods -n inlong -o wide
```

![image](https://user-images.githubusercontent.com/49934421/162116571-76e7ab4e-018b-4755-8f0e-b9d269fe3847.png)

### Modifications

Shorten pod names.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
