### PR TITLE
[INLONG-4392][TubeMQ] Optimize the method of querying the offset information of consumer groups on Broker

### DIFF
--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/AllBrokersOffsetRes.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/AllBrokersOffsetRes.java
@@ -30,6 +30,7 @@ public class AllBrokersOffsetRes {
     @Data
     public static class OffsetInfo {
         private int brokerId;
-        private OffsetQueryRes offsetQueryRes;
+        private String brokerIp;
+        private List<OffsetPartitionRes> offsets;
     }
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/ConsumerInfoRes.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/ConsumerInfoRes.java
@@ -19,9 +19,11 @@ package org.apache.inlong.tubemq.manager.controller.group.result;
 
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class ConsumerInfoRes {
     private String consumeGroup;
-    private String topicSet;
+    private List<String> topicSet;
     private Double consumerNum;
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/GroupOffsetRes.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/GroupOffsetRes.java
@@ -17,15 +17,13 @@
 
 package org.apache.inlong.tubemq.manager.controller.group.result;
 
-import java.util.List;
-
 import lombok.Data;
 
+import java.util.List;
+
 @Data
-public class OffsetQueryRes {
-    private boolean result;
-    private int errCode;
-    private String errMsg;
-    private List<GroupOffsetRes> dataSet;
-    private int totalCnt;
+public class GroupOffsetRes {
+    private String groupName;
+    private List<TopicOffsetRes> subInfo;
+    private int topicCount;
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/OffsetPartitionRes.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/OffsetPartitionRes.java
@@ -17,15 +17,16 @@
 
 package org.apache.inlong.tubemq.manager.controller.group.result;
 
-import java.util.List;
-
 import lombok.Data;
 
 @Data
-public class OffsetQueryRes {
-    private boolean result;
-    private int errCode;
-    private String errMsg;
-    private List<GroupOffsetRes> dataSet;
-    private int totalCnt;
+public class OffsetPartitionRes {
+    private int partitionId;
+    private long curOffset;
+    private int flightOffset;
+    private int curDataOffset;
+    private int offsetLag;
+    private int dataLag;
+    private int offsetMax;
+    private int dataMax;
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/TopicOffsetRes.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/group/result/TopicOffsetRes.java
@@ -17,15 +17,13 @@
 
 package org.apache.inlong.tubemq.manager.controller.group.result;
 
-import java.util.List;
-
 import lombok.Data;
 
+import java.util.List;
+
 @Data
-public class OffsetQueryRes {
-    private boolean result;
-    private int errCode;
-    private String errMsg;
-    private List<GroupOffsetRes> dataSet;
-    private int totalCnt;
+public class TopicOffsetRes {
+    private String topicName;
+    private List<OffsetPartitionRes> offsets;
+    private int partCount;
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/topic/request/DeleteGroupReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/topic/request/DeleteGroupReq.java
@@ -29,4 +29,5 @@ public class DeleteGroupReq extends BaseReq {
     private String confModAuthToken;
     private String topicName;
     private String groupName;
+    private String modifyUser;
 }

--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TopicServiceImpl.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/service/TopicServiceImpl.java
@@ -36,7 +36,10 @@ import org.apache.inlong.tubemq.manager.controller.group.request.DeleteOffsetReq
 import org.apache.inlong.tubemq.manager.controller.group.request.QueryOffsetReq;
 import org.apache.inlong.tubemq.manager.controller.group.result.AllBrokersOffsetRes;
 import org.apache.inlong.tubemq.manager.controller.group.result.AllBrokersOffsetRes.OffsetInfo;
+import org.apache.inlong.tubemq.manager.controller.group.result.GroupOffsetRes;
+import org.apache.inlong.tubemq.manager.controller.group.result.OffsetPartitionRes;
 import org.apache.inlong.tubemq.manager.controller.group.result.OffsetQueryRes;
+import org.apache.inlong.tubemq.manager.controller.group.result.TopicOffsetRes;
 import org.apache.inlong.tubemq.manager.controller.node.request.CloneOffsetReq;
 import org.apache.inlong.tubemq.manager.controller.topic.request.RebalanceConsumerReq;
 import org.apache.inlong.tubemq.manager.controller.topic.request.RebalanceGroupReq;
@@ -273,7 +276,16 @@ public class TopicServiceImpl implements TopicService {
                                     OffsetQueryRes res) {
         OffsetInfo offsetInfo = new OffsetInfo();
         offsetInfo.setBrokerId(topicInfo.getBrokerId());
-        offsetInfo.setOffsetQueryRes(res);
-        offsetPerBroker.add(offsetInfo);
+        offsetInfo.setBrokerIp(topicInfo.getBrokerIp());
+        if (TubeConst.SUCCESS_CODE == res.getErrCode()) {
+            List<GroupOffsetRes> dataSet = res.getDataSet();
+            for (GroupOffsetRes groupOffsetRes : dataSet) {
+                for (TopicOffsetRes topicOffsetRes : groupOffsetRes.getSubInfo()) {
+                    List<OffsetPartitionRes> offsets = topicOffsetRes.getOffsets();
+                    offsetInfo.setOffsets(offsets);
+                }
+            }
+            offsetPerBroker.add(offsetInfo);
+        }
     }
 }


### PR DESCRIPTION
### Title Name: [INLONG-4392][TubeMQ] Optimize the method of querying the offset information of consumer groups on Broker

Fixes #4392 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
