### PR TITLE
[INLONG-4334] Only mark the stale issues and PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,7 +42,7 @@ This directory contains all InLong CI checks.
   label new pull requests based on the paths of files being changed using the [actions/labeler](https://github.com/actions/labeler) action.
   And here is the [labeler configuration](../labeler.yml)
 
-- [![InLong Close Stale Issues and PRs](https://github.com/apache/incubator-inlong/actions/workflows/ci_stale.yml/badge.svg)](https://github.com/apache/incubator-inlong/actions/workflows/ci_stale.yml)
+- [![InLong Mark Stale Issues and PRs](https://github.com/apache/incubator-inlong/actions/workflows/ci_stale.yml/badge.svg)](https://github.com/apache/incubator-inlong/actions/workflows/ci_stale.yml)
 
   Mark issues and pull requests that have not had recent interaction using the [actions/stale](https://github.com/actions/stale) action.
 

--- a/.github/workflows/ci_stale.yml
+++ b/.github/workflows/ci_stale.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: InLong Close Stale Issues and PRs
+name: InLong Mark Stale Issues and PRs
 
 on:
   schedule:
@@ -33,14 +33,12 @@ jobs:
         uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
-          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity.'
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity.'
           days-before-issue-stale: 60       # the idle number of days before marking the issues as stale
           days-before-pr-stale: 60          # the idle number of days before marking the pull requests as stale
-          days-before-issue-close: 30       # the idle number of days before closing the stale issues
-          days-before-pr-close: 30          # the idle number of days before closing the stale pull requests
+          days-before-issue-close: -1       # the issues will never be closed automatically
+          days-before-pr-close: -1          # the pull requests will never be closed automatically
           operations-per-run: 500           # max number of operations per run
           exempt-issue-labels: 'WIP'        # labels on issues exempted from stale
           exempt-pr-labels: 'WIP'           # labels on PRs exempted from stale


### PR DESCRIPTION
fix: #4334

### Motivation

Now, the stale issues and PRs will be closed in the stale workflow. But it is not convenient. They should only be marked, not closed.

### Modifications

Set `days-before-issue-close` and `days-before-pr-close` to `-1`, the issues or the pull requests will never be closed automatically.
