### PR TITLE
[INLONG-4097][Sort] Use javax constrain notNull annotation

### DIFF
--- a/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.validation.constraints.NotNull;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericRowData;
@@ -63,7 +64,6 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/cdc/mysql/table/MySqlReadableMetadata.java
+++ b/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/cdc/mysql/table/MySqlReadableMetadata.java
@@ -23,6 +23,7 @@ import io.debezium.data.Envelope;
 import io.debezium.data.Envelope.FieldName;
 import io.debezium.relational.Table;
 import io.debezium.relational.history.TableChanges;
+import javax.annotation.Nullable;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericArrayData;
@@ -37,7 +38,6 @@ import org.apache.inlong.sort.singletenant.flink.cdc.debezium.table.MetadataConv
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/cdc/mysql/table/MySqlReadableMetadata.java
+++ b/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/cdc/mysql/table/MySqlReadableMetadata.java
@@ -114,7 +114,7 @@ public enum MySqlReadableMetadata {
 
             @Override
             public Object read(SourceRecord record,
-                @org.jetbrains.annotations.Nullable TableChanges.TableChange tableSchema, RowData rowData) {
+                @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
                 // construct canal json
                 Struct messageStruct = (Struct) record.value();
                 Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);


### PR DESCRIPTION
### Title Name:[INLONG-4097][Sort] Use javax constrain notNull annotation 

Fixes #4097

### Motivation

<img width="1784" alt="wecom-temp-0ffb6979f88715e81f6ce0508622b358" src="https://user-images.githubusercontent.com/26538404/167233627-d0da484f-e4fd-4085-87a3-69c83012bce8.png">

The jetbrains annotation is in the package of avro, so when remove the dependency the compilation fails

### Modifications

Use javax constrain notNull annotation 

### Verifying this change

### Documentation

  - Does this pull request introduce a new feature? (no)