### PR TITLE
[INLONG-4139][Manager] Query inlong group by the status list in manager client

### DIFF
--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CommandDescribe.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CommandDescribe.java
@@ -21,7 +21,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.github.pagehelper.PageInfo;
 import org.apache.inlong.manager.client.api.inner.InnerInlongManagerClient;
-import org.apache.inlong.manager.client.cli.util.PrintUtil;
+import org.apache.inlong.manager.client.cli.util.PrintUtils;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupListResponse;
 import org.apache.inlong.manager.common.pojo.sink.SinkListResponse;
 import org.apache.inlong.manager.common.pojo.source.SourceListResponse;
@@ -57,7 +57,7 @@ public class CommandDescribe extends CommandBase {
             try {
                 InnerInlongManagerClient managerClient = new InnerInlongManagerClient(connect().getConfiguration());
                 List<FullStreamResponse> fullStreamResponseList = managerClient.listStreamInfo(groupId);
-                fullStreamResponseList.forEach(response -> PrintUtil.printJson(response.getStreamInfo()));
+                fullStreamResponseList.forEach(response -> PrintUtils.printJson(response.getStreamInfo()));
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }
@@ -84,7 +84,7 @@ public class CommandDescribe extends CommandBase {
             try {
                 InnerInlongManagerClient managerClient = new InnerInlongManagerClient(connect().getConfiguration());
                 PageInfo<InlongGroupListResponse> groupPageInfo = managerClient.listGroups(group, status, 1, pageSize);
-                groupPageInfo.getList().forEach(PrintUtil::printJson);
+                groupPageInfo.getList().forEach(PrintUtils::printJson);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }
@@ -108,7 +108,7 @@ public class CommandDescribe extends CommandBase {
             InnerInlongManagerClient managerClient = new InnerInlongManagerClient(connect().getConfiguration());
             try {
                 List<SinkListResponse> sinkListResponses = managerClient.listSinks(group, stream);
-                sinkListResponses.forEach(PrintUtil::printJson);
+                sinkListResponses.forEach(PrintUtils::printJson);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }
@@ -135,7 +135,7 @@ public class CommandDescribe extends CommandBase {
             try {
                 InnerInlongManagerClient managerClient = new InnerInlongManagerClient(connect().getConfiguration());
                 List<SourceListResponse> sourceListResponses = managerClient.listSources(group, stream, type);
-                sourceListResponses.forEach(PrintUtil::printJson);
+                sourceListResponses.forEach(PrintUtils::printJson);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CommandList.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CommandList.java
@@ -97,16 +97,13 @@ public class CommandList extends CommandBase {
             try {
                 InlongGroupPageRequest pageRequest = new InlongGroupPageRequest();
                 pageRequest.setKeyword(group);
+                // set default page size to DEFAULT_PAGE_SIZE
                 pageSize = pageSize <= 0 ? DEFAULT_PAGE_SIZE : pageSize;
                 pageRequest.setPageNum(1).setPageSize(pageSize);
 
-                List<Integer> statusList = null;
-                if (status != null) {
-                    statusList = InlongGroupStatus.parseStatusCodeByStr(status);
-                }
-                if (CollectionUtils.isEmpty(statusList)) {
-                    statusList = InlongGroupStatus.parseStatusCodeByStr(InlongGroupStatus.STARTED.toString());
-                }
+                // set default status to STARTED
+                status = status == null ? InlongGroupStatus.STARTED.toString() : status;
+                List<Integer> statusList = statusList = InlongGroupStatus.parseStatusCodeByStr(status);
                 pageRequest.setStatusList(statusList);
 
                 InnerInlongManagerClient client = new InnerInlongManagerClient(connect().getConfiguration());

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CommandList.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CommandList.java
@@ -43,7 +43,7 @@ import java.util.List;
 public class CommandList extends CommandBase {
 
     @Parameter()
-    private java.util.List<String> params;
+    private List<String> params;
 
     public CommandList() {
         super("list");
@@ -57,7 +57,7 @@ public class CommandList extends CommandBase {
     private static class ListStream extends CommandUtil {
 
         @Parameter()
-        private java.util.List<String> params;
+        private List<String> params;
 
         @Parameter(names = {"-g", "--group"}, required = true, description = "inlong group id")
         private String groupId;
@@ -81,20 +81,23 @@ public class CommandList extends CommandBase {
     @Parameters(commandDescription = "Get group details")
     private static class ListGroup extends CommandUtil {
 
-        @Parameter(names = {"-n", "--num"}, description = "the number displayed")
-        private final int pageSize = 10;
+        private static final int DEFAULT_PAGE_SIZE = 10;
+
         @Parameter()
         private List<String> params;
         @Parameter(names = {"-s", "--status"})
         private String status;
         @Parameter(names = {"-g", "--group"}, description = "inlong group id")
         private String group;
+        @Parameter(names = {"-n", "--num"}, description = "the number displayed")
+        private int pageSize;
 
         @Override
         void run() {
             try {
                 InlongGroupPageRequest pageRequest = new InlongGroupPageRequest();
                 pageRequest.setKeyword(group);
+                pageSize = pageSize <= 0 ? DEFAULT_PAGE_SIZE : pageSize;
                 pageRequest.setPageNum(1).setPageSize(pageSize);
 
                 List<Integer> statusList = null;
@@ -121,7 +124,7 @@ public class CommandList extends CommandBase {
     private static class ListSink extends CommandUtil {
 
         @Parameter()
-        private java.util.List<String> params;
+        private List<String> params;
 
         @Parameter(names = {"-s", "--stream"}, required = true, description = "stream id")
         private String stream;
@@ -145,7 +148,7 @@ public class CommandList extends CommandBase {
     private static class ListSource extends CommandUtil {
 
         @Parameter()
-        private java.util.List<String> params;
+        private List<String> params;
 
         @Parameter(names = {"-s", "--stream"}, required = true, description = "inlong stream id")
         private String stream;

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CommandList.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CommandList.java
@@ -20,7 +20,6 @@ package org.apache.inlong.manager.client.cli;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.github.pagehelper.PageInfo;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.inlong.manager.client.api.InlongGroupContext.InlongGroupStatus;
 import org.apache.inlong.manager.client.api.inner.InnerInlongManagerClient;
 import org.apache.inlong.manager.client.cli.pojo.GroupInfo;

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CommandToolMain.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CommandToolMain.java
@@ -20,7 +20,6 @@ package org.apache.inlong.manager.client.cli;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,13 +44,7 @@ public class CommandToolMain {
         for (Map.Entry<String, Class<?>> cmd : commandMap.entrySet()) {
             try {
                 jcommander.addCommand(cmd.getKey(), cmd.getValue().getConstructor().newInstance());
-            } catch (InstantiationException e) {
-                e.printStackTrace();
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-            } catch (InvocationTargetException e) {
-                e.printStackTrace();
-            } catch (NoSuchMethodException e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/GroupInfo.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/GroupInfo.java
@@ -18,7 +18,7 @@
 package org.apache.inlong.manager.client.cli.pojo;
 
 import lombok.Data;
-import org.apache.inlong.manager.client.api.InlongGroupContext.InlongGroupState;
+import org.apache.inlong.manager.client.api.InlongGroupContext.InlongGroupStatus;
 
 import java.util.Date;
 
@@ -33,7 +33,7 @@ public class GroupInfo {
     private Date modifyTime;
 
     public void setStatus(String status) {
-        InlongGroupState inlongGroupState = InlongGroupState.parseByBizStatus(Integer.parseInt(status));
-        this.status = inlongGroupState.name() + " (" + status + ")";
+        InlongGroupStatus groupStatus = InlongGroupStatus.parseStatusByCode(Integer.parseInt(status));
+        this.status = groupStatus.name() + " (" + status + ")";
     }
 }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/util/PrintUtils.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/util/PrintUtils.java
@@ -30,7 +30,10 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-public class PrintUtil {
+/**
+ * Util that prints information to the console.
+ */
+public class PrintUtils {
 
     private static final String joint = "+";
     private static final String horizontal = "—";

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/GroupStatus.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/GroupStatus.java
@@ -20,13 +20,13 @@ package org.apache.inlong.manager.client.cli.validator;
 import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.ParameterException;
 import org.apache.commons.lang3.EnumUtils;
-import org.apache.inlong.manager.client.api.InlongGroupContext;
+import org.apache.inlong.manager.client.api.InlongGroupContext.InlongGroupStatus;
 
 public class GroupStatus implements IParameterValidator {
 
     @Override
     public void validate(String name, String value) throws ParameterException {
-        if (!EnumUtils.isValidEnum(InlongGroupContext.InlongGroupState.class, value)) {
+        if (!EnumUtils.isValidEnum(InlongGroupStatus.class, value)) {
             String msg = "should be one of the following values:\n"
                     + "\tCREATE, REJECTED, INITIALIZING, OPERATING, STARTED, FAILED, STOPPED, FINISHED, DELETED";
             throw new ParameterException("Parameter " + name + msg);

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.manager.client.api;
 
-import org.apache.inlong.manager.client.api.InlongGroupContext.InlongGroupState;
+import org.apache.inlong.manager.client.api.InlongGroupContext.InlongGroupStatus;
 import org.apache.inlong.manager.client.api.impl.InlongClientImpl;
 
 import java.util.List;
@@ -82,7 +82,7 @@ public interface InlongClient {
      * @return
      * @throws Exception
      */
-    Map<String, InlongGroupState> listGroupState(List<String> groupNames) throws Exception;
+    Map<String, InlongGroupStatus> listGroupState(List<String> groupNames) throws Exception;
 
     /**
      * Gets group.

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongGroupContext.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongGroupContext.java
@@ -69,7 +69,7 @@ public class InlongGroupContext implements Serializable {
      */
     private Map<String, Map<String, List<String>>> streamErrLogs = Maps.newHashMap();
 
-    private InlongGroupState state;
+    private InlongGroupStatus state;
 
     public InlongGroupContext(InnerGroupContext groupContext, InlongGroupConf streamGroupConf) {
         InlongGroupInfo groupInfo = groupContext.getGroupInfo();
@@ -80,7 +80,7 @@ public class InlongGroupContext implements Serializable {
         this.inlongStreamMap = groupContext.getStreamMap();
         this.groupErrLogs = Maps.newHashMap();
         this.groupLogs = Maps.newHashMap();
-        this.state = InlongGroupState.parseByBizStatus(groupInfo.getStatus());
+        this.state = InlongGroupStatus.parseStatusByCode(groupInfo.getStatus());
         recheckState();
         this.extensions = Maps.newHashMap();
         List<InlongGroupExtInfo> extInfos = groupInfo.getExtList();
@@ -113,7 +113,7 @@ public class InlongGroupContext implements Serializable {
         });
         // check if any stream source is failed
         if (CollectionUtils.isNotEmpty(failedSources)) {
-            this.state = InlongGroupState.FAILED;
+            this.state = InlongGroupStatus.FAILED;
             for (StreamSource failedSource : failedSources) {
                 this.groupErrLogs.computeIfAbsent("failedSources", Lists::newArrayList)
                         .add(GsonUtil.toJson(failedSource));
@@ -126,7 +126,7 @@ public class InlongGroupContext implements Serializable {
                 for (StreamSource source : sourcesInGroup) {
                     if (source.getState() != State.NORMAL) {
                         log.warn("StreamSource:{} is not started", source);
-                        this.state = InlongGroupState.INITIALIZING;
+                        this.state = InlongGroupStatus.INITIALIZING;
                         break;
                     }
                 }
@@ -135,24 +135,27 @@ public class InlongGroupContext implements Serializable {
                 for (StreamSource source : sourcesInGroup) {
                     if (source.getState() != State.FROZEN) {
                         log.warn("StreamSource:{} is not stopped", source);
-                        this.state = InlongGroupState.OPERATING;
+                        this.state = InlongGroupStatus.OPERATING;
                         break;
                     }
                 }
                 return;
             default:
-                return;
         }
     }
 
-    public enum InlongGroupState {
+    public enum InlongGroupStatus {
+
         CREATE, REJECTED, INITIALIZING, OPERATING, STARTED, FAILED, STOPPED, FINISHED, DELETED;
 
-        // Reference to  org.apache.inlong.manager.common.enums.GroupState code
-        public static InlongGroupState parseByBizStatus(int bizCode) {
-
-            GroupStatus groupStatus = GroupStatus.forCode(bizCode);
-
+        /**
+         * Parse InlongGroupStatus from the status code
+         *
+         * @param code of status
+         * @see org.apache.inlong.manager.common.enums.GroupStatus
+         */
+        public static InlongGroupStatus parseStatusByCode(int code) {
+            GroupStatus groupStatus = GroupStatus.forCode(code);
             switch (groupStatus) {
                 case DRAFT:
                 case TO_BE_SUBMIT:
@@ -179,55 +182,59 @@ public class InlongGroupContext implements Serializable {
                 case DELETED:
                     return DELETED;
                 default:
-                    throw new IllegalArgumentException(String.format("Unsupported status %s for group", bizCode));
+                    throw new IllegalArgumentException(String.format("Unsupported status %s for group", code));
             }
         }
 
-        public static List<Integer> parseStatusByStrState(String state) {
-
-            InlongGroupState groupState;
+        /**
+         * Parse group status code by the status string
+         *
+         * @see org.apache.inlong.manager.common.enums.GroupStatus
+         */
+        public static List<Integer> parseStatusCodeByStr(String status) {
+            InlongGroupStatus groupStatus;
             try {
-                groupState = InlongGroupState.valueOf(state);
+                groupStatus = InlongGroupStatus.valueOf(status);
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException(String.format("Unsupported status %s for group", state));
+                throw new IllegalArgumentException(String.format("Unsupported status %s for group", status));
             }
 
-            List<Integer> stateList = new ArrayList<>();
-            switch (groupState) {
+            List<Integer> statusList = new ArrayList<>();
+            switch (groupStatus) {
                 case CREATE:
-                    stateList.add(GroupStatus.DRAFT.getCode());
-                    return stateList;
+                    statusList.add(GroupStatus.DRAFT.getCode());
+                    return statusList;
                 case OPERATING:
-                    stateList.add(GroupStatus.DELETING.getCode());
-                    stateList.add(GroupStatus.SUSPENDING.getCode());
-                    stateList.add(GroupStatus.RESTARTING.getCode());
-                    return stateList;
+                    statusList.add(GroupStatus.DELETING.getCode());
+                    statusList.add(GroupStatus.SUSPENDING.getCode());
+                    statusList.add(GroupStatus.RESTARTING.getCode());
+                    return statusList;
                 case REJECTED:
-                    stateList.add(GroupStatus.APPROVE_REJECTED.getCode());
-                    return stateList;
+                    statusList.add(GroupStatus.APPROVE_REJECTED.getCode());
+                    return statusList;
                 case INITIALIZING:
-                    stateList.add(GroupStatus.TO_BE_APPROVAL.getCode());
-                    stateList.add(GroupStatus.APPROVE_PASSED.getCode());
-                    stateList.add(GroupStatus.CONFIG_ING.getCode());
-                    return stateList;
+                    statusList.add(GroupStatus.TO_BE_APPROVAL.getCode());
+                    statusList.add(GroupStatus.APPROVE_PASSED.getCode());
+                    statusList.add(GroupStatus.CONFIG_ING.getCode());
+                    return statusList;
                 case FAILED:
-                    stateList.add(GroupStatus.CONFIG_FAILED.getCode());
-                    return stateList;
+                    statusList.add(GroupStatus.CONFIG_FAILED.getCode());
+                    return statusList;
                 case STARTED:
-                    stateList.add(GroupStatus.RESTARTED.getCode());
-                    stateList.add(GroupStatus.CONFIG_SUCCESSFUL.getCode());
-                    return stateList;
+                    statusList.add(GroupStatus.RESTARTED.getCode());
+                    statusList.add(GroupStatus.CONFIG_SUCCESSFUL.getCode());
+                    return statusList;
                 case STOPPED:
-                    stateList.add(GroupStatus.SUSPENDED.getCode());
-                    return stateList;
+                    statusList.add(GroupStatus.SUSPENDED.getCode());
+                    return statusList;
                 case FINISHED:
-                    stateList.add(GroupStatus.FINISH.getCode());
-                    return stateList;
+                    statusList.add(GroupStatus.FINISH.getCode());
+                    return statusList;
                 case DELETED:
-                    stateList.add(GroupStatus.DELETED.getCode());
-                    return stateList;
+                    statusList.add(GroupStatus.DELETED.getCode());
+                    return statusList;
                 default:
-                    throw new IllegalArgumentException(String.format("Unsupported status %s for group", state));
+                    throw new IllegalArgumentException(String.format("Unsupported status %s for group", status));
             }
         }
     }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongGroupImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongGroupImpl.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.inlong.manager.client.api.InlongGroup;
 import org.apache.inlong.manager.client.api.InlongGroupConf;
 import org.apache.inlong.manager.client.api.InlongGroupContext;
-import org.apache.inlong.manager.client.api.InlongGroupContext.InlongGroupState;
+import org.apache.inlong.manager.client.api.InlongGroupContext.InlongGroupStatus;
 import org.apache.inlong.manager.client.api.InlongStream;
 import org.apache.inlong.manager.client.api.InlongStreamBuilder;
 import org.apache.inlong.manager.client.api.InlongStreamConf;
@@ -128,8 +128,8 @@ public class InlongGroupImpl implements InlongGroup {
         }
         final String groupId = "b_" + conf.getGroupName();
         InlongGroupResponse groupResponse = managerClient.getGroupInfo(groupId);
-        InlongGroupState state = InlongGroupState.parseByBizStatus(groupResponse.getStatus());
-        AssertUtil.isTrue(state != InlongGroupState.INITIALIZING,
+        InlongGroupStatus state = InlongGroupStatus.parseStatusByCode(groupResponse.getStatus());
+        AssertUtil.isTrue(state != InlongGroupStatus.INITIALIZING,
                 "Inlong Group is in init state, should not be updated");
         InlongGroupInfo groupInfo = InlongGroupTransfer.createGroupInfo(conf);
         InlongGroupRequest groupRequest = groupInfo.genRequest();
@@ -171,7 +171,7 @@ public class InlongGroupImpl implements InlongGroup {
         final String errMsg = idAndErr.getValue();
         final String groupId = idAndErr.getKey();
         AssertUtil.isNull(errMsg, errMsg);
-        managerClient.operateInlongGroup(groupId, InlongGroupState.STOPPED, async);
+        managerClient.operateInlongGroup(groupId, InlongGroupStatus.STOPPED, async);
         return generateSnapshot();
     }
 
@@ -187,7 +187,7 @@ public class InlongGroupImpl implements InlongGroup {
         final String errMsg = idAndErr.getValue();
         final String groupId = idAndErr.getKey();
         AssertUtil.isNull(errMsg, errMsg);
-        managerClient.operateInlongGroup(groupId, InlongGroupState.STARTED, async);
+        managerClient.operateInlongGroup(groupId, InlongGroupStatus.STARTED, async);
         return generateSnapshot();
     }
 

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
@@ -30,7 +30,7 @@ import okhttp3.RequestBody;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.inlong.manager.client.api.ClientConfiguration;
-import org.apache.inlong.manager.client.api.InlongGroupContext.InlongGroupState;
+import org.apache.inlong.manager.client.api.InlongGroupContext.InlongGroupStatus;
 import org.apache.inlong.manager.client.api.auth.Authentication;
 import org.apache.inlong.manager.client.api.auth.DefaultAuthentication;
 import org.apache.inlong.manager.client.api.util.AssertUtil;
@@ -201,14 +201,13 @@ public class InnerInlongManagerClient {
     }
 
     /**
-     * List inlong group
+     * List inlong group by the page request
      *
-     * @param inlongGroupRequest The inlongGroupRequest
+     * @param pageRequest The pageRequest
      * @return Response encapsulate of inlong group list
      */
-    public Response<PageInfo<InlongGroupListResponse>> listGroups(InlongGroupPageRequest inlongGroupRequest)
-            throws Exception {
-        String requestParams = GsonUtil.toJson(inlongGroupRequest);
+    public Response<PageInfo<InlongGroupListResponse>> listGroups(InlongGroupPageRequest pageRequest) throws Exception {
+        String requestParams = GsonUtil.toJson(pageRequest);
         RequestBody requestBody = RequestBody.create(MediaType.parse("application/json"), requestParams);
         String path = HTTP_PATH + "/group/list";
         final String url = formatUrl(path);
@@ -787,19 +786,19 @@ public class InnerInlongManagerClient {
         }
     }
 
-    public boolean operateInlongGroup(String groupId, InlongGroupState status) {
+    public boolean operateInlongGroup(String groupId, InlongGroupStatus status) {
         return operateInlongGroup(groupId, status, false);
     }
 
-    public boolean operateInlongGroup(String groupId, InlongGroupState status, boolean async) {
+    public boolean operateInlongGroup(String groupId, InlongGroupStatus status, boolean async) {
         String path = HTTP_PATH;
-        if (status == InlongGroupState.STOPPED) {
+        if (status == InlongGroupStatus.STOPPED) {
             if (async) {
                 path += "/group/suspendProcessAsync/";
             } else {
                 path += "/group/suspendProcess/";
             }
-        } else if (status == InlongGroupState.STARTED) {
+        } else if (status == InlongGroupStatus.STARTED) {
             if (async) {
                 path += "/group/restartProcessAsync/";
             } else {

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/group/InlongGroupPageRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/group/InlongGroupPageRequest.java
@@ -45,8 +45,11 @@ public class InlongGroupPageRequest extends PageRequest {
     @ApiModelProperty(value = "MQ resource object")
     private String middlewareType;
 
-    @ApiModelProperty(value = "Status")
+    @ApiModelProperty(value = "Group status")
     private Integer status;
+
+    @ApiModelProperty(value = "Group status list")
+    private List<Integer> statusList;
 
     @ApiModelProperty(value = "Current user", hidden = true)
     private String currentUser;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/stream/StreamPipeline.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/stream/StreamPipeline.java
@@ -25,6 +25,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.inlong.manager.common.util.Preconditions;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/stream/StreamPipeline.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/stream/StreamPipeline.java
@@ -25,7 +25,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.inlong.manager.common.util.Preconditions;
 
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -51,10 +50,7 @@ public class StreamPipeline {
     }
 
     /**
-     * Check if pipeline has circle
-     * If has one, return circled node names;
-     *
-     * @return
+     * Check if a pipeline has a circle, if it has, return circled node names
      */
     public Pair<Boolean, Pair<String, String>> hasCircle() {
         Map<String, Set<String>> priorityMap = Maps.newHashMap();
@@ -82,9 +78,7 @@ public class StreamPipeline {
     }
 
     private boolean isReach(Map<String, Set<String>> paths, Set<String> inputs, String output) {
-        Queue<String> queue = new LinkedList<>();
-        queue.addAll(inputs);
-        Set<String> preNodes = new HashSet<>(inputs);
+        Queue<String> queue = new LinkedList<>(inputs);
         while (!queue.isEmpty()) {
             String node = queue.remove();
             if (paths.get(node) == null) {
@@ -96,7 +90,6 @@ public class StreamPipeline {
             }
             for (String postNode : postNodes) {
                 if (!inputs.contains(postNode)) {
-                    preNodes.add(postNode);
                     queue.add(postNode);
                 }
             }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/stream/StreamPipeline.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/stream/StreamPipeline.java
@@ -79,6 +79,7 @@ public class StreamPipeline {
 
     private boolean isReach(Map<String, Set<String>> paths, Set<String> inputs, String output) {
         Queue<String> queue = new LinkedList<>(inputs);
+        Set<String> preNodes = new HashSet<>(inputs);
         while (!queue.isEmpty()) {
             String node = queue.remove();
             if (paths.get(node) == null) {
@@ -89,7 +90,8 @@ public class StreamPipeline {
                 return true;
             }
             for (String postNode : postNodes) {
-                if (!inputs.contains(postNode)) {
+                if (!preNodes.contains(postNode)) {
+                    preNodes.add(postNode);
                     queue.add(postNode);
                 }
             }

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -133,6 +133,12 @@
             <if test="status != null and status != ''">
                 and status = #{status, jdbcType=INTEGER}
             </if>
+            <if test="statusList != null and statusList.size() > 0">
+                and status in
+                <foreach collection="statusList" item="status" index="index" open="(" close=")" separator=",">
+                    #{status}
+                </foreach>
+            </if>
         </where>
         order by modify_time desc
     </select>


### PR DESCRIPTION
### Title Name: [INLONG-4139][Manager] Query inlong group by the status list in manager client

Fixes #4139 

### Motivation

Query inlong group by the status list in manager client.

### Modifications

1. Add statusList param in page request.
2. Change the `State` class to `Status`.

### Verifying this change

- [X] This change is a trivial rework/code cleanup without any test coverage.
