### PR TITLE
[INLONG-3744][CI] Fix trigger condition when pushing Docker image

### DIFF
--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -85,12 +85,25 @@ jobs:
         env:
           CI: false
 
-      - name: Push docker image to Docker Hub
-        if: >-
+      # If the changes are being pushed to a branch like 'release-1.0.0', this step will output true.
+      - name: Check release version
+        id: check-release-version
+        if: >
           success()
           && github.event_name == 'push'
           && github.repository_owner == 'apache'
-          && (github.ref_name == ${{ github.event.repository.default_branch }} || startsWith(github.ref_name, 'release'))
+          && contains(github.ref_name, 'release')
+        run: |
+          if [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=release_version_match::true
+          fi
+
+      - name: Push docker image to Docker Hub
+        if: >
+          success()
+          && github.event_name == 'push'
+          && github.repository_owner == 'apache'
+          && (github.ref_name == ${{ github.event.repository.default_branch }} || steps.check-release-version.outputs.release_version_match == 'true')
         working-directory: docker
         run: bash +x publish.sh
         env:

--- a/.github/workflows/ci_build_docker.yml
+++ b/.github/workflows/ci_build_docker.yml
@@ -86,7 +86,11 @@ jobs:
           CI: false
 
       - name: Push docker image to Docker Hub
-        if: ${{ success() && github.event_name == 'push' && github.ref_name == 'master' && github.repository_owner == 'apache' }}
+        if: >-
+          success()
+          && github.event_name == 'push'
+          && github.repository_owner == 'apache'
+          && (github.ref_name == ${{ github.event.repository.default_branch }} || startsWith(github.ref_name, 'release'))
         working-directory: docker
         run: bash +x publish.sh
         env:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -86,7 +86,7 @@ jobs:
           CI: false
 
       # If the changes are being pushed to the master branch or a branch like 'release-1.0.0', this step will output true.
-      - name: Match branch
+      - name: Match Branch
         id: match-branch
         if: |
           success()

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -86,24 +86,25 @@ jobs:
           CI: false
 
       # If the changes are being pushed to a branch like 'release-1.0.0', this step will output true.
-      - name: Check release version
-        id: check-release-version
+      - name: Match release branch
+        id: match-release-branch
         if: |
-          ${{ success() &&
-          github.event_name == 'push' &&
-          github.repository_owner == 'apache' &&
-          contains(github.ref_name, 'release') }}
+          success()
+          && github.event_name == 'push'
+          && github.repository_owner == 'apache'
+          && contains(github.ref_name, 'release')
         run: |
           if [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=release_version_match::true
+              echo ::set-output name=match::true
           fi
 
       - name: Push docker image to Docker Hub
         if: |
-          ${{ success() &&
-          github.event_name == 'push' &&
-          github.repository_owner == 'apache' &&
-          (github.ref_name == github.event.repository.default_branch || steps.check-release-version.outputs.release_version_match == 'true') }}
+          success()
+          && github.event_name == 'push'
+          && github.repository_owner == 'apache'
+          && (github.ref_name == github.event.repository.default_branch
+              || steps.match-release-branch.outputs.match == 'true')
         working-directory: docker
         run: bash +x publish.sh
         env:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -89,10 +89,10 @@ jobs:
       - name: Check release version
         id: check-release-version
         if: |
-          success() &&
+          ${{ success() &&
           github.event_name == 'push' &&
           github.repository_owner == 'apache' &&
-          contains(github.ref_name, 'release')
+          contains(github.ref_name, 'release') }}
         run: |
           if [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo ::set-output name=release_version_match::true
@@ -100,10 +100,10 @@ jobs:
 
       - name: Push docker image to Docker Hub
         if: |
-          success() &&
+          ${{ success() &&
           github.event_name == 'push' &&
           github.repository_owner == 'apache' &&
-          (github.ref_name == ${{ github.event.repository.default_branch }} || steps.check-release-version.outputs.release_version_match == 'true')
+          (github.ref_name == ${{ github.event.repository.default_branch }} || steps.check-release-version.outputs.release_version_match == 'true') }}
         working-directory: docker
         run: bash +x publish.sh
         env:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -85,26 +85,22 @@ jobs:
         env:
           CI: false
 
-      # If the changes are being pushed to a branch like 'release-1.0.0', this step will output true.
-      - name: Match release branch
-        id: match-release-branch
-        if: |
-          success()
-          && github.event_name == 'push'
-          && github.repository_owner == 'apache'
-          && contains(github.ref_name, 'release')
-        run: |
-          if [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=match::true
-          fi
-
-      - name: Push docker image to Docker Hub
+      # If the changes are being pushed to the master branch or a branch like 'release-1.0.0', this step will output true.
+      - name: Match branch
+        id: match-branch
         if: |
           success()
           && github.event_name == 'push'
           && github.repository_owner == 'apache'
           && (github.ref_name == github.event.repository.default_branch
-              || steps.match-release-branch.outputs.match == 'true')
+              || contains(github.ref_name, 'release'))
+        run: |
+          if [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::set-output name=match::true"
+          fi
+
+      - name: Push docker image to Docker Hub
+        if: ${{ success() && steps.match-branch.outputs.match == 'true' }}
         working-directory: docker
         run: bash +x publish.sh
         env:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -88,7 +88,7 @@ jobs:
       # If the changes are being pushed to a branch like 'release-1.0.0', this step will output true.
       - name: Check release version
         id: check-release-version
-        if: >
+        if: |
           success()
           && github.event_name == 'push'
           && github.repository_owner == 'apache'
@@ -99,7 +99,7 @@ jobs:
           fi
 
       - name: Push docker image to Docker Hub
-        if: >
+        if: |
           success()
           && github.event_name == 'push'
           && github.repository_owner == 'apache'

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -89,10 +89,10 @@ jobs:
       - name: Check release version
         id: check-release-version
         if: |
-          success()
-          && github.event_name == 'push'
-          && github.repository_owner == 'apache'
-          && contains(github.ref_name, 'release')
+          success() &&
+          github.event_name == 'push' &&
+          github.repository_owner == 'apache' &&
+          contains(github.ref_name, 'release')
         run: |
           if [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo ::set-output name=release_version_match::true
@@ -100,10 +100,10 @@ jobs:
 
       - name: Push docker image to Docker Hub
         if: |
-          success()
-          && github.event_name == 'push'
-          && github.repository_owner == 'apache'
-          && (github.ref_name == ${{ github.event.repository.default_branch }} || steps.check-release-version.outputs.release_version_match == 'true')
+          success() &&
+          github.event_name == 'push' &&
+          github.repository_owner == 'apache' &&
+          (github.ref_name == ${{ github.event.repository.default_branch }} || steps.check-release-version.outputs.release_version_match == 'true')
         working-directory: docker
         run: bash +x publish.sh
         env:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -15,12 +15,12 @@
 # limitations under the License.
 #
 
-name: InLong Docker Build
+name: InLong Docker Build and Push
 
 on:
   push:
     paths:
-      - '.github/workflows/ci_build_docker.yml'
+      - '.github/workflows/ci_docker.yml'
       - '**/pom.xml'
       - 'inlong-agent/**'
       - 'inlong-audit/**'
@@ -37,7 +37,7 @@ on:
 
   pull_request:
     paths:
-      - '.github/workflows/ci_build_docker.yml'
+      - '.github/workflows/ci_docker.yml'
       - '**/pom.xml'
       - 'inlong-agent/**'
       - 'inlong-audit/**'
@@ -53,8 +53,8 @@ on:
       - '!*.md'
 
 jobs:
-  build:
-    name: Docker Build
+  docker:
+    name: Docker Build and Push
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -103,7 +103,7 @@ jobs:
           ${{ success() &&
           github.event_name == 'push' &&
           github.repository_owner == 'apache' &&
-          (github.ref_name == ${{ github.event.repository.default_branch }} || steps.check-release-version.outputs.release_version_match == 'true') }}
+          (github.ref_name == github.event.repository.default_branch || steps.check-release-version.outputs.release_version_match == 'true') }}
         working-directory: docker
         run: bash +x publish.sh
         env:


### PR DESCRIPTION
issue: #3744

### Motivation

Docker images are not pushed in `release-*` branches.

### Modifications

- Fix trigger condition when pushing Docker image
- Rename workflow: `ci_build_docker` -> `ci_docker`

BTW, unfortunately, there is any way to do regex matching on `if` conditional expressions yet on GitHub Actions. I referenced https://stackoverflow.com/questions/58862864/github-actions-ci-conditional-regex

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
