### PR TITLE
[INLONG-4429][Sort] Add SQL Server JDBC driver and management version

### DIFF
--- a/inlong-sort/sort-connectors/jdbc/pom.xml
+++ b/inlong-sort/sort-connectors/jdbc/pom.xml
@@ -88,6 +88,7 @@
                                 <includes>
                                     <include>org.apache.flink:flink-connector-jdbc_${flink.scala.binary.version}</include>
                                     <include>org.postgresql:postgresql</include>
+                                    <include>com.microsoft.sqlserver:mssql-jdbc</include>
                                     <include>ru.yandex.clickhouse:clickhouse-jdbc</include>
                                     <include>mysql:mysql-connector-java</include>
                                     <include>com.oracle.database.jdbc:*</include>

--- a/inlong-sort/sort-connectors/jdbc/pom.xml
+++ b/inlong-sort/sort-connectors/jdbc/pom.xml
@@ -53,6 +53,11 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
+        <!--for sqlserver-->
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+        </dependency>
         <!--for jdbc-->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
         <postgresql.version>42.3.4</postgresql.version>
         <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version>
         <mysql.jdbc.version>8.0.21</mysql.jdbc.version>
+        <sqlserver.jdbc.version>7.2.2.jre8</sqlserver.jdbc.version>
         <mybatis.starter.version>2.1.3</mybatis.starter.version>
         <mybatis.version>3.5.9</mybatis.version>
         <druid.version>1.2.6</druid.version>
@@ -520,6 +521,11 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>${sqlserver.jdbc.version}</version>
             </dependency>
             <!--ojdbc8 is FUTC license, we use it test only-->
             <dependency>


### PR DESCRIPTION
Due to module splitting, dependencies need to be introduced separately into.

Fixes #4429 

### Motivation

Due to module splitting, dependencies need to be introduced separately into.
Modules that separate each connector.

### Modifications

Add sqlserver jdbc driver

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
