### PR TITLE
[INLONG-3659][DataProxy] DataProxy add manageable entry, used to stop some services(TCP service). 

### DIFF
--- a/inlong-dataproxy/bin/dataproxy-stop.sh
+++ b/inlong-dataproxy/bin/dataproxy-stop.sh
@@ -19,5 +19,15 @@
 # under the License.
 #
 
+#stopService
+cd "$(dirname "$0")"/../conf || exit
+adminHost=`more common.properties |grep "adminTask.host"|awk -F"=" '{print $2}'`
+adminPort=`more common.properties |grep "adminTask.port"|awk -F"=" '{print $2}'`
+if [ ${adminHost} ] && [ ${adminPort} ]; then
+    curl -X POST -d'[{"headers":{"cmd":"stopService","sourceName":"*"},"body":"body"}]' "http://${adminHost}:${adminPort}"
+    echo "stop server and sleep."
+    sleep 61s
+fi
+
 # this program kills the dataProxy
 ps -ef |grep "org.apache.inlong.dataproxy.node.Application"|grep "inlong-dataproxy"|grep -v grep|awk '{print $2}'|xargs kill -9

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -38,3 +38,8 @@ audit.proxys=127.0.0.1:10081
 report.config.log.enable=true
 report.config.log.server.url=http://127.0.0.1:8083/api/inlong/manager/openapi/stream/log/reportConfigLogStatus
 report.config.log.interval=60000
+
+#adminTask.host=127.0.0.1
+#adminTask.port=9082
+#adminTask.handler=org.apache.inlong.sdk.commons.admin.AdminJsonHandler
+#adminTask.handler.stopService.type=org.apache.inlong.dataproxy.admin.ProxyServiceAdminEventHandler

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/admin/ProxyServiceAdminEventHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/admin/ProxyServiceAdminEventHandler.java
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.admin;
+
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.inlong.sdk.commons.admin.AbstractAdminEventHandler;
+
+import java.lang.management.ManagementFactory;
+import java.util.Set;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.apache.inlong.dataproxy.admin.ProxyServiceMBean.MBEAN_TYPE;
+
+/**
+ * StopServiceAdminEventHandler
+ */
+public class ProxyServiceAdminEventHandler extends AbstractAdminEventHandler {
+
+    /**
+     * configure
+     * 
+     * @param context
+     */
+    @Override
+    public void configure(Context context) {
+    }
+
+    /**
+     * process
+     * 
+     * @param cmd
+     * @param event
+     * @param response
+     */
+    @Override
+    public void process(String cmd, Event event, HttpServletResponse response) {
+        LOG.info("start to process admin task:{}", cmd);
+        String sourceName = event.getHeaders().get(ProxyServiceMBean.KEY_SOURCENAME);
+        switch (cmd) {
+            case ProxyServiceMBean.METHOD_STOPSERVICE :
+                if (sourceName == null) {
+                    break;
+                }
+                if (StringUtils.equals(sourceName, ProxyServiceMBean.ALL_SOURCENAME)) {
+                    this.processAll(cmd, event, response);
+                } else {
+                    this.processOne(cmd, sourceName, response);
+                }
+                break;
+            default :
+                break;
+        }
+        LOG.info("end to process admin task:{}", cmd);
+    }
+
+    /**
+     * processOne
+     * 
+     * @param cmd
+     * @param sourceName
+     * @param response
+     */
+    private void processOne(String cmd, String sourceName, HttpServletResponse response) {
+        LOG.info("start to processOne admin task:{},sort task:{}", cmd, sourceName);
+        StringBuilder result = new StringBuilder();
+        try {
+            String beanName = JMX_DOMAIN + DOMAIN_SEPARATOR
+                    + JMX_TYPE + PROPERTY_EQUAL + MBEAN_TYPE + PROPERTY_SEPARATOR
+                    + JMX_NAME + PROPERTY_EQUAL + sourceName;
+
+            ObjectName objName = new ObjectName(beanName);
+            final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            ObjectInstance mbean = mbs.getObjectInstance(objName);
+            LOG.info("getObjectInstance for type:{},name:{},result:{}", MBEAN_TYPE, sourceName, mbean);
+            String className = mbean.getClassName();
+            Class<?> clazz = ClassUtils.getClass(className);
+            if (ClassUtils.isAssignable(clazz, ProxyServiceMBean.class)) {
+                mbs.invoke(mbean.getObjectName(), cmd, null, null);
+                result.append(String.format("Execute command:%s success in bean:%s\n",
+                        cmd, mbean.getObjectName().toString()));
+            }
+            this.outputResponse(response, result.toString());
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            result.append(e.getMessage());
+            this.outputResponse(response, result.toString());
+        }
+        LOG.info("end to processOne admin task:{},sort task:{}", cmd, sourceName);
+    }
+
+    /**
+     * processAll
+     * 
+     * @param cmd
+     * @param event
+     * @param response
+     */
+    private void processAll(String cmd, Event event, HttpServletResponse response) {
+        LOG.info("start to processAll admin task:{}", cmd);
+        StringBuilder result = new StringBuilder();
+        try {
+            String beanName = JMX_DOMAIN + DOMAIN_SEPARATOR
+                    + JMX_TYPE + PROPERTY_EQUAL + MBEAN_TYPE + PROPERTY_SEPARATOR
+                    + "*";
+            ObjectName objName = new ObjectName(beanName.toString());
+            final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            Set<ObjectInstance> mbeans = mbs.queryMBeans(objName, null);
+            LOG.info("queryMBeans for type:{},result:{}", MBEAN_TYPE, mbeans);
+            for (ObjectInstance mbean : mbeans) {
+                ObjectName beanObjectName = mbean.getObjectName();
+                String className = mbean.getClassName();
+                Class<?> clazz = ClassUtils.getClass(className);
+                if (ClassUtils.isAssignable(clazz, ProxyServiceMBean.class)) {
+                    mbs.invoke(mbean.getObjectName(), cmd, null, null);
+                    result.append(String.format("Execute command:%s success in bean:%s\n",
+                            cmd, beanObjectName.toString()));
+                }
+            }
+            this.outputResponse(response, result.toString());
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            result.append(e.getMessage());
+            this.outputResponse(response, result.toString());
+        }
+        LOG.info("end to processAll admin task:{}", cmd);
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/admin/ProxyServiceMBean.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/admin/ProxyServiceMBean.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.admin;
+
+import javax.management.MXBean;
+
+/**
+ * ProxyServiceMBean<br>
+ * Stop TCP service before stopping DataProxy process.<br>
+ * TCP service will response error to agent, agent will resend data to other DataProxy.<br>
+ * After DataProxy send all channel data to cache cluster, DataProxy can be stopped.<br>
+ */
+@MXBean
+public interface ProxyServiceMBean {
+
+    String MBEAN_TYPE = "ProxyService";
+    String METHOD_STOPSERVICE = "stopService";
+    String KEY_SOURCENAME = "sourceName";
+    String ALL_SOURCENAME = "*";
+
+    /**
+     * stopService
+     */
+    void stopService();
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
@@ -147,7 +147,7 @@ public class RemoteConfigManager implements IRepository {
         }
         int managerIpSize = managerIpList.size();
         for (int i = 0; i < managerIpList.size(); i++) {
-            String host = managerIpList.get(managerIpListIndex.getAndIncrement() % managerIpSize);
+            String host = managerIpList.get(Math.abs(managerIpListIndex.getAndIncrement()) % managerIpSize);
             if (this.reloadDataProxyConfig(proxyClusterName, setName, host)) {
                 break;
             }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/SourceContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/SourceContext.java
@@ -17,11 +17,7 @@
 
 package org.apache.inlong.dataproxy.source;
 
-import io.netty.channel.group.ChannelGroup;
-import java.util.Date;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
+import com.google.common.base.Preconditions;
 
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.flume.Context;
@@ -35,7 +31,12 @@ import org.apache.inlong.dataproxy.metrics.DataProxyMetricItemSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
+import java.util.Date;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import io.netty.channel.group.ChannelGroup;
 
 /**
  * 
@@ -70,6 +71,8 @@ public class SourceContext {
     protected Context parentContext;
     protected long reloadInterval;
     protected Timer reloadTimer;
+    // isRejectService
+    protected boolean isRejectService = false;
 
     /**
      * Constructor
@@ -299,6 +302,24 @@ public class SourceContext {
      */
     public int getMaxThreads() {
         return maxThreads;
+    }
+
+    /**
+     * isRejectService
+     * 
+     * @return
+     */
+    public boolean isRejectService() {
+        return isRejectService;
+    }
+
+    /**
+     * setRejectService
+     * 
+     * @param isRejectService
+     */
+    public void setRejectService(boolean isRejectService) {
+        this.isRejectService = isRejectService;
     }
 
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/tcp/InlongTcpChannelHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/tcp/InlongTcpChannelHandler.java
@@ -17,10 +17,6 @@
 
 package org.apache.inlong.dataproxy.source.tcp;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.flume.Event;
 import org.apache.inlong.dataproxy.metrics.DataProxyMetricItem;
 import org.apache.inlong.dataproxy.metrics.audit.AuditUtils;
@@ -33,6 +29,10 @@ import org.apache.inlong.sdk.commons.protocol.ProxySdk.ResponseInfo;
 import org.apache.inlong.sdk.commons.protocol.ProxySdk.ResultCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -129,6 +129,13 @@ public class InlongTcpChannelHandler extends ChannelInboundHandlerAdapter {
         cb.readBytes(msgBytes);
         // decode
         MessagePack packObject = MessagePack.parseFrom(msgBytes);
+        // reject service
+        if (sourceContext.isRejectService()) {
+            this.addMetric(false, 0, null);
+            this.responsePackage(ctx, ResultCode.ERR_REJECT, packObject);
+            return;
+        }
+        // uncompress
         List<ProxyEvent> events = EventUtils.decodeSdkPack(packObject);
         // topic
         for (ProxyEvent event : events) {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/tcp/InlongTcpSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/tcp/InlongTcpSource.java
@@ -17,27 +17,30 @@
 
 package org.apache.inlong.dataproxy.source.tcp;
 
-import io.netty.channel.ChannelInitializer;
-import java.lang.reflect.Constructor;
+import com.google.common.base.Preconditions;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.flume.Context;
 import org.apache.flume.EventDrivenSource;
 import org.apache.flume.FlumeException;
 import org.apache.flume.conf.Configurable;
+import org.apache.inlong.dataproxy.admin.ProxyServiceMBean;
 import org.apache.inlong.dataproxy.consts.ConfigConstants;
 import org.apache.inlong.dataproxy.source.SimpleTcpSource;
 import org.apache.inlong.dataproxy.source.SourceContext;
+import org.apache.inlong.sdk.commons.admin.AdminServiceRegister;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
+import java.lang.reflect.Constructor;
+
+import io.netty.channel.ChannelInitializer;
 
 /**
  * Inlong tcp source
  */
 public class InlongTcpSource extends SimpleTcpSource
-        implements Configurable, EventDrivenSource {
+        implements Configurable, EventDrivenSource, ProxyServiceMBean {
 
     public static final Logger LOG = LoggerFactory.getLogger(InlongTcpSource.class);
 
@@ -101,6 +104,8 @@ public class InlongTcpSource extends SimpleTcpSource
             if (this.pipelineFactoryConfigurable != null) {
                 this.pipelineFactoryConfigurable.configure(context);
             }
+            // register
+            AdminServiceRegister.register(ProxyServiceMBean.MBEAN_TYPE, this.getClass().getSimpleName(), this);
         } catch (Throwable t) {
             LOG.error(t.getMessage(), t);
         }
@@ -117,8 +122,8 @@ public class InlongTcpSource extends SimpleTcpSource
 
         ChannelInitializer fac = null;
         try {
-            Class<? extends ChannelInitializer> clazz =
-                    (Class<? extends ChannelInitializer>) Class.forName(msgFactoryName);
+            Class<? extends ChannelInitializer> clazz = (Class<? extends ChannelInitializer>) Class
+                    .forName(msgFactoryName);
 
             Constructor ctor = clazz.getConstructor(SourceContext.class, String.class);
 
@@ -139,7 +144,20 @@ public class InlongTcpSource extends SimpleTcpSource
         return fac;
     }
 
+    /**
+     * getProtocolName
+     * 
+     * @return
+     */
     public String getProtocolName() {
         return "tcp";
+    }
+
+    /**
+     * stopService
+     */
+    @Override
+    public void stopService() {
+        this.sourceContext.setRejectService(true);
     }
 }

--- a/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AbstractAdminEventHandler.java
+++ b/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AbstractAdminEventHandler.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.commons.admin;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * AbstractAdminEventHandler
+ */
+public abstract class AbstractAdminEventHandler implements AdminEventHandler {
+
+    public static final Logger LOG = LoggerFactory.getLogger(AbstractAdminEventHandler.class);
+
+    /**
+     * outputResponse
+     * 
+     * @param response
+     * @param outputString
+     */
+    public void outputResponse(HttpServletResponse response, String outputString) {
+        ServletOutputStream outputStream = null;
+        try {
+            outputStream = response.getOutputStream();
+            outputStream.write(outputString.getBytes(Charset.defaultCharset()));
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        } finally {
+            if (outputStream != null) {
+                try {
+                    outputStream.flush();
+                } catch (IOException e) {
+                    LOG.error(e.getMessage(), e);
+                }
+                try {
+                    outputStream.close();
+                } catch (IOException e) {
+                    LOG.error(e.getMessage(), e);
+                }
+            }
+        }
+    }
+
+}

--- a/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminEventHandler.java
+++ b/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminEventHandler.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.commons.admin;
+
+import org.apache.flume.Event;
+import org.apache.flume.conf.Configurable;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * IAdminEventHandler
+ */
+public interface AdminEventHandler extends Configurable {
+
+    String JMX_DOMAIN = "org.apache.inlong";
+    String JMX_TYPE = "type";
+    String JMX_NAME = "name";
+    char DOMAIN_SEPARATOR = ':';
+    char PROPERTY_SEPARATOR = ',';
+    char PROPERTY_EQUAL = '=';
+
+    /**
+     * process
+     * 
+     * @param cmd
+     * @param event
+     * @param response
+     */
+    void process(String cmd, Event event, HttpServletResponse response);
+}

--- a/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminHttpSource.java
+++ b/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminHttpSource.java
@@ -1,0 +1,323 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.commons.admin;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.flume.ChannelException;
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.EventDrivenSource;
+import org.apache.flume.conf.Configurable;
+import org.apache.flume.instrumentation.SourceCounter;
+import org.apache.flume.source.SslContextAwareAbstractSource;
+import org.apache.flume.source.http.HTTPBadRequestException;
+import org.apache.flume.source.http.HTTPSource;
+import org.apache.flume.source.http.HTTPSourceConfigurationConstants;
+import org.apache.flume.tools.FlumeBeanConfigurator;
+import org.apache.flume.tools.HTTPServerConstraintUtil;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.jmx.MBeanContainer;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+
+/**
+ * AdminHttpSource
+ */
+public class AdminHttpSource extends SslContextAwareAbstractSource implements
+        EventDrivenSource, Configurable {
+    /*
+     * There are 2 ways of doing this: a. Have a static server instance and use connectors in each source which binds to
+     * the port defined for that source. b. Each source starts its own server instance, which binds to the source's
+     * port.
+     *
+     * b is more efficient than a because Jetty does not allow binding a servlet to a connector. So each request will
+     * need to go through each each of the handlers/servlet till the correct one is found.
+     *
+     */
+
+    private static final Logger LOG = LoggerFactory.getLogger(HTTPSource.class);
+    private volatile Integer port;
+    private volatile Server srv;
+    private volatile String host;
+    private AdminHttpSourceHandler handler;
+    private SourceCounter sourceCounter;
+
+    private Context sourceContext;
+
+    /**
+     * configure
+     * 
+     * @param context
+     */
+    @Override
+    public void configure(Context context) {
+        configureSsl(context);
+        sourceContext = context;
+        try {
+            port = context.getInteger(HTTPSourceConfigurationConstants.CONFIG_PORT);
+            host = context.getString(HTTPSourceConfigurationConstants.CONFIG_BIND,
+                    HTTPSourceConfigurationConstants.DEFAULT_BIND);
+
+            Preconditions.checkState(host != null && !host.isEmpty(),
+                    "HTTPSource hostname specified is empty");
+            Preconditions.checkNotNull(port, "HTTPSource requires a port number to be"
+                    + " specified");
+
+            String handlerClassName = context.getString(
+                    HTTPSourceConfigurationConstants.CONFIG_HANDLER,
+                    HTTPSourceConfigurationConstants.DEFAULT_HANDLER).trim();
+
+            @SuppressWarnings("unchecked")
+            Class<? extends AdminHttpSourceHandler> clazz = (Class<? extends AdminHttpSourceHandler>) Class
+                    .forName(handlerClassName);
+            handler = clazz.getDeclaredConstructor().newInstance();
+
+            Map<String, String> subProps = context.getSubProperties(
+                    HTTPSourceConfigurationConstants.CONFIG_HANDLER_PREFIX);
+            handler.configure(new Context(subProps));
+        } catch (ClassNotFoundException ex) {
+            LOG.error("Error while configuring HTTPSource. Exception follows.", ex);
+            Throwables.propagate(ex);
+        } catch (ClassCastException ex) {
+            LOG.error("Deserializer is not an instance of HTTPSourceHandler."
+                    + "Deserializer must implement HTTPSourceHandler.");
+            Throwables.propagate(ex);
+        } catch (Exception ex) {
+            LOG.error("Error configuring HTTPSource!", ex);
+            Throwables.propagate(ex);
+        }
+        if (sourceCounter == null) {
+            sourceCounter = new SourceCounter(getName());
+        }
+    }
+
+    /**
+     * start
+     */
+    @Override
+    public void start() {
+        Preconditions.checkState(srv == null,
+                "Running HTTP Server found in source: " + getName()
+                        + " before I started one."
+                        + "Will not attempt to start.");
+        QueuedThreadPool threadPool = new QueuedThreadPool();
+        if (sourceContext.getSubProperties("QueuedThreadPool.").size() > 0) {
+            FlumeBeanConfigurator.setConfigurationFields(threadPool, sourceContext);
+        }
+        srv = new Server(threadPool);
+
+//Register with JMX for advanced monitoring
+        MBeanContainer mbContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());
+        srv.addEventListener(mbContainer);
+        srv.addBean(mbContainer);
+
+        HttpConfiguration httpConfiguration = new HttpConfiguration();
+        httpConfiguration.addCustomizer(new SecureRequestCustomizer());
+
+        FlumeBeanConfigurator.setConfigurationFields(httpConfiguration, sourceContext);
+        ServerConnector connector = getSslContextSupplier().get().map(sslContext -> {
+            SslContextFactory sslCtxFactory = new SslContextFactory();
+            sslCtxFactory.setSslContext(sslContext);
+            sslCtxFactory.setExcludeProtocols(getExcludeProtocols().toArray(new String[]{}));
+            sslCtxFactory.setIncludeProtocols(getIncludeProtocols().toArray(new String[]{}));
+            sslCtxFactory.setExcludeCipherSuites(getExcludeCipherSuites().toArray(new String[]{}));
+            sslCtxFactory.setIncludeCipherSuites(getIncludeCipherSuites().toArray(new String[]{}));
+
+            FlumeBeanConfigurator.setConfigurationFields(sslCtxFactory, sourceContext);
+
+            httpConfiguration.setSecurePort(port);
+            httpConfiguration.setSecureScheme("https");
+
+            return new ServerConnector(srv,
+                    new SslConnectionFactory(sslCtxFactory, HttpVersion.HTTP_1_1.asString()),
+                    new HttpConnectionFactory(httpConfiguration));
+        }).orElse(
+                new ServerConnector(srv, new HttpConnectionFactory(httpConfiguration)));
+
+        connector.setPort(port);
+        connector.setHost(host);
+        connector.setReuseAddress(true);
+
+        FlumeBeanConfigurator.setConfigurationFields(connector, sourceContext);
+
+        srv.addConnector(connector);
+
+        try {
+            ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+            context.setContextPath("/");
+            srv.setHandler(context);
+
+            context.addServlet(new ServletHolder(new FlumeHTTPServlet()), "/");
+            context.setSecurityHandler(HTTPServerConstraintUtil.enforceConstraints());
+            srv.start();
+        } catch (Exception ex) {
+            LOG.error("Error while starting HTTPSource. Exception follows.", ex);
+            Throwables.propagate(ex);
+        }
+        Preconditions.checkArgument(srv.isRunning());
+        sourceCounter.start();
+        super.start();
+    }
+
+    /**
+     * stop
+     */
+    @Override
+    public void stop() {
+        try {
+            srv.stop();
+            srv.join();
+            srv = null;
+        } catch (Exception ex) {
+            LOG.error("Error while stopping HTTPSource. Exception follows.", ex);
+        }
+        sourceCounter.stop();
+        LOG.info("Http source {} stopped. Metrics: {}", getName(), sourceCounter);
+    }
+
+    /**
+     * AdminHttpSource FlumeHTTPServlet
+     */
+    private class FlumeHTTPServlet extends HttpServlet {
+
+        private static final long serialVersionUID = 4891924863218790344L;
+
+        /**
+         * doPost
+         * 
+         * @param  request
+         * @param  response
+         * @throws IOException
+         */
+        @Override
+        public void doPost(HttpServletRequest request, HttpServletResponse response)
+                throws IOException {
+            List<Event> events = Collections.emptyList(); // create empty list
+            try {
+                events = handler.getEvents(request, response);
+            } catch (HTTPBadRequestException ex) {
+                LOG.warn("Received bad request from client. ", ex);
+                sourceCounter.incrementEventReadFail();
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                        "Bad request from client. "
+                                + ex.getMessage());
+                return;
+            } catch (Exception ex) {
+                LOG.warn("Deserializer threw unexpected exception. ", ex);
+                sourceCounter.incrementEventReadFail();
+                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                        "Deserializer threw unexpected exception. "
+                                + ex.getMessage());
+                return;
+            }
+            sourceCounter.incrementAppendBatchReceivedCount();
+            try {
+                if (events != null) {
+                    sourceCounter.addToEventReceivedCount(events.size());
+                    getChannelProcessor().processEventBatch(events);
+                }
+            } catch (ChannelException ex) {
+                LOG.warn("Error appending event to channel. "
+                        + "Channel might be full. Consider increasing the channel "
+                        + "capacity or make sure the sinks perform faster.", ex);
+                sourceCounter.incrementChannelWriteFail();
+                response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+                        "Error appending event to channel. Channel might be full."
+                                + ex.getMessage());
+                return;
+            } catch (Exception ex) {
+                LOG.warn("Unexpected error appending event to channel. ", ex);
+                sourceCounter.incrementGenericProcessingFail();
+                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                        "Unexpected error while appending event to channel. "
+                                + ex.getMessage());
+                return;
+            }
+            response.setCharacterEncoding(request.getCharacterEncoding());
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.flushBuffer();
+            sourceCounter.incrementAppendBatchAcceptedCount();
+            if (events != null) {
+                sourceCounter.addToEventAcceptedCount(events.size());
+            }
+        }
+
+        /**
+         * doGet
+         * 
+         * @param  request
+         * @param  response
+         * @throws IOException
+         */
+        @Override
+        public void doGet(HttpServletRequest request, HttpServletResponse response)
+                throws IOException {
+            doPost(request, response);
+        }
+    }
+
+    /**
+     * configureSsl
+     * 
+     * @param context
+     */
+    @Override
+    protected void configureSsl(Context context) {
+        handleDeprecatedParameter(context, "ssl", "enableSSL");
+        handleDeprecatedParameter(context, "exclude-protocols", "excludeProtocols");
+        handleDeprecatedParameter(context, "keystore-password", "keystorePassword");
+
+        super.configureSsl(context);
+    }
+
+    /**
+     * handleDeprecatedParameter
+     * 
+     * @param context
+     * @param newParam
+     * @param oldParam
+     */
+    private void handleDeprecatedParameter(Context context, String newParam, String oldParam) {
+        if (!context.containsKey(newParam) && context.containsKey(oldParam)) {
+            context.put(newParam, context.getString(oldParam));
+        }
+    }
+
+}

--- a/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminHttpSourceHandler.java
+++ b/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminHttpSourceHandler.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.commons.admin;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.flume.Event;
+import org.apache.flume.conf.Configurable;
+import org.apache.flume.source.http.HTTPBadRequestException;
+
+/**
+ * 
+ * IAdminHttpSourceHandler
+ */
+public interface AdminHttpSourceHandler extends Configurable {
+
+    /**
+     * Takes an {@linkplain HttpServletRequest} and returns a list of Flume Events. If this request cannot be parsed
+     * into Flume events based on the format this method will throw an exception. This method may also throw an
+     * exception if there is some sort of other error.
+     * <p>
+     *
+     * @param  request                 The request to be parsed into Flume events.
+     * @param  response.
+     * @return                         List of Flume events generated from the request.
+     * @throws HTTPBadRequestException If the was not parsed correctly into an event because the request was not in the
+     *                                 expected format.
+     * @throws Exception               If there was an unexpected error.
+     */
+    List<Event> getEvents(HttpServletRequest request, HttpServletResponse response)
+            throws HTTPBadRequestException, Exception;
+}

--- a/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminJsonHandler.java
+++ b/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminJsonHandler.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.commons.admin;
+
+import org.apache.commons.lang.ClassUtils;
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.source.http.HTTPBadRequestException;
+import org.apache.flume.source.http.JSONHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * AdminJsonHandler
+ */
+public class AdminJsonHandler implements AdminHttpSourceHandler {
+
+    public static final Logger LOG = LoggerFactory.getLogger(AdminJsonHandler.class);
+    public static final String KEY_CMD = "cmd";
+    private Context context;
+    private JSONHandler requestHandler;
+    private Map<String, AdminEventHandler> handlerMap = new HashMap<>();
+
+    /**
+     * configure
+     * 
+     * @param context
+     */
+    @Override
+    public void configure(Context context) {
+        this.context = context;
+        this.requestHandler = new JSONHandler();
+        this.requestHandler.configure(context);
+    }
+
+    @Override
+    public List<Event> getEvents(HttpServletRequest request, HttpServletResponse response)
+            throws HTTPBadRequestException, Exception {
+        List<Event> events = this.requestHandler.getEvents(request);
+        for (Event event : events) {
+            String cmd = event.getHeaders().get(KEY_CMD);
+            if (cmd == null) {
+                LOG.error("Invalid admin event,%s is null", KEY_CMD);
+                continue;
+            }
+            AdminEventHandler handler = this.handlerMap.get(cmd);
+            if (handler == null) {
+                String handlerType = context.getString(cmd + ".type");
+                if (handlerType == null) {
+                    LOG.error("Invalid admin event,%s:%s,type is null", KEY_CMD, cmd);
+                    continue;
+                }
+                try {
+                    Class<?> handlerClass = ClassUtils.getClass(handlerType);
+                    Object handlerObject = handlerClass.getDeclaredConstructor().newInstance();
+                    if (handlerObject instanceof AdminEventHandler) {
+                        handler = (AdminEventHandler) handlerObject;
+                        Context subContext = new Context(context.getSubProperties(cmd + "."));
+                        handler.configure(subContext);
+                        this.handlerMap.put(cmd, handler);
+                    } else {
+                        LOG.error("Invalid admin event,%s:%s,type:%s is not AdminEventHandler", KEY_CMD, cmd,
+                                handlerType);
+                        continue;
+                    }
+                } catch (Exception e) {
+                    LOG.error("Invalid admin event,%s:%s,type:%s can not be created,error:%s", KEY_CMD, cmd,
+                            handlerType, e.getMessage(), e);
+                    continue;
+                }
+            }
+            handler.process(cmd, event, response);
+        }
+        return null;
+    }
+}

--- a/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminServiceRegister.java
+++ b/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminServiceRegister.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.commons.admin;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.ManagementFactory;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import static org.apache.inlong.sdk.commons.admin.AdminEventHandler.DOMAIN_SEPARATOR;
+import static org.apache.inlong.sdk.commons.admin.AdminEventHandler.JMX_DOMAIN;
+import static org.apache.inlong.sdk.commons.admin.AdminEventHandler.JMX_NAME;
+import static org.apache.inlong.sdk.commons.admin.AdminEventHandler.JMX_TYPE;
+import static org.apache.inlong.sdk.commons.admin.AdminEventHandler.PROPERTY_EQUAL;
+import static org.apache.inlong.sdk.commons.admin.AdminEventHandler.PROPERTY_SEPARATOR;
+
+/**
+ * AdminServiceRegister
+ */
+public class AdminServiceRegister {
+
+    public static final Logger LOG = LoggerFactory.getLogger(AdminServiceRegister.class);
+
+    /**
+     * register AdminService
+     */
+    public static void register(String type, String name, Object mbean) {
+        final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        String beanName = JMX_DOMAIN + DOMAIN_SEPARATOR
+                + JMX_TYPE + PROPERTY_EQUAL + type + PROPERTY_SEPARATOR
+                + JMX_NAME + PROPERTY_EQUAL + name;
+        LOG.info("start to register mbean:{}", beanName);
+        try {
+            ObjectName objName = new ObjectName(beanName);
+            mbs.registerMBean(mbean, objName);
+            LOG.info("end to register mbean:{}", beanName);
+        } catch (Exception ex) {
+            LOG.error("exception while register mbean:{},error:{}", beanName, ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * main
+     * 
+     * @param args
+     */
+    public static void main(String[] args) {
+        String type = "type1";
+        String name = "name1";
+        String beanName = JMX_DOMAIN + DOMAIN_SEPARATOR
+                + JMX_TYPE + PROPERTY_EQUAL + type + PROPERTY_SEPARATOR
+                + JMX_NAME + PROPERTY_EQUAL + name;
+        try {
+            ObjectName objName = new ObjectName(beanName);
+            System.out.println(objName.toString());
+            System.out.println(objName.getCanonicalKeyPropertyListString());
+            System.out.println(objName.getCanonicalName());
+            System.out.println(objName.getKeyProperty(JMX_NAME));
+        } catch (Exception ex) {
+            LOG.error("exception while register mbean:{},error:{}", beanName, ex.getMessage(), ex);
+        }
+
+    }
+}

--- a/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminTask.java
+++ b/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/AdminTask.java
@@ -1,0 +1,291 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.commons.admin;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.apache.flume.SinkRunner;
+import org.apache.flume.SourceRunner;
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.flume.lifecycle.LifecycleSupervisor;
+import org.apache.flume.lifecycle.LifecycleSupervisor.SupervisorPolicy;
+import org.apache.flume.node.MaterializedConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.eventbus.Subscribe;
+
+/**
+ * 
+ * AdminTask
+ */
+public class AdminTask {
+
+    public static final Logger LOG = LoggerFactory.getLogger(AdminTask.class);
+    public static final String KEY_HOST = "adminTask.host";
+    public static final String KEY_PORT = "adminTask.port";
+    public static final String KEY_HANDLER = "adminTask.handler";
+    public static final String FLUME_ROOT = "admin";
+
+    private Context context;
+    private final LifecycleSupervisor supervisor;
+    private MaterializedConfiguration materializedConfiguration;
+    private final ReentrantLock lifecycleLock = new ReentrantLock();
+
+    /**
+     * Constructor
+     * 
+     * @param context
+     */
+    public AdminTask(Context context) {
+        this.context = context;
+        this.supervisor = new LifecycleSupervisor();
+    }
+
+    /**
+     * start
+     */
+    public void start() {
+        try {
+            Map<String, String> flumeConfiguration = generateFlumeConfiguration();
+            if (flumeConfiguration == null) {
+                return;
+            }
+            LOG.info("Start admin task,flumeConf:{}", flumeConfiguration);
+            PropertiesConfigurationProvider configurationProvider = new PropertiesConfigurationProvider(
+                    FLUME_ROOT, flumeConfiguration);
+            this.handleConfigurationEvent(configurationProvider.getConfiguration());
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * generateFlumeConfiguration
+     * 
+     * @return             Map
+     * @throws IOException
+     */
+    private Map<String, String> generateFlumeConfiguration() throws IOException {
+        String host = context.getString(KEY_HOST);
+        if (host == null) {
+            LOG.error("Can not start admin task, host is null.");
+            return null;
+        }
+        String port = context.getString(KEY_PORT);
+        if (port == null) {
+            LOG.error("Can not start admin task, port is null.");
+            return null;
+        }
+        String handlerType = context.getString(KEY_HANDLER);
+        if (handlerType == null) {
+            LOG.error("Can not start admin task, handlerType is null.");
+            return null;
+        }
+        String flumeString = String.format("admin.sources=r1\n"
+                + "admin.sinks=k1\n"
+                + "admin.channels=c1\n"
+                + "admin.sources.r1.type=" + AdminHttpSource.class.getName() + "\n"
+                + "admin.sources.r1.bind=%s\n"
+                + "admin.sources.r1.port=%s\n"
+                + "admin.sources.r1.channels=c1\n"
+                + "admin.sources.r1.handler=%s\n"
+                + "admin.sinks.k1.type=logger\n"
+                + "admin.sinks.k1.channel=c1\n"
+                + "admin.channels.c1.type=memory\n"
+                + "admin.channels.c1.capacity=1000\n"
+                + "admin.channels.c1.transactionCapacity=100", host,
+                port,
+                handlerType);
+        Properties props = new Properties();
+        props.load(new StringReader(flumeString));
+        Map<String, String> flumeMap = new HashMap<>();
+        props.forEach((key, value) -> {
+            flumeMap.put(String.valueOf(key), String.valueOf(value));
+        });
+        // adminTask.handler.stopService.type=org.apache.inlong.dataproxy.admin.ProxyServiceAdminEventHandler
+        // adminTask.handler.stopService.param1=xxx
+        // adminTask.handler.stopService.param2=xxx
+        // adminTask.handler.stopConsumer.type=org.apache.inlong.sort.standalone.admin.ConsumerServiceAdminEventHandler
+        // adminTask.handler.stopConsumer.param1=xxx
+        // adminTask.handler.stopConsumer.param2=xxx
+        // adminTask.handler.ackAll.type=org.apache.inlong.sort.standalone.admin.ConsumerServiceAdminEventHandler
+        // adminTask.handler.ackAll.param1=xxx
+        // adminTask.handler.ackAll.param2=xxx
+        Map<String, String> subHandlerConfig = context.getSubProperties(KEY_HANDLER + ".");
+        subHandlerConfig.forEach((key, value) -> {
+            flumeMap.put("admin.sources.r1.handler." + key, value);
+        });
+        return flumeMap;
+    }
+
+    /**
+     * handleConfigurationEvent
+     * 
+     * @param conf
+     */
+    @Subscribe
+    public void handleConfigurationEvent(MaterializedConfiguration conf) {
+        try {
+            lifecycleLock.lockInterruptibly();
+            stopAllComponents();
+            startAllComponents(conf);
+        } catch (InterruptedException e) {
+            LOG.info("Interrupted while trying to handle configuration event");
+            return;
+        } finally {
+            // If interrupted while trying to lock, we don't own the lock, so must not attempt to unlock
+            if (lifecycleLock.isHeldByCurrentThread()) {
+                lifecycleLock.unlock();
+            }
+        }
+    }
+
+    /**
+     * stop
+     */
+    public void stop() {
+        lifecycleLock.lock();
+        stopAllComponents();
+        try {
+            supervisor.stop();
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    /**
+     * stopAllComponents
+     */
+    private void stopAllComponents() {
+        if (this.materializedConfiguration != null) {
+            LOG.info("Shutting down configuration: {}", this.materializedConfiguration);
+            for (Entry<String, SourceRunner> entry : this.materializedConfiguration.getSourceRunners().entrySet()) {
+                try {
+                    LOG.info("Stopping Source " + entry.getKey());
+                    supervisor.unsupervise(entry.getValue());
+                } catch (Exception e) {
+                    LOG.error("Error while stopping {}", entry.getValue(), e);
+                }
+            }
+
+            for (Entry<String, SinkRunner> entry : this.materializedConfiguration.getSinkRunners().entrySet()) {
+                try {
+                    LOG.info("Stopping Sink " + entry.getKey());
+                    supervisor.unsupervise(entry.getValue());
+                } catch (Exception e) {
+                    LOG.error("Error while stopping {}", entry.getValue(), e);
+                }
+            }
+
+            for (Entry<String, Channel> entry : this.materializedConfiguration.getChannels().entrySet()) {
+                try {
+                    LOG.info("Stopping Channel " + entry.getKey());
+                    supervisor.unsupervise(entry.getValue());
+                } catch (Exception e) {
+                    LOG.error("Error while stopping {}", entry.getValue(), e);
+                }
+            }
+        }
+    }
+
+    /**
+     * startAllComponents
+     * 
+     * @param materializedConfiguration
+     */
+    private void startAllComponents(MaterializedConfiguration materializedConfiguration) {
+        LOG.info("Starting new configuration:{}", materializedConfiguration);
+
+        this.materializedConfiguration = materializedConfiguration;
+
+        for (Entry<String, Channel> entry : materializedConfiguration.getChannels().entrySet()) {
+            try {
+                LOG.info("Starting Channel " + entry.getKey());
+                supervisor.supervise(entry.getValue(),
+                        new SupervisorPolicy.AlwaysRestartPolicy(), LifecycleState.START);
+            } catch (Exception e) {
+                LOG.error("Error while starting {}", entry.getValue(), e);
+            }
+        }
+
+        /*
+         * Wait for all channels to start.
+         */
+        for (Channel ch : materializedConfiguration.getChannels().values()) {
+            while (ch.getLifecycleState() != LifecycleState.START
+                    && !supervisor.isComponentInErrorState(ch)) {
+                try {
+                    LOG.info("Waiting for channel: " + ch.getName() + " to start. Sleeping for 500 ms");
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    LOG.error("Interrupted while waiting for channel to start.", e);
+                }
+            }
+        }
+
+        for (Entry<String, SinkRunner> entry : materializedConfiguration.getSinkRunners().entrySet()) {
+            try {
+                LOG.info("Starting Sink " + entry.getKey());
+                supervisor.supervise(entry.getValue(),
+                        new SupervisorPolicy.AlwaysRestartPolicy(), LifecycleState.START);
+            } catch (Exception e) {
+                LOG.error("Error while starting {}", entry.getValue(), e);
+            }
+        }
+
+        for (Entry<String, SourceRunner> entry : materializedConfiguration.getSourceRunners().entrySet()) {
+            try {
+                LOG.info("Starting Source " + entry.getKey());
+                supervisor.supervise(entry.getValue(),
+                        new SupervisorPolicy.AlwaysRestartPolicy(), LifecycleState.START);
+            } catch (Exception e) {
+                LOG.error("Error while starting {}", entry.getValue(), e);
+            }
+        }
+    }
+
+    /**
+     * main
+     * 
+     * @param args
+     */
+    public static void main(String[] args) {
+        try {
+            Context context = new Context();
+            context.put(KEY_HOST, "127.0.0.1");
+            context.put(KEY_PORT, "8080");
+            context.put(KEY_HANDLER, "org.apache.inlong.dataproxy.admin.AdminJsonHandler");
+            context.put(KEY_HANDLER + ".stopService.type",
+                    "org.apache.inlong.dataproxy.admin.ProxyServiceAdminEventHandler");
+            AdminTask task = new AdminTask(context);
+            task.start();
+            Thread.sleep(10000);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/PropertiesConfigurationProvider.java
+++ b/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/admin/PropertiesConfigurationProvider.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.commons.admin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.flume.conf.FlumeConfiguration;
+import org.apache.flume.node.AbstractConfigurationProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * PropertiesConfigurationProvider
+ */
+public class PropertiesConfigurationProvider extends
+        AbstractConfigurationProvider {
+
+    public static final Logger LOG = LoggerFactory.getLogger(PropertiesConfigurationProvider.class);
+
+    private final Map<String, String> flumeConf;
+
+    /**
+     * PropertiesConfigurationProvider
+     * 
+     * @param agentName
+     * @param flumeConf
+     */
+    public PropertiesConfigurationProvider(String rootName, Map<String, String> flumeConf) {
+        super(rootName);
+        this.flumeConf = flumeConf;
+    }
+
+    /**
+     * getFlumeConfiguration
+     * 
+     * @return
+     */
+    @Override
+    public FlumeConfiguration getFlumeConfiguration() {
+        try {
+            return new FlumeConfiguration(flumeConf);
+        } catch (Exception e) {
+            LOG.error("exception catch:" + e.getMessage(), e);
+        }
+        return new FlumeConfiguration(new HashMap<String, String>());
+    }
+}


### PR DESCRIPTION
### Title Name: [INLONG-3659][DataProxy] DataProxy add manageable entry, used to stop some services(TCP service). 

Fixes #3659 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
