### PR TITLE
[INLONG-4390][Sort] Exclude mysql:mysql-connector-java:jar package

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/TDSQLPostgresLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/TDSQLPostgresLoadNode.java
@@ -38,10 +38,11 @@ import java.util.Map;
 
 /**
  * TDSQLPostgres load node can load data into TDSQL Postgres
- * @see <a herf="https://cloud.tencent.com/product/tbase">TDSQL Postgres</a>
- * TDSQL Postgres is an enterprise-level distributed HTAP database. Through a single database cluster to provide
- * users with highly consistent distributed database services and high-performance data warehouse services,
- * a set of integrated enterprise-level solutions is formed.
+ *
+ * @see <a href="https://cloud.tencent.com/product/tbase">TDSQL Postgres</a>
+ *         TDSQL Postgres is an enterprise-level distributed HTAP database. Through a single database cluster
+ *         to provide users with highly consistent distributed database services and high-performance
+ *         data warehouse services, a set of integrated enterprise-level solutions is formed.
  */
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("tdsqlPostgresLoad")

--- a/inlong-sort/sort-connectors/mysql-cdc/pom.xml
+++ b/inlong-sort/sort-connectors/mysql-cdc/pom.xml
@@ -37,12 +37,6 @@
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-connector-mysql-cdc</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>mysql</groupId>
-                    <artifactId>mysql-connector-java</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/inlong-sort/sort-connectors/mysql-cdc/pom.xml
+++ b/inlong-sort/sort-connectors/mysql-cdc/pom.xml
@@ -37,6 +37,12 @@
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-connector-mysql-cdc</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -982,6 +982,13 @@
                 <groupId>com.ververica</groupId>
                 <artifactId>flink-connector-mysql-cdc</artifactId>
                 <version>${flink.connector.mysql.cdc.version}</version>
+                <!-- mysql-connector-java is LGPL license and needs to be excluded -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>mysql</groupId>
+                        <artifactId>mysql-connector-java</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
GPL components do not conform to the terms of this project,so exclude this packeage.
If you want to continue to use related capabilities, please introduce this dependency in your own project.

Fixes #4390 

### Motivation

GPL components do not conform to the terms of this project.

### Modifications

Exclude this package

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
