### PR TITLE
[INLONG-4120][Manager] Change the keyWord to keyword in query params

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
@@ -166,7 +166,7 @@ public class InnerInlongManagerClient {
             pageNum = 1;
         }
         JSONObject groupQuery = new JSONObject();
-        groupQuery.put("keyWord", keyword);
+        groupQuery.put("keyword", keyword);
         groupQuery.put("status", status);
         groupQuery.put("pageNum", pageNum);
         groupQuery.put("pageSize", pageSize);

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/ClusterPageRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/ClusterPageRequest.java
@@ -38,8 +38,8 @@ public class ClusterPageRequest extends PageRequest {
     @ApiModelProperty(value = "Cluster IP")
     private String ip;
 
-    @ApiModelProperty(value = "Keywords, name, description, etc.")
-    private String keyWord;
+    @ApiModelProperty(value = "Keyword, name, description, etc.")
+    private String keyword;
 
     @ApiModelProperty(value = "Status")
     private Integer status;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/group/InlongGroupPageRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/group/InlongGroupPageRequest.java
@@ -33,8 +33,8 @@ import java.util.List;
 @ApiModel("Inlong group query request")
 public class InlongGroupPageRequest extends PageRequest {
 
-    @ApiModelProperty(value = "Keywords")
-    private String keyWord;
+    @ApiModelProperty(value = "Keyword, can be group id or name")
+    private String keyword;
 
     @ApiModelProperty(value = "Inlong group name list")
     private List<String> nameList;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sink/SinkPageRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sink/SinkPageRequest.java
@@ -43,8 +43,8 @@ public class SinkPageRequest extends PageRequest {
     @ApiModelProperty(value = "Sink type, such as HIVE")
     private String sinkType;
 
-    @ApiModelProperty(value = "Key word")
-    private String keyWord;
+    @ApiModelProperty(value = "Keyword, can be group id, stream id or sink name")
+    private String keyword;
 
     @ApiModelProperty(value = "Status")
     private Integer status;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/SourcePageRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/SourcePageRequest.java
@@ -43,8 +43,8 @@ public class SourcePageRequest extends PageRequest {
     @ApiModelProperty(value = "Source type, such as FILE")
     private String sourceType;
 
-    @ApiModelProperty(value = "Key word")
-    private String keyWord;
+    @ApiModelProperty(value = "Keyword, can be group id, stream id or source name")
+    private String keyword;
 
     @ApiModelProperty(value = "Status")
     private Integer status;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/stream/InlongStreamPageRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/stream/InlongStreamPageRequest.java
@@ -34,8 +34,8 @@ public class InlongStreamPageRequest extends PageRequest {
     @ApiModelProperty(value = "Inlong group id")
     private String inlongGroupId;
 
-    @ApiModelProperty(value = "Key word")
-    private String keyWord;
+    @ApiModelProperty(value = "Keyword, can be stream id or name")
+    private String keyword;
 
     @ApiModelProperty(value = "Source type, including: FILE, DB, AUTO_PUSH (DATA_PROXY_SDK, HTTP)")
     private String dataSourceType;

--- a/inlong-manager/manager-dao/src/main/resources/mappers/DataProxyClusterEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/DataProxyClusterEntityMapper.xml
@@ -57,8 +57,8 @@
         <where>
             is_deleted = 0
             and find_in_set(#{currentUser,jdbcType=VARCHAR}, in_charges)
-            <if test="keyWord != null and keyWord != ''">
-                and (name like CONCAT('%', #{keyWord}, '%') or description like CONCAT('%', #{keyWord}, '%'))
+            <if test="keyword != null and keyword != ''">
+                and (name like CONCAT('%', #{keyword}, '%') or description like CONCAT('%', #{keyword}, '%'))
             </if>
             <if test="status != null and status != ''">
                 and status = #{status, jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -112,8 +112,8 @@
                 creator = #{currentUser, jdbcType=VARCHAR} or find_in_set(#{currentUser, jdbcType=VARCHAR}, in_charges)
                 )
             </if>
-            <if test="keyWord != null and keyWord != ''">
-                and (inlong_group_id like CONCAT('%',#{keyWord},'%') or name like CONCAT('%',#{keyWord},'%'))
+            <if test="keyword != null and keyword != ''">
+                and (inlong_group_id like CONCAT('%',#{keyword},'%') or name like CONCAT('%',#{keyword},'%'))
             </if>
             <if test="groupIdList != null and groupIdList.size() > 0">
                 and inlong_group_id in

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongStreamEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongStreamEntityMapper.xml
@@ -111,10 +111,10 @@
             <if test="request.dataSourceType != null and request.dataSourceType != ''">
                 and stream.data_source_type = #{request.dataSourceType, jdbcType=VARCHAR}
             </if>
-            <if test="request.keyWord != null and request.keyWord != ''">
-                and (stream.inlong_stream_id like CONCAT('%', #{request.keyWord}, '%')
-                or stream.name like CONCAT('%', #{request.keyWord}, '%')
-                or stream.description like CONCAT('%', #{request.keyWord}, '%')
+            <if test="request.keyword != null and request.keyword != ''">
+                and (
+                stream.inlong_stream_id like CONCAT('%', #{request.keyword}, '%')
+                or stream.name like CONCAT('%', #{request.keyword}, '%')
                 )
             </if>
             <if test="request.status != null and request.status != ''">

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
@@ -84,11 +84,11 @@
             <if test="request.inlongStreamId != null and request.inlongStreamId != ''">
                 and inlong_stream_id = #{request.inlongStreamId, jdbcType=VARCHAR}
             </if>
-            <if test="request.keyWord != null and request.keyWord != ''">
+            <if test="request.keyword != null and request.keyword != ''">
                 and (
-                inlong_group_id like CONCAT('%', #{request.keyWord}, '%')
-                or inlong_stream_id like CONCAT('%', #{request.keyWord}, '%')
-                or sink_name like CONCAT('%', #{request.keyWord}, '%')
+                inlong_group_id like CONCAT('%', #{request.keyword}, '%')
+                or inlong_stream_id like CONCAT('%', #{request.keyword}, '%')
+                or sink_name like CONCAT('%', #{request.keyword}, '%')
                 )
             </if>
             <if test="request.status != null and request.status != ''">

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
@@ -110,11 +110,11 @@
             <if test="request.sourceType != null and request.sourceType != ''">
                 and source_type = #{request.sourceType, jdbcType=VARCHAR}
             </if>
-            <if test="request.keyWord != null and request.keyWord != ''">
+            <if test="request.keyword != null and request.keyword != ''">
                 and (
-                inlong_group_id like CONCAT('%', #{request.keyWord}, '%')
-                or inlong_stream_id like CONCAT('%', #{request.keyWord}, '%')
-                or source_name like CONCAT('%', #{request.keyWord}, '%')
+                inlong_group_id like CONCAT('%', #{request.keyword}, '%')
+                or inlong_stream_id like CONCAT('%', #{request.keyword}, '%')
+                or source_name like CONCAT('%', #{request.keyword}, '%')
                 )
             </if>
             <if test="request.status != null and request.status != ''">


### PR DESCRIPTION
### Title Name: [INLONG-4120][Manager] Change the keyWord to keyword in query params

Fixes #4120

### Motivation

Change the keyWord to keyword in query params, because the keyWord was error.

### Verifying this change

- [X] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (no)
