### PR TITLE
[INLONG-3564][SDK] javadoc comments in wrong place

### DIFF
--- a/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/protocol/ProxyEvent.java
+++ b/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/protocol/ProxyEvent.java
@@ -25,10 +25,6 @@ import org.apache.inlong.sdk.commons.protocol.ProxySdk.MessageObj;
  * 
  * ProxyEvent
  */
-/**
- * 
- * ProxyEvent
- */
 public class ProxyEvent extends SdkEvent {
 
     protected long sourceTime;


### PR DESCRIPTION
### Title Name: [INLONG-XYZ][component] Title of the pull request

where *XYZ* should be replaced by the actual issue number.

Fixes https://github.com/apache/incubator-inlong/issues/3564

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
