### PR TITLE
[INLONG-3745][Manager] Manager-plugins fix canstants bug of savepointDirectory

### DIFF
--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/IntegrationTaskRunner.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/IntegrationTaskRunner.java
@@ -78,8 +78,8 @@ public class IntegrationTaskRunner implements Runnable {
             case RESTART:
                 try {
                     StopWithSavepointRequest stopWithSavepointRequest = new StopWithSavepointRequest();
-                    stopWithSavepointRequest.setDrain(Constants.DRAIN);
                     FlinkConfig flinkConfig = flinkService.getFlinkConfig();
+                    stopWithSavepointRequest.setDrain(flinkConfig.isDrain());
                     stopWithSavepointRequest.setTargetDirectory(flinkConfig.getSavepointDirectory());
                     String location = flinkService.stopJob(flinkInfo.getJobId(), stopWithSavepointRequest);
                     flinkInfo.setSavepointPath(location);
@@ -117,8 +117,8 @@ public class IntegrationTaskRunner implements Runnable {
             case STOP:
                 try {
                     StopWithSavepointRequest stopWithSavepointRequest = new StopWithSavepointRequest();
-                    stopWithSavepointRequest.setDrain(Constants.DRAIN);
                     FlinkConfig flinkConfig = flinkService.getFlinkConfig();
+                    stopWithSavepointRequest.setDrain(flinkConfig.isDrain());
                     stopWithSavepointRequest.setTargetDirectory(flinkConfig.getSavepointDirectory());
                     String location = flinkService.stopJob(flinkInfo.getJobId(), stopWithSavepointRequest);
                     flinkInfo.setSavepointPath(location);

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/IntegrationTaskRunner.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/IntegrationTaskRunner.java
@@ -79,7 +79,8 @@ public class IntegrationTaskRunner implements Runnable {
                 try {
                     StopWithSavepointRequest stopWithSavepointRequest = new StopWithSavepointRequest();
                     stopWithSavepointRequest.setDrain(Constants.DRAIN);
-                    stopWithSavepointRequest.setTargetDirectory(Constants.SAVEPOINT_DIRECTORY);
+                    FlinkConfig flinkConfig = flinkService.getFlinkConfig();
+                    stopWithSavepointRequest.setTargetDirectory(flinkConfig.getSavepointDirectory());
                     String location = flinkService.stopJob(flinkInfo.getJobId(), stopWithSavepointRequest);
                     flinkInfo.setSavepointPath(location);
                     log.info("the jobId: {} savepoint: {} ", flinkInfo.getJobId(), location);

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/IntegrationTaskRunner.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/IntegrationTaskRunner.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.inlong.manager.plugin.flink.dto.FlinkConfig;
 import org.apache.inlong.manager.plugin.flink.dto.FlinkInfo;
 import org.apache.inlong.manager.plugin.flink.dto.StopWithSavepointRequest;
-import org.apache.inlong.manager.plugin.flink.enums.Constants;
 import org.apache.inlong.manager.plugin.flink.enums.TaskCommitType;
 
 import static org.apache.flink.api.common.JobStatus.FINISHED;

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/dto/FlinkConfig.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/dto/FlinkConfig.java
@@ -32,4 +32,6 @@ public class FlinkConfig {
 
     private Integer parallelism;
 
+    private boolean drain;
+
 }

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/enums/Constants.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/enums/Constants.java
@@ -30,6 +30,8 @@ public class Constants {
 
     public static final String SAVEPOINT_DIRECTORY = "flink.savepoint.directory";
 
+    public static final String DRAIN = "flink.drain";
+
     //dataflow
     public static final String SOURCE_INFO = "source_info";
 
@@ -61,7 +63,5 @@ public class Constants {
     public static final String URL_SEPARATOR = "/";
 
     public static final String SEPARATOR = ":";
-
-    public static final boolean DRAIN = false;
 
 }

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/util/FlinkConfiguration.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/util/FlinkConfiguration.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 import static org.apache.inlong.manager.plugin.flink.enums.Constants.ADDRESS;
+import static org.apache.inlong.manager.plugin.flink.enums.Constants.DRAIN;
 import static org.apache.inlong.manager.plugin.flink.enums.Constants.JOB_MANAGER_PORT;
 import static org.apache.inlong.manager.plugin.flink.enums.Constants.PARALLELISM;
 import static org.apache.inlong.manager.plugin.flink.enums.Constants.PORT;
@@ -99,6 +100,7 @@ public class FlinkConfiguration {
         flinkConfig.setParallelism(Integer.valueOf(properties.getProperty(PARALLELISM)));
         flinkConfig.setSavepointDirectory(properties.getProperty(SAVEPOINT_DIRECTORY));
         flinkConfig.setJobManagerPort(Integer.valueOf(properties.getProperty(JOB_MANAGER_PORT)));
+        flinkConfig.setDrain(Boolean.parseBoolean(properties.getProperty(DRAIN)));
         return flinkConfig;
     }
 

--- a/inlong-manager/manager-plugins/src/main/resources/flink-sort-plugin.properties
+++ b/inlong-manager/manager-plugins/src/main/resources/flink-sort-plugin.properties
@@ -32,3 +32,5 @@ flink.jobmanager.port=6123
 flink.savepoint.directory=file:///data/inlong-sort/savepoints
 # Flink parallelism
 flink.parallelism=1
+#flink stoprequest drain
+flink.drain=false


### PR DESCRIPTION
### Title Name: [INLONG-3745] manager-plugis fix canstants bug

where *XYZ* should be replaced by the actual issue number.

Fixes #3745 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
