### PR TITLE
Fix docker-compose quickstart start cmd error

### DIFF
--- a/docker/docker-compose/README.md
+++ b/docker/docker-compose/README.md
@@ -12,7 +12,7 @@ Requirements:
 Manually copy SQL files from `inlong-manager/sql` and `inlong-audit/sql` to the `docker/docker-compose/sql` directory.
 
 ```shell
-cp inlong-manager/sql/apache_inlong_manager.sql docker/docker-compose/sql
+cp inlong-manager/manager-web/sql/apache_inlong_manager.sql docker/docker-compose/sql
 cp inlong-audit/sql/apache_inlong_audit.sql docker/docker-compose/sql
 ```
 


### PR DESCRIPTION
### Title Name: [INLONG-1.0.0][docker-compose] Fix docker-compose quickstart start cmd error


### Motivation


### Modifications

Fix docker-compose quickstart start cmd error

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:

- [x] This change added tests and can be verified as follows:

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
