### PR TITLE
[INLONG-4205][CI] Fix error in the greeting workflow

### DIFF
--- a/.github/workflows/ci_greeting.yml
+++ b/.github/workflows/ci_greeting.yml
@@ -18,7 +18,7 @@
 name: InLong Greeting
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
   issues:


### PR DESCRIPTION
fix: #4205

### Motivation

Fix error in the greeting workflow.

> The `pull_request_target` event is similar to `pull_request`, except that it runs in the context of the base repository of the pull request, rather than in the merge commit. This means that you can more safely make your secrets available to the workflows triggered by the pull request, because only workflows defined in the commit on the base repository are run. For example, this event allows you to create workflows that label and comment on pull requests, based on the contents of the event payload.

reference:

- https://github.com/actions/first-interaction/issues/31
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

### Modifications

- replace `pull_request` with `pull_request_target`
