### PR TITLE
[INLONG-4388][Manager] Change Elasticsearch scaling_factor use correct mapping info

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sink/es/ElasticsearchFieldInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sink/es/ElasticsearchFieldInfo.java
@@ -54,7 +54,7 @@ public class ElasticsearchFieldInfo {
     private String searchAnalyzer;
 
     @ApiModelProperty("Elasticsearch Scaling Factor")
-    private Integer scalingFactor;
+    private String scalingFactor;
 
     /**
      * Get the extra param from the Json

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/es/ElasticsearchApi.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/es/ElasticsearchApi.java
@@ -115,28 +115,28 @@ public class ElasticsearchApi {
      */
     private List<String> getMappingInfo(List<ElasticsearchFieldInfo> fieldsInfo) {
         List<String> fieldList = new ArrayList<>();
-        for (ElasticsearchFieldInfo entry : fieldsInfo) {
-            StringBuilder fieldStr = new StringBuilder().append("        \"").append(entry.getName())
+        for (ElasticsearchFieldInfo field : fieldsInfo) {
+            StringBuilder fieldStr = new StringBuilder().append("        \"").append(field.getName())
                     .append("\" : {\n          \"type\" : \"")
-                    .append(entry.getType()).append("\"");
-            if (entry.getType().equals("text")) {
-                if (StringUtils.isNotEmpty(entry.getAnalyzer())) {
+                    .append(field.getType()).append("\"");
+            if (field.getType().equals("text")) {
+                if (StringUtils.isNotEmpty(field.getAnalyzer())) {
                     fieldStr.append(",\n          \"analyzer\" : \"")
-                            .append(entry.getAnalyzer()).append("\"");
+                            .append(field.getAnalyzer()).append("\"");
                 }
-                if (StringUtils.isNotEmpty(entry.getSearchAnalyzer())) {
+                if (StringUtils.isNotEmpty(field.getSearchAnalyzer())) {
                     fieldStr.append(",\n          \"search_analyzer\" : \"")
-                            .append(entry.getSearchAnalyzer()).append("\"");
+                            .append(field.getSearchAnalyzer()).append("\"");
                 }
-            } else if (entry.getType().equals("date")) {
-                if (StringUtils.isNotEmpty(entry.getFormat())) {
+            } else if (field.getType().equals("date")) {
+                if (StringUtils.isNotEmpty(field.getFormat())) {
                     fieldStr.append(",\n          \"format\" : \"")
-                            .append(entry.getFormat()).append("\"");
+                            .append(field.getFormat()).append("\"");
                 }
-            } else if (entry.getType().equals("scaled_float")) {
-                if (StringUtils.isNotEmpty(entry.getScalingFactor())) {
+            } else if (field.getType().equals("scaled_float")) {
+                if (StringUtils.isNotEmpty(field.getScalingFactor())) {
                     fieldStr.append(",\n          \"scaling_factor\" : \"")
-                            .append(entry.getScalingFactor()).append("\"");
+                            .append(field.getScalingFactor()).append("\"");
                 }
             }
             fieldStr.append("\n        }");
@@ -212,9 +212,9 @@ public class ElasticsearchApi {
         Map<String, MappingMetaData> mapping = getFields(indexName);
         Map<String, Object> filedMap = (Map<String, Object>)mapping.get(indexName).getSourceAsMap().get(FIELD_KEY);
         for (String key : filedMap.keySet()) {
-            for (ElasticsearchFieldInfo entry : notExistFieldInfos) {
-                if (entry.getName().equals(key)) {
-                    notExistFieldInfos.remove(entry);
+            for (ElasticsearchFieldInfo field : notExistFieldInfos) {
+                if (field.getName().equals(key)) {
+                    notExistFieldInfos.remove(field);
                     break;
                 }
             }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/es/ElasticsearchApi.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/es/ElasticsearchApi.java
@@ -133,10 +133,10 @@ public class ElasticsearchApi {
                     fieldStr.append(",\n          \"format\" : \"")
                             .append(entry.getFormat()).append("\"");
                 }
-            } else if (entry.getType().contains("float")) {
-                if (StringUtils.isNotEmpty(entry.getFormat())) {
+            } else if (entry.getType().equals("scaled_float")) {
+                if (StringUtils.isNotEmpty(entry.getScalingFactor())) {
                     fieldStr.append(",\n          \"scaling_factor\" : \"")
-                            .append(entry.getFormat()).append("\"");
+                            .append(entry.getScalingFactor()).append("\"");
                 }
             }
             fieldStr.append("\n        }");


### PR DESCRIPTION
### Title Name: [INLONG-4388][Manager] Change Elasticsearch scaling_factor use correct mapping info

Elasticsearch scaling_factor used format info, it's wrong. Fix this problem.

Fixes #4388 

### Motivation

Elasticsearch scaling_factor used format info, it's wrong.

### Modifications

Change scaling_factor uses correct information.

