### PR TITLE
[INLONG-4405][Sort] Support run SQL script

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/configuration/Constants.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/configuration/Constants.java
@@ -299,6 +299,9 @@ public class Constants {
     public static final ConfigOption<String> GROUP_INFO_FILE = key("group.info.file").noDefaultValue()
             .withDescription("The file which contains group info for a single tenant job");
 
+    public static final ConfigOption<String> SQL_SCRIPT_FILE = key("sql.script.file").noDefaultValue()
+            .withDescription("The file which is sql script and contains multi statement");
+
     // ------------------------------------------------------------------------
     //  File format and compression related
     // ------------------------------------------------------------------------

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/NativeFlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/NativeFlinkSqlParser.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * parse flink sql script file
@@ -80,9 +81,9 @@ public class NativeFlinkSqlParser implements Parser {
         String[] statementSet = statements.split(";");
         for (String statement : statementSet) {
             statement = statement.trim();
-            if (statement.startsWith("CREATE TABLE") || statement.startsWith("create table")) {
+            if (statement.toUpperCase(Locale.ROOT).startsWith("CREATE TABLE")) {
                 createTableSqls.add(statement);
-            } else if (statement.startsWith("INSERT INTO") || statement.startsWith("insert into")) {
+            } else if (statement.toUpperCase(Locale.ROOT).startsWith("INSERT INTO")) {
                 insertSqls.add(statement);
             } else {
                 throw new IllegalArgumentException("not support sql: " + statement);

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/NativeFlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/NativeFlinkSqlParser.java
@@ -1,0 +1,93 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.inlong.sort.parser.impl;
+
+import com.google.common.base.Preconditions;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.inlong.sort.function.RegexpReplaceFirstFunction;
+import org.apache.inlong.sort.parser.Parser;
+import org.apache.inlong.sort.parser.result.FlinkSqlParseResult;
+import org.apache.inlong.sort.parser.result.ParseResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * parse flink sql script file
+ * script file include CREATE TABLE statement
+ */
+public class NativeFlinkSqlParser implements Parser {
+
+    private static final Logger log = LoggerFactory.getLogger(FlinkSqlParser.class);
+
+    private final TableEnvironment tableEnv;
+    private final String statements;
+
+    public NativeFlinkSqlParser(TableEnvironment tableEnv, String statements) {
+        this.tableEnv = tableEnv;
+        this.statements = statements;
+        registerUDF();
+    }
+
+    /**
+     * Register udf
+     */
+    private void registerUDF() {
+        tableEnv.createTemporarySystemFunction("REGEXP_REPLACE_FIRST", RegexpReplaceFirstFunction.class);
+    }
+
+    /**
+     * Get a instance of NativeFlinkSqlParser
+     *
+     * @param tableEnv The tableEnv,it is the execution environment of flink sql
+     * @param statements The statements, it is statement set
+     * @return NativeFlinkSqlParser The flink sql parse handler
+     */
+    public static NativeFlinkSqlParser getInstance(TableEnvironment tableEnv, String statements) {
+        return new NativeFlinkSqlParser(tableEnv, statements);
+    }
+
+
+    /**
+     * parse flink sql script file
+     *
+     * @return ParseResult the result of parsing
+     */
+    @Override
+    public ParseResult parse() {
+        Preconditions.checkNotNull(statements, "sql statement set is null");
+        Preconditions.checkNotNull(tableEnv, "tableEnv is null");
+        List<String> createTableSqls = new ArrayList<>();
+        List<String> insertSqls = new ArrayList<>();
+        String[] statementSet = statements.split(";");
+        for (String statement : statementSet) {
+            statement = statement.trim();
+            if (statement.startsWith("CREATE TABLE") || statement.startsWith("create table")) {
+                createTableSqls.add(statement);
+            } else if (statement.startsWith("INSERT INTO") || statement.startsWith("insert into")) {
+                insertSqls.add(statement);
+            } else {
+                throw new IllegalArgumentException("not support sql: " + statement);
+            }
+        }
+        return new FlinkSqlParseResult(tableEnv, createTableSqls, insertSqls);
+    }
+}

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/NativeFlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/NativeFlinkSqlParser.java
@@ -81,7 +81,8 @@ public class NativeFlinkSqlParser implements Parser {
         String[] statementSet = statements.split(";");
         for (String statement : statementSet) {
             statement = statement.trim();
-            if (statement.toUpperCase(Locale.ROOT).startsWith("CREATE TABLE")) {
+            if (statement.toUpperCase(Locale.ROOT).startsWith("CREATE TABLE") || statement.toUpperCase(Locale.ROOT)
+                    .startsWith("CREATE VIEW")) {
                 createTableSqls.add(statement);
             } else if (statement.toUpperCase(Locale.ROOT).startsWith("INSERT INTO")) {
                 insertSqls.add(statement);

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/NativeFlinkSqlParserTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/NativeFlinkSqlParserTest.java
@@ -1,0 +1,81 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.inlong.sort.parser;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.inlong.sort.parser.impl.NativeFlinkSqlParser;
+import org.apache.inlong.sort.parser.result.ParseResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for {@link NativeFlinkSqlParser}
+ */
+public class NativeFlinkSqlParserTest {
+
+    @Test
+    public void testNativeFlinkSqlParser() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        env.disableOperatorChaining();
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .useBlinkPlanner()
+                .inStreamingMode()
+                .build();
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        String data = "  CREATE TABLE `table_1`(\n"
+                + "    `age` INT,\n"
+                + "    `name` STRING)\n"
+                + "    WITH (\n"
+                + "    'connector' = 'mysql-cdc-inlong',\n"
+                + "    'hostname' = 'localhost',\n"
+                + "    'username' = 'root',\n"
+                + "    'password' = 'inlong',\n"
+                + "    'database-name' = 'test',\n"
+                + "    'scan.incremental.snapshot.enabled' = 'false',\n"
+                + "    'server-time-zone' = 'GMT+8',\n"
+                + "    'table-name' = 'user',\n"
+                + "    'port' = '3306'\n"
+                + ");\n"
+                + "CREATE TABLE `table_2`(\n"
+                + "    PRIMARY KEY (`name`,`age`) NOT ENFORCED,\n"
+                + "    `name` STRING,\n"
+                + "    `age` INT)\n"
+                + "    WITH (\n"
+                + "    'connector' = 'jdbc',\n"
+                + "    'url' = 'jdbc:postgresql://localhost:5432/postgres',\n"
+                + "    'username' = 'postgres',\n"
+                + "    'password' = 'inlong',\n"
+                + "    'table-name' = 'public.user'\n"
+                + ");\n"
+                + "INSERT INTO `table_2` \n"
+                + "    SELECT \n"
+                + "    `name` AS `name`,\n"
+                + "    `age` AS `age`\n"
+                + "    FROM `table_1`;";
+        NativeFlinkSqlParser parser = NativeFlinkSqlParser.getInstance(tableEnv, data);
+        ParseResult result = parser.parse();
+        Assert.assertTrue(result.tryExecute());
+    }
+
+}

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/NativeFlinkSqlParserTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/NativeFlinkSqlParserTest.java
@@ -43,7 +43,7 @@ public class NativeFlinkSqlParserTest {
                 .inStreamingMode()
                 .build();
         StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
-        String data = "  CREATE TABLE `table_1`(\n"
+        String data = "  CREATe TABLE `table_1`(\n"
                 + "    `age` INT,\n"
                 + "    `name` STRING)\n"
                 + "    WITH (\n"

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/PostgresLoadNodeFlinkSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/PostgresLoadNodeFlinkSqlParseTest.java
@@ -61,7 +61,7 @@ public class PostgresLoadNodeFlinkSqlParseTest extends AbstractTestBase {
         return new MySqlExtractNode("1", "mysql_input", fields,
                 null, map, null,
                 Collections.singletonList("user"), "localhost", "root", "inlong",
-                "test", null, null,
+                "test", 3306, null,
                 false, "GMT+8");
     }
 


### PR DESCRIPTION
### Title Name: [INLONG-4405][Sort] Support run SQL script

Fixes #4405 

### Motivation

sort support run sql script.

### Modifications

Add `NativeFlinkSqlParser` to parse SQL file.
In `Entrance` class, run SQL script by `--sql.script.file` configuration. 
