### PR TITLE
[INLONG-4532][Manager] Fix init sort config error during initing group info in the client

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongGroupImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongGroupImpl.java
@@ -71,6 +71,8 @@ public class InlongGroupImpl implements InlongGroup {
         if (newGroupInfo != null) {
             this.groupContext.setGroupInfo(groupInfo);
         } else {
+            BaseSortConf sortConf = groupInfo.getSortConf();
+            groupInfo = InlongGroupTransfer.createGroupInfo(groupInfo, sortConf);
             String groupId = managerClient.createGroup(groupInfo.genRequest());
             groupInfo.setInlongGroupId(groupId);
         }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongGroupTransfer.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongGroupTransfer.java
@@ -74,7 +74,7 @@ public class InlongGroupTransfer {
 
         if (sortConf == null) {
             throw new IllegalArgumentException(
-                    String.format("Sort config should not be empty for Inlong=", originGroupInfo.getInlongGroupId()));
+                    String.format("sort config cannot be empty for group=", originGroupInfo.getInlongGroupId()));
         }
         // set the sort config into ext list
         SortType sortType = sortConf.getType();

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongGroupTransfer.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/InlongGroupTransfer.java
@@ -72,6 +72,10 @@ public class InlongGroupTransfer {
             originGroupInfo.getExtList().addAll(extInfos);
         }
 
+        if (sortConf == null) {
+            throw new IllegalArgumentException(
+                    String.format("Sort config should not be empty for Inlong=", originGroupInfo.getInlongGroupId()));
+        }
         // set the sort config into ext list
         SortType sortType = sortConf.getType();
         List<InlongGroupExtInfo> sortExtInfos;


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-4532][Manager] Fix group init method in Client

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/incubator-inlong/issues) number)*

- Fixes #4532 

### Motivation

### Modifications

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
