### PR TITLE
[INLONG-4102][Dashboard] Add tooltip for dataPath of the Hive sink

### DIFF
--- a/inlong-dashboard/src/components/MetaData/StorageHive.tsx
+++ b/inlong-dashboard/src/components/MetaData/StorageHive.tsx
@@ -159,8 +159,9 @@ const getForm: GetStorageFormFieldsType = (
       label: i18n.t('components.AccessHelper.StorageMetaData.Hive.DataPath'),
       name: 'dataPath',
       rules: [{ required: true }],
+      tooltip: i18n.t('components.AccessHelper.StorageMetaData.DataPathHelp'),
       props: {
-        placeholder: 'hdfs://127.0.0.1:9000/user/hive/warehouse',
+        placeholder: 'hdfs://127.0.0.1:9000/user/hive/warehouse/default',
         disabled: isEdit && [110, 130].includes(currentValues?.status),
       },
     },

--- a/inlong-dashboard/src/locales/cn.json
+++ b/inlong-dashboard/src/locales/cn.json
@@ -58,6 +58,7 @@
   "components.AccessHelper.StorageMetaData.Hive.ConnectionSucceeded": "连接成功",
   "components.AccessHelper.StorageMetaData.Hive.ConnectionFailed": "连接失败",
   "components.AccessHelper.StorageMetaData.Hive.DataPath": "数据路径",
+  "components.AccessHelper.StorageMetaData.DataPathHelp": "DB的存储路径，不包括表名，如：hdfs://127.0.0.1:9000/warehouse/inlong.db",
   "components.AccessHelper.StorageMetaData.Hive.FieldName": "字段名",
   "components.AccessHelper.StorageMetaData.Hive.FieldType": "字段类型",
   "components.AccessHelper.StorageMetaData.Hive.FieldDescription": "字段描述",

--- a/inlong-dashboard/src/locales/en.json
+++ b/inlong-dashboard/src/locales/en.json
@@ -58,6 +58,7 @@
   "components.AccessHelper.StorageMetaData.Hive.ConnectionSucceeded": "Connection succeeded",
   "components.AccessHelper.StorageMetaData.Hive.ConnectionFailed": "Connection failed",
   "components.AccessHelper.StorageMetaData.Hive.DataPath": "DataPath",
+  "components.AccessHelper.StorageMetaData.DataPathHelp": "Storage path of the DB, excluding the table name, such as: hdfs://127.0.0.1:9000/warehouse/inlong.db",
   "components.AccessHelper.StorageMetaData.Hive.FieldName": "FieldName",
   "components.AccessHelper.StorageMetaData.Hive.FieldType": "FieldType",
   "components.AccessHelper.StorageMetaData.Hive.FieldDescription": "Field description",


### PR DESCRIPTION
### Title Name: [INLONG-4102][Dashboard] Add tooltip for dataPath of the Hive sink

Fixes #4102 

### Motivation

Add tooltip for dataPath of the Hive sink.

### Verifying this change

- [X] This change is a trivial rework/code cleanup without any test coverage.
