### PR TITLE
[INLONG-4491][Sort] Fix missing dependencies after packaging for sort-dist module

### DIFF
--- a/inlong-sort/sort-dist/pom.xml
+++ b/inlong-sort/sort-dist/pom.xml
@@ -118,28 +118,9 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
                             <finalName>${project.artifactId}-${project.version}</finalName>
-                            <artifactSet>
-                                <includes>
-                                    <include>org.apache.inlong:sort-common</include>
-                                    <include>org.apache.inlong:sort-core</include>
-                                    <include>org.apache.inlong:sort-api</include>
-                                    <!--User do not need to care which format include, sort include all basic format-->
-                                    <include>org.apache.inlong:sort-format-common</include>
-                                    <include>org.apache.inlong:sort-format-base</include>
-                                    <include>org.apache.inlong:sort-format-csv</include>
-                                    <include>org.apache.inlong:sort-format-inlongmsg-base</include>
-                                    <include>org.apache.inlong:sort-format-inlongmsg-csv</include>
-                                    <include>org.apache.inlong:sort-format-json</include>
-                                    <include>org.apache.inlong:sort-format-kv</include>
-                                    <include>org.apache.flink:flink-csv</include>
-                                    <include>org.apache.flink:flink-json</include>
-                                    <include>org.apache.flink:flink-sql-avro</include>
-                                    <include>org.apache.flink:flink-sql-parquet_${scala.binary.version}</include>
-                                    <include>org.apache.flink:flink-sql-orc_${scala.binary.version}</include>
-                                </includes>
-                            </artifactSet>
                             <filters>
                                 <!-- Globally exclude log4j.properties from our JAR files. -->
                                 <filter>


### PR DESCRIPTION
[INLONG-4491][Sort] Fix missing dependencies after packaging for sort-dist module

- Fixes #4491 

### Motivation

Fix `sort-dist` maven package lose dependencies.

### Modifications

1. remove `artifactSet` of `sort-dist pom`. 
2. set `createDependencyReducedPom` false.

sort-dist is a execute jar should set `createDependencyReducedPom` false.
wo can see the [discussion](https://stackoverflow.com/questions/22904573/what-is-the-purpose-of-dependency-reduced-pom-xml-generated-by-the-shade-plugin).
And [flink-dist](https://github.com/apache/flink/blob/master/flink-dist/pom.xml) set `createDependencyReducedPom` false too.

