### PR TITLE
 [INLONG-4221][Manager] Remove duplicate serializationType in KafkaSourceListResponse

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/SourceListResponse.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/SourceListResponse.java
@@ -45,7 +45,7 @@ public class SourceListResponse {
     private String sourceName;
 
     @ApiModelProperty("Data Serialization, support: csv, json, canal, avro, etc")
-    private String serializationType;
+    private String serializationType = "none";
 
     @ApiModelProperty("Data node name")
     private String dataNodeName;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/kafka/KafkaSourceListResponse.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/kafka/KafkaSourceListResponse.java
@@ -46,9 +46,6 @@ public class KafkaSourceListResponse extends SourceListResponse {
     @ApiModelProperty("Limit the number of bytes read per second")
     private String byteSpeedLimit;
 
-    @ApiModelProperty("Data Serialization, support: json, canal, avro, etc")
-    private String serializationType = "none";
-
     @ApiModelProperty(value = "Topic partition offset",
             notes = "For example, '0#100_1#10' means the offset of partition 0 is 100, the offset of partition 1 is 10")
     private String topicPartitionOffset;


### PR DESCRIPTION
### Title Name:  [INLONG-4221][Manager] Remove duplicate field 'serializationType' in KafkaSourceListResponse

where *XYZ* should be replaced by the actual issue number.

Fixes #4221 

### Motivation

### Modifications

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
