### PR TITLE
fix #4144 [Bug][K8s] HTTP error appears on the login dashboard when deploying InLong using helm

### DIFF
--- a/docker/kubernetes/templates/dashboard-statefulset.yaml
+++ b/docker/kubernetes/templates/dashboard-statefulset.yaml
@@ -85,7 +85,7 @@ spec:
           {{- end }}
           env:
             - name: MANAGER_API_ADDRESS
-              value: "{{ template "inlong.tubemqManager.hostname" .}}:{{ .Values.tubemqManager.port }}"
+              value: "{{ template "inlong.manager.hostname" .}}:{{ .Values.manager.port }}"
           ports:
             - name: {{ .Values.dashboard.component }}-port
               containerPort: 80


### PR DESCRIPTION
[Bug][K8s] HTTP error appears on the login dashboard when deploying InLong using helm #4144

### Title Name: [INLONG-XYZ][component] Title of the pull request

where *XYZ* should be replaced by the actual issue number.

Fixes #<xyz>

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
