### PR TITLE
[INLONG-4497][Manager] Fix the method of asynchronously deleting the inlong group in the client

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
@@ -533,15 +533,20 @@ public class InnerInlongManagerClient {
         String path = HTTP_PATH;
         if (async) {
             path += "/group/deleteAsync/" + groupId;
+            String finalGroupId = this.sendDeleteForClass(
+                    formatUrl(path),
+                    null,
+                    String.class
+            );
+            return groupId.equals(finalGroupId);
         } else {
             path += "/group/delete/" + groupId;
+            return this.sendDeleteForClass(
+                    formatUrl(path),
+                    null,
+                    Boolean.class
+            );
         }
-
-        return this.sendDeleteForClass(
-                formatUrl(path),
-                null,
-                Boolean.class
-        );
     }
 
     /**


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-4497][Manager] Fix deleteGroup Async method in Client

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/incubator-inlong/issues) number)*

- Fixes #4497 

### Motivation

### Modifications

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
