### PR TITLE
[INLONG-3898][Docker] Fix log paths of Agent, Audit, DataProxy and TubeMQ Manager containers

### DIFF
--- a/inlong-agent/agent-docker/agent-docker.sh
+++ b/inlong-agent/agent-docker/agent-docker.sh
@@ -38,4 +38,4 @@ EOF
 bash +x ${file_path}/bin/agent.sh start
 sleep 3
 # keep alive
-tail -F ${file_path}/logs/agent.log
+tail -F ${file_path}/logs/info.log

--- a/inlong-audit/audit-docker/audit-docker.sh
+++ b/inlong-audit/audit-docker/audit-docker.sh
@@ -57,4 +57,4 @@ bash +x ${file_path}/bin/proxy-start.sh
 bash +x ${file_path}/bin/store-start.sh
 sleep 3
 # keep alive
-tail -F ${file_path}/logs/audit.log
+tail -F ${file_path}/logs/info.log

--- a/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
+++ b/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
@@ -26,4 +26,4 @@ sed -i "s/audit.proxys=.*$/audit.proxys=${AUDIT_PROXY_URL}/g" "${common_conf_fil
 bash +x ${file_path}/bin/dataproxy-start.sh
 sleep 3
 # keep alive
-tail -F ${file_path}/logs/flume.log
+tail -F ${file_path}/logs/info.log

--- a/inlong-tubemq/tubemq-docker/tubemq-manager/manager-docker.sh
+++ b/inlong-tubemq/tubemq-docker/tubemq-manager/manager-docker.sh
@@ -42,4 +42,4 @@ curl --header "Content-Type: application/json" --request POST --data \
 http://localhost:8089/v1/cluster?method=add
 
 # keep alive
-tail -F ${file_path}/../logs/tubemq-manager.out
+tail -F ${file_path}/../logs/info.log


### PR DESCRIPTION
Fixes: #3898 

### Motivation

Fix log paths of Agent, Audit, DataProxy and TubeMQ Manager containers.

### Modifications

change logs path to `logs/info.log`
