### PR TITLE
[INLONG-3681][Manager] Add an initialize database step in Docker container

### DIFF
--- a/docker/kubernetes/templates/manager-statefulset.yaml
+++ b/docker/kubernetes/templates/manager-statefulset.yaml
@@ -56,6 +56,25 @@ spec:
         {{- toYaml .Values.manager.affinity | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.manager.terminationGracePeriodSeconds }}
+      initContainers:
+        - name: wait-{{ .Values.mysql.component }}-ready
+          image: {{ .Values.images.initContainer.repository }}:{{ .Values.images.initContainer.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          command: [ "/bin/sh", "-c" ]
+          args:
+            - |-
+              count={{ .Values.mysql.replicas }}
+              for i in $(seq 0 $(expr $count - 1))
+              do
+                replica="{{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}-$i"
+                host="$replica.{{ template "inlong.mysql.hostname" . }}"
+                port={{ .Values.mysql.port }}
+                until nc -z $host $port 2>/dev/null
+                do
+                  echo "waiting for $replica to be ready"
+                  sleep 3
+                done
+              done
       containers:
         - name: {{ template "inlong.fullname" . }}-{{ .Values.manager.component }}
           image: {{ .Values.images.manager.repository }}:{{ .Values.images.manager.tag }}

--- a/inlong-manager/manager-docker/Dockerfile
+++ b/inlong-manager/manager-docker/Dockerfile
@@ -18,7 +18,7 @@
 #
 FROM openjdk:8-jdk
 RUN apt-get update \
-    && apt-get install -y net-tools vim mysql-client \
+    && apt-get install -y net-tools vim default-mysql-client \
     && rm -rf /var/lib/apt/lists/*
 EXPOSE 8083
 # profile and env virables

--- a/inlong-manager/manager-docker/Dockerfile
+++ b/inlong-manager/manager-docker/Dockerfile
@@ -18,7 +18,7 @@
 #
 FROM openjdk:8-jdk
 RUN apt-get update \
-    && apt-get install -y net-tools vim \
+    && apt-get install -y net-tools vim mysql-client \
     && rm -rf /var/lib/apt/lists/*
 EXPOSE 8083
 # profile and env virables


### PR DESCRIPTION
Fixes: #3681

### Motivation

Add an initialize database step in Docker container.

### Modifications

- Install `default-mysql-client` in manager `Dockerfile`
- Add an initialize database step in `manager-docker.sh`
- Add initContainer to wait mysql ready in `manager-statefulset.yaml`

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
