### PR TITLE
[INLONG-3845][Docker][K8s] Fix the MySQL permission error in Manager Pod

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -18,7 +18,7 @@ version: '3.5'
 
 services:
   mysql:
-    image: mysql:5.7
+    image: mysql:8.0.28
     container_name: mysql
     ports:
       - "3306:3306"

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -41,7 +41,7 @@ images:
     tag: latest
   mysql:
     repository: mysql
-    tag: 5.7
+    tag: 8.0.28
   zookeeper:
     repository: zookeeper
     tag: latest


### PR DESCRIPTION
fixes: #3845

### Motivation

Fix the MySQL permission error in Manager Pod.

![image](https://user-images.githubusercontent.com/49934421/165497391-b9a22ba8-c0e1-4fcb-a9d8-a055f1ee972c.png)

The [manager.log](https://github.com/apache/incubator-inlong/files/8571125/manager.log) by the command:

```shell
sudo kubectl logs inlong-manager-0 -n inlong
```



### Modifications

Modify the mysql container version to 8.0.28.
