### PR TITLE
[INLONG-3734][Audit] Add an initialize database step in Docker container

### DIFF
--- a/docker/kubernetes/templates/audit-statefulset.yaml
+++ b/docker/kubernetes/templates/audit-statefulset.yaml
@@ -103,7 +103,7 @@ spec:
           {{- end }}
           env:
             - name: JDBC_URL
-              value: "jdbc:mysql://{{ template "inlong.mysql.hostname" . }}:{{ .Values.mysql.port }}/apache_inlong_audit?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&nullCatalogMeansCurrent=true&serverTimezone=GMT%2b8"
+              value: "{{ template "inlong.mysql.hostname" . }}:{{ .Values.mysql.port }}"
             - name: USERNAME
               value: {{ include "inlong.mysql.username" . | quote }}
             - name: PASSWORD

--- a/inlong-audit/audit-docker/Dockerfile
+++ b/inlong-audit/audit-docker/Dockerfile
@@ -19,7 +19,7 @@
 FROM openjdk:8-jdk
 # add tarball from target output
 RUN apt-get update \
-    && apt-get install -y net-tools vim \
+    && apt-get install -y net-tools vim default-mysql-client \
     && rm -rf /var/lib/apt/lists/*
 ARG AUDIT_TARBALL
 ADD ${AUDIT_TARBALL} /opt/inlong-audit


### PR DESCRIPTION
Fixes: #3734

### Motivation

Refer to https://github.com/apache/incubator-inlong/pull/3715#issuecomment-1099151404

Add an initialize database step in Docker container

### Modifications

- Install `default-mysql-client` in audit `Dockerfile`
- Add an initialize database step in `audit-docker.sh`
- Fix `JDBC_URL` in `audit-statefulset.yaml`

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
