### PR TITLE
[INLONG-4217][TubeMQ] Add the flow control method and filtering method of the consumption group settings

### DIFF
--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/GroupController.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/GroupController.java
@@ -26,6 +26,8 @@ import org.apache.inlong.tubemq.manager.controller.TubeMQResult;
 import org.apache.inlong.tubemq.manager.controller.group.request.AddBlackGroupReq;
 import org.apache.inlong.tubemq.manager.controller.group.request.DeleteBlackGroupReq;
 import org.apache.inlong.tubemq.manager.controller.group.request.DeleteOffsetReq;
+import org.apache.inlong.tubemq.manager.controller.group.request.FilterCondGroupReq;
+import org.apache.inlong.tubemq.manager.controller.group.request.FlowControlGroupReq;
 import org.apache.inlong.tubemq.manager.controller.group.request.QueryOffsetReq;
 import org.apache.inlong.tubemq.manager.controller.node.request.CloneOffsetReq;
 import org.apache.inlong.tubemq.manager.controller.topic.request.BatchAddGroupAuthReq;
@@ -71,6 +73,10 @@ public class GroupController {
                 return topicService.rebalanceGroup(gson.fromJson(req, RebalanceGroupReq.class));
             case TubeConst.REBALANCE_CONSUMER:
                 return masterService.baseRequestMaster(gson.fromJson(req, RebalanceConsumerReq.class));
+            case TubeConst.FILTER_COND:
+                return masterService.baseRequestMaster(gson.fromJson(req, FilterCondGroupReq.class));
+            case TubeConst.FLOW_CONTROL:
+                return masterService.baseRequestMaster(gson.fromJson(req, FlowControlGroupReq.class));
             default:
                 return TubeMQResult.errorResult(TubeMQErrorConst.NO_SUCH_METHOD);
         }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/GroupController.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/GroupController.java
@@ -73,7 +73,7 @@ public class GroupController {
                 return topicService.rebalanceGroup(gson.fromJson(req, RebalanceGroupReq.class));
             case TubeConst.REBALANCE_CONSUMER:
                 return masterService.baseRequestMaster(gson.fromJson(req, RebalanceConsumerReq.class));
-            case TubeConst.FILTER_COND:
+            case TubeConst.FILTER_CONDITION:
                 return masterService.baseRequestMaster(gson.fromJson(req, FilterCondGroupReq.class));
             case TubeConst.FLOW_CONTROL:
                 return masterService.baseRequestMaster(gson.fromJson(req, FlowControlGroupReq.class));

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/request/FilterCondGroupReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/request/FilterCondGroupReq.java
@@ -22,12 +22,17 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.inlong.tubemq.manager.controller.node.request.BaseReq;
 
+/**
+ * Consumer group filter item record
+ */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class DeleteBlackGroupReq extends BaseReq {
+public class FilterCondGroupReq extends BaseReq {
+    private String groupName;
     private String topicName;
     private String confModAuthToken;
-    private String groupName;
-    private String modifyUser;
+    private Integer condStatus;
+    private String filterConds;
+    private String createUser;
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/request/FlowControlGroupReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/request/FlowControlGroupReq.java
@@ -22,12 +22,16 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.inlong.tubemq.manager.controller.node.request.BaseReq;
 
+/**
+ * Consumer group flow control rules
+ */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class DeleteBlackGroupReq extends BaseReq {
-    private String topicName;
-    private String confModAuthToken;
+public class FlowControlGroupReq extends BaseReq {
     private String groupName;
-    private String modifyUser;
+    private Integer statusId;
+    private Integer qryPriorityId;
+    private String confModAuthToken;
+    private String createUser;
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TubeConst.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TubeConst.java
@@ -60,7 +60,7 @@ public class TubeConst {
     public static final String AUTH_CONTROL = "authControl";
     public static final String ADD_TOPIC_TASK = "addTopicTask";
     public static final String QUERY_CAN_WRITE = "queryCanWrite";
-    public static final String FILTER_COND = "filterCond";
+    public static final String FILTER_CONDITION = "filterCondition";
     public static final String FLOW_CONTROL = "flowControl";
 
 

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TubeConst.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TubeConst.java
@@ -60,6 +60,9 @@ public class TubeConst {
     public static final String AUTH_CONTROL = "authControl";
     public static final String ADD_TOPIC_TASK = "addTopicTask";
     public static final String QUERY_CAN_WRITE = "queryCanWrite";
+    public static final String FILTER_COND = "filterCond";
+    public static final String FLOW_CONTROL = "flowControl";
+
 
     /**
      * status code


### PR DESCRIPTION
### Title Name: [INLONG-4217][TubeMQ] Add the flow control method and filtering method of the consumption group settings

Fixes #4217 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
