### PR TITLE
[INLONG-4477][Audit] Audit-store supports Pulsar authenticate

### DIFF
--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/config/MessageQueueConfig.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/config/MessageQueueConfig.java
@@ -39,6 +39,12 @@ public class MessageQueueConfig {
     @Value("${audit.pulsar.consumer.enable.retry:false}")
     private boolean pulsarConsumerEnableRetry = false;
 
+    @Value("${audit.pulsar.token:}")
+    private String pulsarToken;
+
+    @Value("${audit.pulsar.enable.auth:true}")
+    private boolean pulsarEnableAuth;
+
     @Value("${audit.pulsar.consumer.receive.queue.size:1000}")
     private int consumerReceiveQueueSize = 1000;
 

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/consume/PulsarConsume.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/consume/PulsarConsume.java
@@ -23,6 +23,8 @@ import org.apache.inlong.audit.config.MessageQueueConfig;
 import org.apache.inlong.audit.config.StoreConfig;
 import org.apache.inlong.audit.db.dao.AuditDataDao;
 import org.apache.inlong.audit.service.ElasticsearchService;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageListener;
@@ -63,10 +65,13 @@ public class PulsarConsume extends BaseConsume {
     private PulsarClient getOrCreatePulsarClient(String pulsarServerUrl) {
         LOG.info("start consumer pulsarServerUrl = {}", pulsarServerUrl);
         PulsarClient pulsarClient = null;
+        ClientBuilder builder = PulsarClient.builder();
         try {
-            pulsarClient = PulsarClient.builder().serviceUrl(pulsarServerUrl)
-                    .connectionTimeout(mqConfig.getClientOperationTimeoutSecond(),
-                            TimeUnit.SECONDS).build();
+            if (mqConfig.isPulsarEnableAuth() && StringUtils.isNotEmpty(mqConfig.getPulsarToken())) {
+                builder.authentication(AuthenticationFactory.token(mqConfig.getPulsarToken()));
+            }
+            pulsarClient = builder.serviceUrl(pulsarServerUrl)
+                    .connectionTimeout(mqConfig.getClientOperationTimeoutSecond(), TimeUnit.SECONDS).build();
         } catch (PulsarClientException e) {
             LOG.error("getOrCreatePulsarClient has pulsar {} err {}", pulsarServerUrl, e);
         }

--- a/inlong-audit/conf/application.properties
+++ b/inlong-audit/conf/application.properties
@@ -55,6 +55,8 @@ audit.config.store.mode=mysql
 audit.pulsar.server.url=pulsar://127.0.0.1:6650
 audit.pulsar.topic=persistent://public/default/inlong-audit
 audit.pulsar.consumer.sub.name=inlong-audit-subscription
+audit.pulsar.token=inlong-audit-token
+audit.pulsar.enable.auth=true
 
 # tube config
 audit.tube.masterlist=127.0.0.1:8715


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-4477][Audit] Audit-store supports Pulsar authenticate

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/incubator-inlong/issues) number)*

- Fixes #4477 

### Modifications

- add pulsar auth switch and token in inlong-audit application.properties

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
