### PR TITLE
[INLONG-3603][Manager] The serialization type cannot be empty for File source

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/file/FileSourceRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/file/FileSourceRequest.java
@@ -32,8 +32,8 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@ApiModel(value = "Request of the kafka source info")
 @JsonTypeDefine(value = SourceType.SOURCE_FILE)
+@ApiModel(value = "Request of the kafka source info")
 public class FileSourceRequest extends SourceRequest {
 
     @ApiModelProperty("Agent IP address")

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/file/FileSourceOperation.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/file/FileSourceOperation.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.service.source.file;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.enums.SourceType;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
@@ -44,8 +45,12 @@ public class FileSourceOperation extends AbstractSourceOperation {
     @Override
     protected void setTargetEntity(SourceRequest request, StreamSourceEntity targetEntity) {
         FileSourceRequest sourceRequest = (FileSourceRequest) request;
-        CommonBeanUtils.copyProperties(sourceRequest, targetEntity, true);
+        if (StringUtils.isBlank(sourceRequest.getSerializationType())) {
+            throw new BusinessException("The serialization type cannot be empty for File source");
+        }
+
         try {
+            CommonBeanUtils.copyProperties(sourceRequest, targetEntity, true);
             FileSourceDTO dto = FileSourceDTO.getFromRequest(sourceRequest);
             targetEntity.setExtParams(objectMapper.writeValueAsString(dto));
         } catch (Exception e) {

--- a/inlong-tubemq/pom.xml
+++ b/inlong-tubemq/pom.xml
@@ -94,7 +94,7 @@
             <name>berkeleydb-je</name>
             <url>https://download.oracle.com/maven/</url>
             <releases>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </releases>
             <snapshots>
                 <enabled>false</enabled>


### PR DESCRIPTION
### Title Name: [INLONG-3603][Manager] The serialization type cannot be empty for File source

Fixes #3603

### Motivation

The serialization type cannot be empty for the File source.

### Verifying this change

- [X] Make sure that the change passes the CI checks.
