### PR TITLE
[INLONG-3591][Sort-Standalone] Support multiple SortTask with the one-on-one relationship of Source and SortTask.

### DIFF
--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/InLongTopicManagerImpl.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/InLongTopicManagerImpl.java
@@ -66,8 +66,8 @@ public class InLongTopicManagerImpl extends InLongTopicManager {
         super(context, queryConsumeConfig);
         updateMetaDataWorker = new UpdateMetaDataThread(context.getConfig().getUpdateMetaDataIntervalSec(),
                 TimeUnit.SECONDS);
-        String threadName = "sortsdk_inlongtopic_manager_"
-                + StringUtil.formatDate(new Date(), "yyyy-MM-dd HH:mm:ss");
+        String threadName = "sortsdk_inlongtopic_manager_" + context.getConfig().getSortTaskId()
+                + "_" + StringUtil.formatDate(new Date(), "yyyy-MM-dd HH:mm:ss");
         updateMetaDataWorker.start(threadName);
     }
 

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/DefaultEvent2IndexRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/DefaultEvent2IndexRequestHandler.java
@@ -114,7 +114,7 @@ public class DefaultEvent2IndexRequestHandler implements IEvent2IndexRequestHand
     public static String getExtInfo(ProfileEvent event) {
         String extinfoValue = event.getHeaders().get(KEY_EXTINFO);
         if (extinfoValue != null) {
-            return extinfoValue;
+            return KEY_EXTINFO + "=" + extinfoValue;
         }
         extinfoValue = KEY_EXTINFO + "=" + event.getHeaders().get(EventConstants.HEADER_KEY_SOURCE_IP);
         return extinfoValue;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/DefaultEvent2IndexRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/DefaultEvent2IndexRequestHandler.java
@@ -23,9 +23,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.inlong.sdk.commons.protocol.EventConstants;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
 import org.apache.inlong.sort.standalone.utils.UnescapeHelper;
 
@@ -34,6 +34,8 @@ import org.apache.inlong.sort.standalone.utils.UnescapeHelper;
  * DefaultEvent2IndexRequestHandler
  */
 public class DefaultEvent2IndexRequestHandler implements IEvent2IndexRequestHandler {
+
+    public static final String KEY_EXTINFO = "extinfo";
 
     private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     private AtomicLong esIndexIndex = new AtomicLong(System.currentTimeMillis());
@@ -110,16 +112,11 @@ public class DefaultEvent2IndexRequestHandler implements IEvent2IndexRequestHand
      * @return
      */
     public static String getExtInfo(ProfileEvent event) {
-        if (event.getHeaders().size() > 0) {
-            StringBuilder sBuilder = new StringBuilder();
-            for (Entry<String, String> extInfo : event.getHeaders().entrySet()) {
-                String key = extInfo.getKey();
-                String value = extInfo.getValue();
-                sBuilder.append(key).append('=').append(value).append('&');
-            }
-            String extinfo = sBuilder.substring(0, sBuilder.length() - 1);
-            return extinfo;
+        String extinfoValue = event.getHeaders().get(KEY_EXTINFO);
+        if (extinfoValue != null) {
+            return extinfoValue;
         }
-        return "";
+        extinfoValue = KEY_EXTINFO + "=" + event.getHeaders().get(EventConstants.HEADER_KEY_SOURCE_IP);
+        return extinfoValue;
     }
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -106,7 +106,9 @@ public final class SortSdkSource extends AbstractSource implements Configurable,
     public void stop() {
         pool.shutdownNow();
         LOG.info("Close sort client {}.", taskName);
-        sortClient.close();
+        if (sortClient != null) {
+            sortClient.close();
+        }
     }
 
     /**


### PR DESCRIPTION
### Title Name: [INLONG-3591][Sort-Standalone] Support multiple SortTask with the one-on-one relationship of Source and SortTask.

Fixes #3591 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
