### PR TITLE
[INLONG-3951][Manager] Unique index error for cluster_name in SQL file

### DIFF
--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -149,7 +149,7 @@ CREATE TABLE `inlong_cluster_node`
     `create_time` timestamp    NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
     `modify_time` timestamp    NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `unique_cluster_node` (`cluster_name`, `type`, `ip`, `port`, `is_deleted`)
+    UNIQUE KEY `unique_cluster_node` (`parent_id`, `type`, `ip`, `port`, `is_deleted`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='Inlong cluster node table';
 


### PR DESCRIPTION
### Title Name: [INLONG-3951][Manager] Unique index error for cluster_name in SQL file

Fixes #3951 

### Motivation

Unique index error for cluster_name in SQL file.

### Verifying this change

- [X] This change is a trivial rework/code cleanup without any test coverage.
