### PR TITLE
[INLONG-4453][Sort-Standalone] Fix bug that report wrong audit when send to kafka failed

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSink.java
@@ -21,14 +21,11 @@ import org.apache.flume.Context;
 import org.apache.flume.Sink;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.sink.AbstractSink;
-import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class KafkaFederationSink extends AbstractSink implements Configurable {
     private static final Logger LOG = InlongLoggerFactory.getLogger(KafkaFederationSink.class);

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSink.java
@@ -35,21 +35,13 @@ public class KafkaFederationSink extends AbstractSink implements Configurable {
     private Context parentContext;
     private KafkaFederationSinkContext context;
     private List<KafkaFederationWorker> workers = new ArrayList<>();
-    private Map<String, String> dimensions;
 
     /** init and start workers */
     @Override
     public void start() {
         String sinkName = this.getName();
-        if (getChannel() == null) {
-            LOG.error("channel is null");
-        }
-        this.context = new KafkaFederationSinkContext(getName(), parentContext, getChannel());
+        this.context = new KafkaFederationSinkContext(sinkName, parentContext, getChannel());
         this.context.start();
-        this.dimensions = new HashMap<>();
-        this.dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.context.getClusterId());
-        this.dimensions.put(SortMetricItem.KEY_TASK_NAME, this.context.getTaskName());
-        this.dimensions.put(SortMetricItem.KEY_SINK_ID, this.context.getSinkName());
         // create worker
         for (int i = 0; i < context.getMaxThreads(); i++) {
             KafkaFederationWorker worker = new KafkaFederationWorker(sinkName, i, context);

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
@@ -28,7 +28,6 @@ import org.apache.inlong.sort.standalone.config.pojo.InlongId;
 import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
 import org.apache.inlong.sort.standalone.utils.Constants;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
-import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 import java.util.Map;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
@@ -89,10 +89,6 @@ public class KafkaFederationWorker extends Thread {
             Transaction tx = null;
             try {
                 Channel channel = context.getChannel();
-                if (channel == null) {
-                    LOG.error("in kafka worker, channel is null ");
-                    break;
-                }
                 tx = channel.getTransaction();
                 tx.begin();
                 Event rowEvent = channel.take();
@@ -117,7 +113,7 @@ public class KafkaFederationWorker extends Thread {
             } catch (Exception e) {
                 LOG.error(e.getMessage(), e);
                 if (tx != null) {
-                    tx.rollback();
+                    tx.commit();
                     tx.close();
                 }
                 // metric
@@ -140,11 +136,8 @@ public class KafkaFederationWorker extends Thread {
         String inlongStreamId = headers.get(Constants.INLONG_STREAM_ID);
         String uid = InlongId.generateUid(inlongGroupId, inlongStreamId);
         String topic = this.context.getTopic(uid);
-        if (!StringUtils.isBlank(topic)) {
-            headers.put(Constants.TOPIC, topic);
-            return topic;
-        }
-        return "-";
+        headers.put(Constants.TOPIC, topic);
+        return topic;
     }
 
     /** sleepOneInterval */

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
@@ -112,7 +112,7 @@ public class KafkaFederationWorker extends Thread {
             } catch (Exception e) {
                 LOG.error(e.getMessage(), e);
                 if (tx != null) {
-                    tx.commit();
+                    tx.rollback();
                     tx.close();
                 }
                 // metric

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaProducerCluster.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaProducerCluster.java
@@ -132,6 +132,7 @@ public class KafkaProducerCluster implements LifecycleAware {
             tx.commit();
             profileEvent.ack();
             tx.close();
+            sinkContext.addSendResultMetric(profileEvent, topic, false, sendTime);
             return true;
         }
         try {
@@ -145,7 +146,7 @@ public class KafkaProducerCluster implements LifecycleAware {
                             LOG.error(String.format("send failed, topic is %s, partition is %s",
                                     metadata.topic(), metadata.partition()), ex);
                             tx.rollback();
-                            sinkContext.addSendResultMetric(profileEvent, topic, true, sendTime);
+                            sinkContext.addSendResultMetric(profileEvent, topic, false, sendTime);
                         }
                         tx.close();
                     });
@@ -154,7 +155,7 @@ public class KafkaProducerCluster implements LifecycleAware {
             tx.rollback();
             tx.close();
             LOG.error(e.getMessage(), e);
-            sinkContext.addSendResultMetric(profileEvent, topic, true, sendTime);
+            sinkContext.addSendResultMetric(profileEvent, topic, false, sendTime);
             return false;
         }
     }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -151,23 +151,23 @@ public final class SortSdkSource extends AbstractSource
     }
 
     /**
-     * Create one {@link SortClient} with specific sort id.
+     * Create one {@link SortClient} with specific sort task.
      *
      * <p>
      * In current version, the {@link FetchCallback} will hold the client to ACK. For more details see
      * {@link FetchCallback#onFinished}
      * </p>
      *
-     * @param  sortId Sort in of new client.
+     * @param  sortTaskName Sort in of new client.
      * @return        New sort client.
      */
-    private SortClient newClient(final String sortId) {
-        LOG.info("Start to new sort client for id: {}", sortId);
+    private SortClient newClient(final String sortTaskName) {
+        LOG.info("Start to new sort client for task: {}", sortTaskName);
         try {
-            final SortClientConfig clientConfig = new SortClientConfig(sortId, this.sortClusterName,
+            final SortClientConfig clientConfig = new SortClientConfig(sortTaskName, this.sortClusterName,
                     new DefaultTopicChangeListener(),
                     SortSdkSource.defaultStrategy, InetAddress.getLocalHost().getHostAddress());
-            final FetchCallback callback = FetchCallback.Factory.create(sortId, getChannelProcessor(), context);
+            final FetchCallback callback = FetchCallback.Factory.create(sortTaskName, getChannelProcessor(), context);
             clientConfig.setCallback(callback);
 
             // create SortClient
@@ -211,9 +211,9 @@ public final class SortSdkSource extends AbstractSource
             callback.setClient(client);
             return client;
         } catch (UnknownHostException ex) {
-            LOG.error("Got one UnknownHostException when init client of id:{}", sortId, ex);
+            LOG.error("Got one UnknownHostException when init client of id:{}", sortTaskName, ex);
         } catch (Throwable th) {
-            LOG.error("Got one throwable when init client of id:{}", sortId, th);
+            LOG.error("Got one throwable when init client of id:{}", sortTaskName, th);
         }
         return null;
     }


### PR DESCRIPTION

### Title Name: [INLONG-4453][Sort-Standalone] Fix bug that report wrong audit when send to kafka failed

Fixes #4453 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
