### PR TITLE
[INLONG-3835][Sort] Register CascadeFunctionWrapper in the parent interface

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/transformation/Function.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/transformation/Function.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.protocol.transformation;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonSubTypes;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.inlong.sort.protocol.transformation.function.CascadeFunctionWrapper;
 import org.apache.inlong.sort.protocol.transformation.function.HopEndFunction;
 import org.apache.inlong.sort.protocol.transformation.function.HopFunction;
 import org.apache.inlong.sort.protocol.transformation.function.HopStartFunction;
@@ -56,7 +57,8 @@ import java.util.List;
         @JsonSubTypes.Type(value = MultiValueFilterFunction.class, name = "multiValueFilter"),
         @JsonSubTypes.Type(value = SplitIndexFunction.class, name = "splitIndex"),
         @JsonSubTypes.Type(value = RegexpReplaceFunction.class, name = "regexpReplace"),
-        @JsonSubTypes.Type(value = RegexpReplaceFirstFunction.class, name = "regexpReplaceFirst")
+        @JsonSubTypes.Type(value = RegexpReplaceFirstFunction.class, name = "regexpReplaceFirst"),
+        @JsonSubTypes.Type(value = CascadeFunctionWrapper.class, name = "cascadeFunctionWrapper")
 })
 public interface Function extends FunctionParam {
 

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/transformation/FunctionParam.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/transformation/FunctionParam.java
@@ -22,6 +22,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonSub
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.inlong.sort.protocol.BuiltInFieldInfo;
 import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.transformation.function.CascadeFunctionWrapper;
 import org.apache.inlong.sort.protocol.transformation.function.HopEndFunction;
 import org.apache.inlong.sort.protocol.transformation.function.HopFunction;
 import org.apache.inlong.sort.protocol.transformation.function.HopStartFunction;
@@ -92,7 +93,8 @@ import org.apache.inlong.sort.protocol.transformation.operator.OrOperator;
         @JsonSubTypes.Type(value = MultiValueFilterFunction.class, name = "multiValueFilter"),
         @JsonSubTypes.Type(value = SplitIndexFunction.class, name = "splitIndex"),
         @JsonSubTypes.Type(value = RegexpReplaceFunction.class, name = "regexpReplace"),
-        @JsonSubTypes.Type(value = RegexpReplaceFirstFunction.class, name = "regexpReplaceFirst")
+        @JsonSubTypes.Type(value = RegexpReplaceFirstFunction.class, name = "regexpReplaceFirst"),
+        @JsonSubTypes.Type(value = CascadeFunctionWrapper.class, name = "cascadeFunctionWrapper")
 })
 public interface FunctionParam {
 

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/transformation/function/CascadeFunctionWrapperTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/transformation/function/CascadeFunctionWrapperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.transformation.function;
+
+import org.apache.inlong.sort.formats.common.StringFormatInfo;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.transformation.Function;
+import org.apache.inlong.sort.protocol.transformation.FunctionBaseTest;
+import org.apache.inlong.sort.protocol.transformation.StringConstantParam;
+
+import java.util.Arrays;
+
+/**
+ * Test for {@link CascadeFunctionWrapper}
+ */
+public class CascadeFunctionWrapperTest extends FunctionBaseTest {
+
+    @Override
+    public Function getTestObject() {
+        return new CascadeFunctionWrapper(
+                Arrays.asList(
+                        new RegexpReplaceFirstFunction(new FieldInfo("replace_field", new StringFormatInfo()),
+                                new StringConstantParam("replace_str"),
+                                new StringConstantParam("target_str")),
+                        new RegexpReplaceFunction(new FieldInfo("replace_field", new StringFormatInfo()),
+                                new StringConstantParam("replace_str"),
+                                new StringConstantParam("target_str"))
+                ));
+    }
+
+    @Override
+    public String getExpectFormat() {
+        return "REGEXP_REPLACE(REGEXP_REPLACE_FIRST(`replace_field`, 'replace_str', 'target_str'), "
+                + "'replace_str', 'target_str')";
+    }
+}


### PR DESCRIPTION
### Title Name: [INLONG-3835][Sort] Register CascadeFunctionWrapper in the parent interface

Fixes #3835 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
