### PR TITLE
[INLONG-4500][Manager][Dashboard] Remove non-null restriction on hiveConfDir parameter

### DIFF
--- a/inlong-dashboard/src/components/MetaData/StorageHive.tsx
+++ b/inlong-dashboard/src/components/MetaData/StorageHive.tsx
@@ -169,7 +169,6 @@ const getForm: GetStorageFormFieldsType = (
       type: 'input',
       label: i18n.t('components.AccessHelper.StorageMetaData.Hive.ConfDir'),
       name: 'hiveConfDir',
-      rules: [{ required: true }],
       tooltip: i18n.t('components.AccessHelper.StorageMetaData.Hive.ConfDirHelp'),
       props: {
         placeholder: '/usr/hive/conf',

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sink/hive/HiveSinkRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sink/hive/HiveSinkRequest.java
@@ -85,7 +85,6 @@ public class HiveSinkRequest extends SinkRequest {
     @ApiModelProperty("Version for Hive, such as: 3.2.1")
     private String hiveVersion;
 
-    @NotNull(message = "hiveConfDir cannot be null")
     @ApiModelProperty("Config directory of Hive on HDFS, must include hive-site.xml")
     private String hiveConfDir;
 


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #4500 

### Motivation

Remove non-null restriction on hiveConfDir parameter, as the Sort module has no non-null restriction on this field.

### Verifying this change

- [X] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)
