### PR TITLE
[INLONG-4535][Agent] Support configurable automatic exit function when OOM happens

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/common/AgentThreadFactory.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/common/AgentThreadFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.agent.common;
 
+import org.apache.inlong.agent.utils.AgentUtils;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +43,9 @@ public class AgentThreadFactory implements ThreadFactory {
     @Override
     public Thread newThread(Runnable r) {
         Thread t = new Thread(r, threadType + "-running-thread-" + mThreadNum.getAndIncrement());
+        if (AgentUtils.enableOOMExit()) {
+            t.setUncaughtExceptionHandler(ThreadUtils::threadThrowableHandler);
+        }
         LOGGER.debug("{} created", t.getName());
         return t;
     }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
@@ -191,4 +191,7 @@ public class AgentConstants {
     public static final String JOB_VERSION = "job.version";
     public static final Integer DEFAULT_JOB_VERSION = 1;
 
+    public static final String AGENT_ENABLE_OOM_EXIT = "agent.enable.oom.exit";
+    public static final boolean DEFAULT_ENABLE_OOM_EXIT = false;
+
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -52,10 +52,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.inlong.agent.constant.AgentConstants.AGENT_ENABLE_OOM_EXIT;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_IP;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_UUID;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_UUID_OPEN;
 import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_AGENT_LOCAL_UUID_OPEN;
+import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_ENABLE_OOM_EXIT;
 import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_LOCAL_IP;
 
 /**
@@ -427,6 +429,10 @@ public class AgentUtils {
             throw new RuntimeException(ex);
         }
         return finalPath;
+    }
+
+    public static boolean enableOOMExit() {
+        return AgentConfiguration.getAgentConf().getBoolean(AGENT_ENABLE_OOM_EXIT, DEFAULT_ENABLE_OOM_EXIT);
     }
 
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/ThreadUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/ThreadUtils.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ThreadUtils {
 
-    private static final Logger logger = LoggerFactory.getLogger(ThreadUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThreadUtils.class);
 
     public static void threadThrowableHandler(Thread t, Throwable e) {
         if (AgentUtils.enableOOMExit()) {
@@ -36,7 +36,7 @@ public class ThreadUtils {
 
     private static void handleOOM(Thread t, Throwable e) {
         if (ExceptionUtils.indexOfThrowable(e, java.lang.OutOfMemoryError.class) != -1) {
-            logger.error("Agent exit caused by {} OutOfMemory: ", t.getName(), e);
+            LOGGER.error("Agent exit caused by {} OutOfMemory: ", t.getName(), e);
             forceShutDown();
         }
     }
@@ -45,7 +45,7 @@ public class ThreadUtils {
         try {
             Runtime.getRuntime().exit(-1);
         } catch (Throwable e) {
-            logger.error("exit failed, just halt, exception: ", e);
+            LOGGER.error("exit failed, just halt, exception: ", e);
             Runtime.getRuntime().halt(-2);
         }
     }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/ThreadUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/ThreadUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.utils;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ThreadUtils, used for handle specified throwable, such as oom, etc.
+ */
+public class ThreadUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ThreadUtils.class);
+
+    public static void threadThrowableHandler(Thread t, Throwable e) {
+        if (AgentUtils.enableOOMExit()) {
+            handleOOM(t, e);
+        }
+    }
+
+    private static void handleOOM(Thread t, Throwable e) {
+        if (ExceptionUtils.indexOfThrowable(e, java.lang.OutOfMemoryError.class) != -1) {
+            logger.error("Agent exit caused by {} OutOfMemory: ", t.getName(), e);
+            forceShutDown();
+        }
+    }
+
+    private static void forceShutDown() {
+        try {
+            Runtime.getRuntime().exit(-1);
+        } catch (Throwable e) {
+            logger.error("exit failed, just halt, exception: ", e);
+            Runtime.getRuntime().halt(-2);
+        }
+    }
+
+}
+

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
@@ -24,6 +24,7 @@ import org.apache.inlong.agent.core.job.JobManager;
 import org.apache.inlong.agent.core.job.JobWrapper;
 import org.apache.inlong.agent.utils.AgentUtils;
 import org.apache.inlong.agent.utils.HttpManager;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.apache.inlong.common.pojo.agent.TaskSnapshotMessage;
 import org.apache.inlong.common.pojo.agent.TaskSnapshotRequest;
 import org.slf4j.Logger;
@@ -138,8 +139,9 @@ public class HeartbeatManager extends AbstractDaemon {
                     int heartbeatInterval = conf.getInt(AGENT_HEARTBEAT_INTERVAL,
                             DEFAULT_AGENT_HEARTBEAT_INTERVAL);
                     TimeUnit.SECONDS.sleep(heartbeatInterval);
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     LOGGER.error("error caught", ex);
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
                 }
             }
         };

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/Job.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/Job.java
@@ -24,6 +24,7 @@ import org.apache.inlong.agent.plugin.Channel;
 import org.apache.inlong.agent.plugin.Reader;
 import org.apache.inlong.agent.plugin.Sink;
 import org.apache.inlong.agent.plugin.Source;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,8 +98,9 @@ public class Job {
                 String taskId = String.format("%s_%d", jobInstanceId, index++);
                 taskList.add(new Task(taskId, reader, writer, channel, getJobConf()));
             }
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
             LOGGER.error("create task failed", ex);
+            ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
             throw new RuntimeException(ex);
         }
         return taskList;

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobManager.java
@@ -27,6 +27,7 @@ import org.apache.inlong.agent.db.JobProfileDb;
 import org.apache.inlong.agent.db.StateSearchKey;
 import org.apache.inlong.agent.utils.AgentUtils;
 import org.apache.inlong.agent.utils.ConfigUtil;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,6 +122,8 @@ public class JobManager extends AbstractDaemon {
         } catch (Exception rje) {
             LOGGER.debug("reject job {}", job.getJobInstanceId(), rje);
             pendingJobs.putIfAbsent(job.getJobInstanceId(), job);
+        } catch (Throwable t) {
+            ThreadUtils.threadThrowableHandler(Thread.currentThread(), t);
         }
     }
 
@@ -233,8 +236,9 @@ public class JobManager extends AbstractDaemon {
                         }
                     }
                     TimeUnit.SECONDS.sleep(monitorInterval);
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     LOGGER.error("error caught", ex);
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
                 }
             }
         };
@@ -253,8 +257,9 @@ public class JobManager extends AbstractDaemon {
                 }
                 try {
                     TimeUnit.SECONDS.sleep(jobDbCacheCheckInterval);
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     LOGGER.error("sleep error caught", ex);
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
                 }
             }
         };

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
@@ -24,6 +24,7 @@ import org.apache.inlong.agent.constant.AgentConstants;
 import org.apache.inlong.agent.core.AgentManager;
 import org.apache.inlong.agent.utils.AgentUtils;
 import org.apache.inlong.agent.utils.ConfigUtil;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -236,8 +237,9 @@ public class TaskManager extends AbstractDaemon {
                         }
                     }
                     TimeUnit.SECONDS.sleep(monitorInterval);
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     LOGGER.error("Exception caught", ex);
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
                 }
             }
         };

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskPositionManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskPositionManager.java
@@ -22,6 +22,7 @@ import org.apache.inlong.agent.conf.AgentConfiguration;
 import org.apache.inlong.agent.conf.JobProfile;
 import org.apache.inlong.agent.core.AgentManager;
 import org.apache.inlong.agent.db.JobProfileDb;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,8 +101,9 @@ public class TaskPositionManager extends AbstractDaemon {
                     int flushTime = conf.getInt(AGENT_HEARTBEAT_INTERVAL,
                             DEFAULT_AGENT_FETCHER_INTERVAL);
                     TimeUnit.SECONDS.sleep(flushTime);
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     LOGGER.error("error caught", ex);
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
                 }
             }
         };

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/trigger/TriggerManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/trigger/TriggerManager.java
@@ -27,6 +27,7 @@ import org.apache.inlong.agent.core.AgentManager;
 import org.apache.inlong.agent.core.job.JobWrapper;
 import org.apache.inlong.agent.db.TriggerProfileDb;
 import org.apache.inlong.agent.plugin.Trigger;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,8 +84,9 @@ public class TriggerManager extends AbstractDaemon {
             triggerMap.put(triggerId, trigger);
             trigger.init(triggerProfile);
             trigger.run();
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
             LOGGER.error("exception caught", ex);
+            ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
             return false;
         }
         return true;
@@ -127,8 +129,10 @@ public class TriggerManager extends AbstractDaemon {
                         }
                     });
                     TimeUnit.SECONDS.sleep(triggerFetchInterval);
-                } catch (Exception ignored) {
-                    LOGGER.info("ignored Exception ", ignored);
+                } catch (Throwable e) {
+                    LOGGER.info("ignored Exception ", e);
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), e);
+
                 }
             }
 
@@ -167,8 +171,9 @@ public class TriggerManager extends AbstractDaemon {
                         }
                     });
                     TimeUnit.MINUTES.sleep(JOB_CHECK_INTERVAL);
-                } catch (Exception ignored) {
-                    LOGGER.info("ignored Exception ", ignored);
+                } catch (Throwable e) {
+                    LOGGER.info("ignored Exception ", e);
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), e);
                 }
             }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -37,6 +37,7 @@ import org.apache.inlong.agent.pojo.DbCollectorTaskRequestDto;
 import org.apache.inlong.agent.pojo.DbCollectorTaskResult;
 import org.apache.inlong.agent.utils.AgentUtils;
 import org.apache.inlong.agent.utils.HttpManager;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.apache.inlong.common.db.CommandEntity;
 import org.apache.inlong.common.enums.ManagerOpEnum;
 import org.apache.inlong.common.enums.PullJobTypeEnum;
@@ -489,8 +490,9 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
 
                     // fetch db collector task from manager
                     fetchDbCollectTask();
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     LOGGER.warn("exception caught", ex);
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
                 }
             }
         };

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
@@ -28,6 +28,7 @@ import org.apache.inlong.agent.plugin.Message;
 import org.apache.inlong.agent.plugin.MessageFilter;
 import org.apache.inlong.agent.plugin.message.PackProxyMessage;
 import org.apache.inlong.agent.utils.AgentUtils;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,6 +121,8 @@ public class ProxySink extends AbstractSink {
             }
         } catch (Exception e) {
             LOGGER.error("write message to Proxy sink error", e);
+        } catch (Throwable t) {
+            ThreadUtils.threadThrowableHandler(Thread.currentThread(), t);
         }
     }
 
@@ -170,6 +173,8 @@ public class ProxySink extends AbstractSink {
                     AgentUtils.silenceSleepInMs(batchFlushInterval);
                 } catch (Exception ex) {
                     LOGGER.error("error caught", ex);
+                } catch (Throwable t) {
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), t);
                 }
             }
         };
@@ -196,8 +201,9 @@ public class ProxySink extends AbstractSink {
         senderManager = new SenderManager(jobConf, inlongGroupId, sourceName);
         try {
             senderManager.addMessageSender();
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
             LOGGER.error("error while init sender for group id {}", inlongGroupId);
+            ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
             throw new IllegalStateException(ex);
         }
     }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/snapshot/BinlogSnapshotBase.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/snapshot/BinlogSnapshotBase.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.agent.plugin.sources.snapshot;
 
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,8 +77,9 @@ public class BinlogSnapshotBase implements SnapshotBase {
             offset = outputStream.toByteArray();
             inputStream.close();
             outputStream.close();
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
             log.error("load binlog offset error", ex);
+            ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
         }
     }
 
@@ -90,8 +92,10 @@ public class BinlogSnapshotBase implements SnapshotBase {
             offset = bytes;
             try (OutputStream output = new FileOutputStream(file)) {
                 output.write(bytes);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 log.error("save offset to file error", e);
+                ThreadUtils.threadThrowableHandler(Thread.currentThread(), e);
+
             }
         }
     }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/DirectoryTrigger.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/DirectoryTrigger.java
@@ -24,6 +24,7 @@ import org.apache.inlong.agent.constant.AgentConstants;
 import org.apache.inlong.agent.constant.JobConstants;
 import org.apache.inlong.agent.plugin.Trigger;
 import org.apache.inlong.agent.plugin.utils.PluginUtils;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,8 +201,9 @@ public class DirectoryTrigger extends AbstractDaemon implements Trigger {
                         watchKeys.addAll(tmpWatchers);
                         watchKeys.removeAll(tmpDeletedWatchers);
                     });
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     LOGGER.error("error caught", ex);
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
                 }
             }
         };

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/PathPattern.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/PathPattern.java
@@ -20,6 +20,7 @@ package org.apache.inlong.agent.plugin.trigger;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.inlong.agent.plugin.filter.DateFormatRegex;
+import org.apache.inlong.agent.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +99,10 @@ public class PathPattern {
                     }
                 });
             } catch (Exception e) {
-                LOGGER.error("error caught", e);
+                LOGGER.error("exception caught", e);
+            } catch (Throwable t) {
+                ThreadUtils.threadThrowableHandler(Thread.currentThread(), t);
+
             }
         }
     }

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/TestOOMExit.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/TestOOMExit.java
@@ -34,7 +34,7 @@ public class TestOOMExit {
     private final MockJobManager jobManager = new MockJobManager();
 
     @Test
-    public void TestOOM() {
+    public void testOOM() {
         AgentConfiguration conf = AgentConfiguration.getAgentConf();
         conf.setBoolean(AGENT_ENABLE_OOM_EXIT, true);
         jobManager.start();

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/TestOOMExit.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/TestOOMExit.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.plugin;
+
+import org.apache.inlong.agent.common.AbstractDaemon;
+import org.apache.inlong.agent.conf.AgentConfiguration;
+import org.apache.inlong.agent.utils.ThreadUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.inlong.agent.constant.AgentConstants.AGENT_ENABLE_OOM_EXIT;
+
+public class TestOOMExit {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestOOMExit.class);
+    private final MockJobManager jobManager = new MockJobManager();
+
+    @Test
+    public void TestOOM() {
+        AgentConfiguration conf = AgentConfiguration.getAgentConf();
+        conf.setBoolean(AGENT_ENABLE_OOM_EXIT, true);
+        jobManager.start();
+        jobManager.join();
+    }
+
+    static class MockJobManager extends AbstractDaemon {
+
+        @Override
+        public void start() {
+            submitWorker(throwOOMThread());
+        }
+
+        @Override
+        public void stop() throws Exception {
+
+        }
+
+        public Runnable throwOOMThread() {
+            return () -> {
+                int i = 0;
+                while (true) {
+                    try {
+                        LOGGER.info("throw OOM thread: " + i);
+                        TimeUnit.SECONDS.sleep(1);
+                        i++;
+                        if (i == 5) {
+                            LOGGER.info("throw OOM");
+                            throw new OutOfMemoryError();
+                        }
+                    } catch (Throwable ex) {
+                        ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
+                    }
+                }
+            };
+        }
+    }
+
+}

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -53,6 +53,7 @@ thread.pool.await.time=30
 agent.local.ip=127.0.0.1
 agent.local.uuid=
 agent.local.uuid.open=false
+agent.enable.oom.exit=false
 
 
 ###########################


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-4535][Agent] Support configurable automatic exit function when OOM happens

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/incubator-inlong/issues) number)*

- Fixes #4535 

### Motivation
- Generally, the occurrence of OutOfMemoryError means that agent won't run and collect data as ususal. To solve this problem and avoid human manipulation , we let agent supports automatically exit when OOM happens. Therefore, users can use scripts or other detection tools to monitor whether agent exits and restarts it if necessary.

### Modifications
- If "agent.enable.oom.exit" parameter is set as "true" in agent.properties, agent will automatically exit when OutOfMemoryError happens. 

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
