### PR TITLE
[INLONG-4161][CI] Fix incorrect name in stale workflow

### DIFF
--- a/.github/workflows/ci_stale.yml
+++ b/.github/workflows/ci_stale.yml
@@ -21,14 +21,13 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   stale:
-    name: Stable
+    name: Stale
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Mark issues and PRs
         uses: actions/stale@v5
@@ -45,5 +44,5 @@ jobs:
           operations-per-run: 500           # max number of operations per run
           exempt-issue-labels: 'WIP'        # labels on issues exempted from stale
           exempt-pr-labels: 'WIP'           # labels on PRs exempted from stale
-          stale-issue-label: 'stable'       # label to apply on staled issues
-          stale-pr-label: 'stable'          # label to apply on staled PRs
+          stale-issue-label: 'stale'        # label to apply on staled issues
+          stale-pr-label: 'stale'           # label to apply on staled PRs


### PR DESCRIPTION
fix: #4161

### Motivation

Fix incorrect name in stale workflow

### Modifications

- step name: `stable` -> `stale`
- label name: `stable` -> `stale`
