### PR TITLE
[INLONG-4385][Sort] Excluse or remove the mysql:mysql-connector-java:jar:8.0.21 package

### DIFF
--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -49,16 +49,6 @@
         <dependencies>
             <dependency>
                 <groupId>io.debezium</groupId>
-                <artifactId>debezium-connector-mysql</artifactId>
-                <version>${debezium.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.debezium</groupId>
-                <artifactId>debezium-connector-sqlserver</artifactId>
-                <version>${debezium.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.debezium</groupId>
                 <artifactId>debezium-api</artifactId>
                 <version>${debezium.version}</version>
             </dependency>

--- a/inlong-sort/sort-connectors/mysql-cdc/pom.xml
+++ b/inlong-sort/sort-connectors/mysql-cdc/pom.xml
@@ -37,27 +37,6 @@
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-connector-mysql-cdc</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>flink-connector-debezium</artifactId>
-                    <groupId>com.ververica</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>debezium-connector-mysql</artifactId>
-                    <groupId>io.debezium</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-connector-mysql</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>debezium-core</artifactId>
-                    <groupId>io.debezium</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/inlong-sort/sort-connectors/pom.xml
+++ b/inlong-sort/sort-connectors/pom.xml
@@ -181,16 +181,6 @@
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-connector-sqlserver-cdc</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.debezium</groupId>
-                    <artifactId>debezium-connector-sqlserver</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-connector-sqlserver</artifactId>
         </dependency>
     </dependencies>
 

--- a/licenses/inlong-sort/LICENSE
+++ b/licenses/inlong-sort/LICENSE
@@ -670,8 +670,6 @@ The text of each license is the standard Apache 2.0 license.
   org.apache.zookeeper:zookeeper:3.6.3 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-server), (Apache License, Version 2.0)
   org.apache.zookeeper:zookeeper-jute:3.6.3 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-jute), (Apache License, Version 2.0)
   io.streamnative.connectors:pulsar-flink-connector_2.11:1.13.6.1-rc9 - StreamNative :: Pulsar Flink Connector :: Scala 2.11 (https://github.com/streamnative/pulsar-flink/blob/release-1.13/LICENSE), (Apache License, Version 2.0)
-  io.debezium:debezium-connector-sqlserver:1.5.4.Final - Apache debezium (https://github.com/debezium/debezium/tree/v1.5.4.Final/debezium-connector-sqlserver), (Apache License, Version 2.0)
-  io.debezium:debezium-connector-mysql:1.5.4.Final - Apache debezium (https://github.com/debezium/debezium/tree/v1.5.4.Final/debezium-connector-mysql), (Apache License, Version 2.0)
   io.debezium:debezium-core:1.5.4.Final - Apache debezium (https://github.com/debezium/debezium/tree/v1.5.4.Final/debezium-core), (Apache License, Version 2.0)
   io.debezium:debezium-embedded:1.5.4.Final - Apache debezium (https://github.com/debezium/debezium/tree/v1.5.4.Final/debezium-embedded), (Apache License, Version 2.0)
   io.debezium:debezium-api:1.5.4.Final - Apache debezium (https://github.com/debezium/debezium/tree/v1.5.4.Final/debezium-api), (Apache License, Version 2.0)


### PR DESCRIPTION
[Bug][Sort]
The imported dependency uses a protocol that does not conform to apache, then removed related direct reference.

Fixes #4385 

### Motivation

GPL component,then  removed related direct reference.

### Modifications

alter pom and license

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
 cdc: 
mysql-->kafka
mysql-->sqlserver
and so on

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
