### PR TITLE
[INLONG-4283][Agent] Specifies kafka-clients version to 3.0.0

### DIFF
--- a/inlong-agent/agent-release/pom.xml
+++ b/inlong-agent/agent-release/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>agent-plugins</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.clients.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/licenses/inlong-agent/LICENSE
+++ b/licenses/inlong-agent/LICENSE
@@ -620,7 +620,6 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
   org.eclipse.jetty:jetty-util:9.4.44.v20210927 - Jetty :: Utilities (https://eclipse.org/jetty/jetty-util), (Apache Software License - Version 2.0;  Eclipse Public License - Version 1.0)
   org.eclipse.jetty:jetty-util-ajax:9.4.44.v20210927 - Jetty :: Utilities :: Ajax(JSON) (https://eclipse.org/jetty/jetty-util-ajax), (Apache Software License - Version 2.0;  Eclipse Public License - Version 1.0)
   org.apache.kafka:kafka_2.11:2.4.1 - Apache Kafka (https://kafka.apache.org), (The Apache Software License, Version 2.0)
-  org.apache.kafka:kafka-clients:2.4.1 - Apache Kafka (https://kafka.apache.org), (The Apache Software License, Version 2.0)
   org.apache.kafka:kafka-clients:3.0.0 - Apache Kafka (https://kafka.apache.org), (The Apache Software License, Version 2.0)
   org.apache.thrift:libthrift:0.9.3 - Apache Thrift (http://thrift.apache.org),  (The Apache Software License, Version 2.0)
   log4j:log4j:1.2.17 - Apache Log4j (http://logging.apache.org/log4j/1.2/), (The Apache Software License, Version 2.0)


### PR DESCRIPTION
The agent module specifies dependencies on kafka-clients: version 3.0.0

Fixes #4283

![wecom-temp-ba6ebecfbd35173dce9d248e004ede94](https://user-images.githubusercontent.com/20356765/169502542-86d16d0f-08d0-4280-ae71-c13163ef35e6.png)
