### PR TITLE
[INLONG-3830][Sort] Fix the error that the SQL execution order is inconsistent with the generation order

### DIFF
--- a/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-single-tenant/src/main/java/org/apache/inlong/sort/singletenant/flink/parser/impl/FlinkSqlParser.java
@@ -54,7 +54,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 /**
  * Flink sql parse handler
@@ -67,9 +66,9 @@ public class FlinkSqlParser implements Parser {
     private final TableEnvironment tableEnv;
     private final GroupInfo groupInfo;
     private final Set<String> hasParsedSet = new HashSet<>();
-    private final Map<String, String> extractTableSqls = new TreeMap<>();
-    private final Map<String, String> transformTableSqls = new TreeMap<>();
-    private final Map<String, String> loadTableSqls = new TreeMap<>();
+    private final List<String> extractTableSqls = new ArrayList<>();
+    private final List<String> transformTableSqls = new ArrayList<>();
+    private final List<String> loadTableSqls = new ArrayList<>();
     private final List<String> insertSqls = new ArrayList<>();
 
     /**
@@ -118,9 +117,9 @@ public class FlinkSqlParser implements Parser {
             parseStream(streamInfo);
         }
         log.info("parse group success, groupId:{}", groupInfo.getGroupId());
-        List<String> createTableSqls = new ArrayList<>(extractTableSqls.values());
-        createTableSqls.addAll(transformTableSqls.values());
-        createTableSqls.addAll(loadTableSqls.values());
+        List<String> createTableSqls = new ArrayList<>(extractTableSqls);
+        createTableSqls.addAll(transformTableSqls);
+        createTableSqls.addAll(loadTableSqls);
         return new FlinkSqlParseResult(tableEnv, createTableSqls, insertSqls);
     }
 
@@ -183,11 +182,11 @@ public class FlinkSqlParser implements Parser {
 
     private void registerTableSql(Node node, String sql) {
         if (node instanceof ExtractNode) {
-            extractTableSqls.put(node.getId(), sql);
+            extractTableSqls.add(sql);
         } else if (node instanceof TransformNode) {
-            transformTableSqls.put(node.getId(), sql);
+            transformTableSqls.add(sql);
         } else if (node instanceof LoadNode) {
-            loadTableSqls.put(node.getId(), sql);
+            loadTableSqls.add(sql);
         } else {
             throw new UnsupportedOperationException("Only support [ExtractNode|TransformNode|LoadNode]");
         }


### PR DESCRIPTION
…eneration order

### Title Name: [INLONG-3830][Sort] Fix the error that the SQL execution order is inconsistent with the generation order

Fixes #3830 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
