### PR TITLE
[INLONG-4183][Manager] Fix splitFields in manager service

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/FieldRelationShipUtils.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/FieldRelationShipUtils.java
@@ -183,7 +183,6 @@ public class FieldRelationShipUtils {
     private static List<FieldRelationShip> parseSplitRule(SplitRule splitRule, Set<String> splitFields,
             String transformName, String preNode) {
         StreamField sourceField = splitRule.getSourceField();
-        splitFields.add(sourceField.getFieldName());
         FieldInfo fieldInfo = FieldInfoUtils.parseStreamField(sourceField);
         fieldInfo.setNodeId(preNode);
         String seperator = splitRule.getSeperator();


### PR DESCRIPTION
### Title Name: [INLONG-4183][Manager]Fix splitFields in Manager service

where *XYZ* should be replaced by the actual issue number.

Fixes #4183 

### Motivation

### Modifications

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
