### PR TITLE
[INLONG-4001][Docker] Modify MySQL Docker image version to `8.0.28`

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -18,7 +18,7 @@ version: '3.5'
 
 services:
   mysql:
-    image: mysql:5.7
+    image: mysql:8.0.28
     container_name: mysql
     ports:
       - "3306:3306"


### PR DESCRIPTION
Fixes: #4001

### Motivation

Refer to https://github.com/apache/incubator-inlong/pull/3978#issuecomment-1111660330

Modify MySQL Docker image version to `8.0.28`

### Modifications

- `docker/docker-compose/docker-compose.yml`
