### PR TITLE
[INLONG-4451][TubeMQ] Revert update the base docker image for TubeMQ

### DIFF
--- a/inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile
+++ b/inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # tubemq depend on zookeeper
-FROM zookeeper:3.6
+FROM zookeeper:3.4
 # install tools for debug
 RUN apt-get update \
     && apt-get install -y net-tools vim curl procps \


### PR DESCRIPTION
This reverts commit 4e340b639fd07c5f86d3754cb149a4002838019b.

### Title Name: [INLONG-XYZ][component] Title of the pull request

where *XYZ* should be replaced by the actual issue number.

Fixes #<xyz>

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
