### PR TITLE
[INLONG-4133][Manager] Not pass the type field when querying sources and sinks

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkService.java
@@ -42,13 +42,12 @@ public interface StreamSinkService {
     Integer save(SinkRequest request, String operator);
 
     /**
-     * Query sink information based on id and type.
+     * Query sink information based on id.
      *
      * @param id Sink id.
-     * @param sinkType Sink type.
      * @return Sink info.
      */
-    SinkResponse get(Integer id, String sinkType);
+    SinkResponse get(Integer id);
 
     /**
      * Query sink information based on inlong group id and inlong stream id.

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/StreamSourceService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/StreamSourceService.java
@@ -40,13 +40,12 @@ public interface StreamSourceService {
     Integer save(SourceRequest request, String operator);
 
     /**
-     * Query source information based on id and type.
+     * Query source information based on id
      *
      * @param id source id.
-     * @param sourceType Source type.
      * @return Source info
      */
-    SourceResponse get(Integer id, String sourceType);
+    SourceResponse get(Integer id);
 
     /**
      * Query source information based on inlong group id and inlong stream id.

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/listener/AbstractSourceOperateListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/listener/AbstractSourceOperateListener.java
@@ -110,7 +110,7 @@ public abstract class AbstractSourceOperateListener implements DataSourceOperate
             } else {
                 log.warn("StreamSource={} cannot be operated for state={}", sourceResponse, sourceStatus);
                 TimeUnit.SECONDS.sleep(5);
-                sourceResponse = streamSourceService.get(sourceResponse.getId(), sourceResponse.getSourceType());
+                sourceResponse = streamSourceService.get(sourceResponse.getId());
             }
         }
         SourceStatus sourceStatus = SourceStatus.forCode(sourceResponse.getStatus());

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/sink/ClickHouseStreamSinkServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/sink/ClickHouseStreamSinkServiceTest.java
@@ -74,7 +74,7 @@ public class ClickHouseStreamSinkServiceTest extends ServiceBaseTest {
     @Test
     public void testListByIdentifier() {
         Integer sinkId = this.saveSink("default1");
-        SinkResponse sink = sinkService.get(sinkId, SinkType.SINK_CLICKHOUSE);
+        SinkResponse sink = sinkService.get(sinkId);
         Assert.assertEquals(globalGroupId, sink.getInlongGroupId());
         deleteKafkaSink(sinkId);
     }
@@ -82,7 +82,7 @@ public class ClickHouseStreamSinkServiceTest extends ServiceBaseTest {
     @Test
     public void testGetAndUpdate() {
         Integer sinkId = this.saveSink("default2");
-        SinkResponse response = sinkService.get(sinkId, SinkType.SINK_CLICKHOUSE);
+        SinkResponse response = sinkService.get(sinkId);
         Assert.assertEquals(globalGroupId, response.getInlongGroupId());
 
         ClickHouseSinkResponse kafkaSinkResponse = (ClickHouseSinkResponse) response;

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/sink/HiveStreamSinkServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/sink/HiveStreamSinkServiceTest.java
@@ -70,7 +70,7 @@ public class HiveStreamSinkServiceTest extends ServiceBaseTest {
     public void testListByIdentifier() {
         Integer id = this.saveSink();
 
-        SinkResponse sink = sinkService.get(id, SinkType.SINK_HIVE);
+        SinkResponse sink = sinkService.get(id);
         Assert.assertEquals(globalGroupId, sink.getInlongGroupId());
 
         sinkService.delete(id, SinkType.SINK_HIVE, globalOperator);
@@ -79,7 +79,7 @@ public class HiveStreamSinkServiceTest extends ServiceBaseTest {
     @Test
     public void testGetAndUpdate() {
         Integer id = this.saveSink();
-        SinkResponse response = sinkService.get(id, SinkType.SINK_HIVE);
+        SinkResponse response = sinkService.get(id);
         Assert.assertEquals(globalGroupId, response.getInlongGroupId());
 
         HiveSinkResponse hiveResponse = (HiveSinkResponse) response;

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/sink/IcebergStreamSinkServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/sink/IcebergStreamSinkServiceTest.java
@@ -66,7 +66,7 @@ public class IcebergStreamSinkServiceTest extends ServiceBaseTest {
     @Test
     public void testListByIdentifier() {
         Integer id = this.saveSink("default2");
-        SinkResponse sink = sinkService.get(id, SinkType.SINK_ICEBERG);
+        SinkResponse sink = sinkService.get(id);
         Assert.assertEquals(globalGroupId, sink.getInlongGroupId());
         sinkService.delete(id, SinkType.SINK_ICEBERG, globalOperator);
     }
@@ -74,7 +74,7 @@ public class IcebergStreamSinkServiceTest extends ServiceBaseTest {
     @Test
     public void testGetAndUpdate() {
         Integer id = this.saveSink("default3");
-        SinkResponse response = sinkService.get(id, SinkType.SINK_ICEBERG);
+        SinkResponse response = sinkService.get(id);
         Assert.assertEquals(globalGroupId, response.getInlongGroupId());
 
         IcebergSinkResponse icebergSinkResponse = (IcebergSinkResponse) response;

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/sink/KafkaStreamSinkServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/sink/KafkaStreamSinkServiceTest.java
@@ -71,7 +71,7 @@ public class KafkaStreamSinkServiceTest extends ServiceBaseTest {
     @Test
     public void testListByIdentifier() {
         Integer kafkaSinkId = this.saveSink("default1");
-        SinkResponse sink = sinkService.get(kafkaSinkId, SinkType.SINK_KAFKA);
+        SinkResponse sink = sinkService.get(kafkaSinkId);
         Assert.assertEquals(globalGroupId, sink.getInlongGroupId());
         deleteKafkaSink(kafkaSinkId);
     }
@@ -79,7 +79,7 @@ public class KafkaStreamSinkServiceTest extends ServiceBaseTest {
     @Test
     public void testGetAndUpdate() {
         Integer kafkaSinkId = this.saveSink("default2");
-        SinkResponse response = sinkService.get(kafkaSinkId, SinkType.SINK_KAFKA);
+        SinkResponse response = sinkService.get(kafkaSinkId);
         Assert.assertEquals(globalGroupId, response.getInlongGroupId());
 
         KafkaSinkResponse kafkaSinkResponse = (KafkaSinkResponse) response;

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/source/StreamSourceServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/source/StreamSourceServiceTest.java
@@ -68,7 +68,7 @@ public class StreamSourceServiceTest extends ServiceBaseTest {
     public void testListByIdentifier() {
         Integer id = this.saveSource();
 
-        SourceResponse source = sourceService.get(id, SourceType.BINLOG.getType());
+        SourceResponse source = sourceService.get(id);
         Assert.assertEquals(globalGroupId, source.getInlongGroupId());
 
         sourceService.delete(id, SourceType.BINLOG.getType(), globalOperator);
@@ -77,7 +77,7 @@ public class StreamSourceServiceTest extends ServiceBaseTest {
     @Test
     public void testGetAndUpdate() {
         Integer id = this.saveSource();
-        SourceResponse response = sourceService.get(id, SourceType.BINLOG.getType());
+        SourceResponse response = sourceService.get(id);
         Assert.assertEquals(globalGroupId, response.getInlongGroupId());
 
         BinlogSourceResponse binlogResponse = (BinlogSourceResponse) response;

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/source/listener/DataSourceListenerTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/source/listener/DataSourceListenerTest.java
@@ -88,7 +88,7 @@ public class DataSourceListenerTest extends WorkflowServiceImplTest {
         WorkflowProcess process = context.getProcess();
         WorkflowTask task = process.getTaskByName("stopSource");
         Assert.assertTrue(task instanceof ServiceTask);
-        SourceResponse sourceResponse = streamSourceService.get(sourceId, SourceType.BINLOG.toString());
+        SourceResponse sourceResponse = streamSourceService.get(sourceId);
         Assert.assertSame(SourceStatus.forCode(sourceResponse.getStatus()), SourceStatus.TO_BE_ISSUED_FROZEN);
     }
 
@@ -119,7 +119,7 @@ public class DataSourceListenerTest extends WorkflowServiceImplTest {
         WorkflowProcess process = context.getProcess();
         WorkflowTask task = process.getTaskByName("restartSource");
         Assert.assertTrue(task instanceof ServiceTask);
-        SourceResponse sourceResponse = streamSourceService.get(sourceId, SourceType.BINLOG.toString());
+        SourceResponse sourceResponse = streamSourceService.get(sourceId);
         Assert.assertSame(SourceStatus.forCode(sourceResponse.getStatus()), SourceStatus.TO_BE_ISSUED_ACTIVE);
     }
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSinkController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSinkController.java
@@ -69,12 +69,9 @@ public class StreamSinkController {
 
     @RequestMapping(value = "/get/{id}", method = RequestMethod.GET)
     @ApiOperation(value = "Query sink information")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "id", dataTypeClass = Integer.class, required = true),
-            @ApiImplicitParam(name = "sinkType", dataTypeClass = String.class, required = true)
-    })
-    public Response<SinkResponse> get(@PathVariable Integer id, @RequestParam String sinkType) {
-        return Response.success(sinkService.get(id, sinkType));
+    @ApiImplicitParam(name = "id", dataTypeClass = Integer.class, required = true)
+    public Response<SinkResponse> get(@PathVariable Integer id) {
+        return Response.success(sinkService.get(id));
     }
 
     @RequestMapping(value = "/list", method = RequestMethod.GET)

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSourceController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSourceController.java
@@ -60,12 +60,9 @@ public class StreamSourceController {
 
     @RequestMapping(value = "/get/{id}", method = RequestMethod.GET)
     @ApiOperation(value = "Query stream source")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "id", dataTypeClass = Integer.class, required = true),
-            @ApiImplicitParam(name = "sourceType", dataTypeClass = String.class, required = true)
-    })
-    public Response<SourceResponse> get(@PathVariable Integer id, @RequestParam String sourceType) {
-        return Response.success(sourceService.get(id, sourceType));
+    @ApiImplicitParam(name = "id", dataTypeClass = Integer.class, required = true)
+    public Response<SourceResponse> get(@PathVariable Integer id) {
+        return Response.success(sourceService.get(id));
     }
 
     @RequestMapping(value = "/list", method = RequestMethod.GET)


### PR DESCRIPTION
### Title Name: [INLONG-4133][component] Not pass the type field when querying sources and sinks

Fixes #4133

### Motivation

Not pass the type field when querying sources and sinks

### Modifications

Modify the parameters of the get function in the controller of source and sink

Add verification names for the saving and modification methods of source and sink whether they are the same

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [X] This change is already covered by existing tests, such as:
  *(please describe tests)*
`org.apache.inlong.manager.service.core.source.StreamSourceServiceTest`
`org.apache.inlong.manager.service.core.sink.ClickHouseStreamSinkServiceTest`
`org.apache.inlong.manager.service.core.sink.KafkaStreamSinkServiceTest`
- [ ] This change added tests and can be verified as follows:


### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
