### PR TITLE
[INLONG-4541][Manager] Support save extension params for inlong cluster

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/InlongClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/InlongClusterInfo.java
@@ -18,18 +18,25 @@
 package org.apache.inlong.manager.common.pojo.cluster;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
 
 import java.util.Date;
 
 /**
- * Inlong cluster response
+ * Inlong cluster info
  */
 @Data
-@ApiModel("Inlong cluster response")
-public class InlongClusterResponse {
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel("Inlong cluster info")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, visible = true, property = "type")
+public class InlongClusterInfo {
 
     @ApiModelProperty(value = "Primary key")
     private Integer id;
@@ -75,5 +82,9 @@ public class InlongClusterResponse {
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private Date modifyTime;
+
+    public InlongClusterRequest genRequest() {
+        return CommonBeanUtils.copyProperties(this, InlongClusterRequest::new);
+    }
 
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/InlongClusterRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/InlongClusterRequest.java
@@ -17,9 +17,13 @@
 
 package org.apache.inlong.manager.common.pojo.cluster;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
@@ -27,7 +31,11 @@ import javax.validation.constraints.NotBlank;
  * Inlong cluster request
  */
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @ApiModel("Inlong cluster request")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, visible = true, property = "type")
 public class InlongClusterRequest {
 
     @ApiModelProperty(value = "Primary key")

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/dataproxy/DataProxyClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/dataproxy/DataProxyClusterInfo.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.pojo.cluster.dataproxy;
+
+import io.swagger.annotations.ApiModel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.enums.ClusterType;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+
+/**
+ * Inlong cluster info for DataProxy
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeDefine(value = ClusterType.CLS_DATA_PROXY)
+@ApiModel("Inlong cluster info for DataProxy")
+public class DataProxyClusterInfo extends InlongClusterInfo {
+
+    // no fields
+
+    public DataProxyClusterInfo() {
+        this.setType(ClusterType.CLS_DATA_PROXY);
+    }
+
+    @Override
+    public DataProxyClusterRequest genRequest() {
+        return CommonBeanUtils.copyProperties(this, DataProxyClusterRequest::new);
+    }
+
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/dataproxy/DataProxyClusterRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/dataproxy/DataProxyClusterRequest.java
@@ -15,35 +15,30 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.common.enums;
+package org.apache.inlong.manager.common.pojo.cluster.dataproxy;
 
-import org.apache.inlong.manager.common.exceptions.BusinessException;
+import io.swagger.annotations.ApiModel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.enums.ClusterType;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
 
 /**
- * Enum of cluster type.
+ * Inlong cluster request for DataProxy
  */
-public enum ClusterType {
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeDefine(value = ClusterType.CLS_DATA_PROXY)
+@ApiModel("Inlong cluster request for DataProxy")
+public class DataProxyClusterRequest extends InlongClusterRequest {
 
-    TUBE,
-    PULSAR,
-    DATA_PROXY,
+    // no field
 
-    ;
-
-    public static final String CLS_TUBE = "TUBE";
-    public static final String CLS_PULSAR = "PULSAR";
-    public static final String CLS_DATA_PROXY = "DATA_PROXY";
-
-    /**
-     * Get the SinkType enum via the given sinkType string
-     */
-    public static ClusterType forType(String type) {
-        for (ClusterType clsType : values()) {
-            if (clsType.name().equals(type)) {
-                return clsType;
-            }
-        }
-        throw new BusinessException(String.format(ErrorCodeEnum.MQ_TYPE_NOT_SUPPORTED.getMessage(), type));
+    public DataProxyClusterRequest() {
+        this.setType(ClusterType.CLS_DATA_PROXY);
     }
 
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/pulsar/PulsarClusterDTO.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/pulsar/PulsarClusterDTO.java
@@ -49,6 +49,16 @@ public class PulsarClusterDTO {
     private String tenant;
 
     /**
+     * Get the dto instance from the request
+     */
+    public static PulsarClusterDTO getFromRequest(PulsarClusterRequest request) {
+        return PulsarClusterDTO.builder()
+                .adminUrl(request.getAdminUrl())
+                .tenant(request.getTenant())
+                .build();
+    }
+
+    /**
      * Get the dto instance from the JSON string.
      */
     public static PulsarClusterDTO getFromJson(@NotNull String extParams) {

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/pulsar/PulsarClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/pulsar/PulsarClusterInfo.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.pojo.cluster.pulsar;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.enums.ClusterType;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+
+/**
+ * Inlong cluster info for Pulsar
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeDefine(value = ClusterType.CLS_PULSAR)
+@ApiModel("Inlong cluster info for Pulsar")
+public class PulsarClusterInfo extends InlongClusterInfo {
+
+    @ApiModelProperty(value = "Pulsar admin URL, such as: http://127.0.0.1:8080")
+    private String adminUrl;
+
+    @ApiModelProperty(value = "Pulsar tenant")
+    private String tenant;
+
+    public PulsarClusterInfo() {
+        this.setType(ClusterType.CLS_PULSAR);
+    }
+
+    @Override
+    public PulsarClusterRequest genRequest() {
+        return CommonBeanUtils.copyProperties(this, PulsarClusterRequest::new);
+    }
+
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/pulsar/PulsarClusterRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/pulsar/PulsarClusterRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.pojo.cluster.pulsar;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.enums.ClusterType;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+
+/**
+ * Inlong cluster request for Pulsar
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeDefine(value = ClusterType.CLS_PULSAR)
+@ApiModel("Inlong cluster request for Pulsar")
+public class PulsarClusterRequest extends InlongClusterRequest {
+
+    @ApiModelProperty(value = "Pulsar admin URL, such as: http://127.0.0.1:8080")
+    private String adminUrl;
+
+    @ApiModelProperty(value = "Pulsar tenant")
+    private String tenant;
+
+    public PulsarClusterRequest() {
+        this.setType(ClusterType.CLS_PULSAR);
+    }
+
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterInfo.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.pojo.cluster.tube;
+
+import io.swagger.annotations.ApiModel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.enums.ClusterType;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+
+/**
+ * Inlong cluster info for Tube
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeDefine(value = ClusterType.CLS_TUBE)
+@ApiModel("Inlong cluster info for Tube")
+public class TubeClusterInfo extends InlongClusterInfo {
+
+    // no fields
+
+    public TubeClusterInfo() {
+        this.setType(ClusterType.CLS_TUBE);
+    }
+
+    @Override
+    public TubeClusterRequest genRequest() {
+        return CommonBeanUtils.copyProperties(this, TubeClusterRequest::new);
+    }
+
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterRequest.java
@@ -15,35 +15,30 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.common.enums;
+package org.apache.inlong.manager.common.pojo.cluster.tube;
 
-import org.apache.inlong.manager.common.exceptions.BusinessException;
+import io.swagger.annotations.ApiModel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.enums.ClusterType;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
 
 /**
- * Enum of cluster type.
+ * Inlong cluster request for Tube
  */
-public enum ClusterType {
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeDefine(value = ClusterType.CLS_TUBE)
+@ApiModel("Inlong cluster request for Tube")
+public class TubeClusterRequest extends InlongClusterRequest {
 
-    TUBE,
-    PULSAR,
-    DATA_PROXY,
+    // no field
 
-    ;
-
-    public static final String CLS_TUBE = "TUBE";
-    public static final String CLS_PULSAR = "PULSAR";
-    public static final String CLS_DATA_PROXY = "DATA_PROXY";
-
-    /**
-     * Get the SinkType enum via the given sinkType string
-     */
-    public static ClusterType forType(String type) {
-        for (ClusterType clsType : values()) {
-            if (clsType.name().equals(type)) {
-                return clsType;
-            }
-        }
-        throw new BusinessException(String.format(ErrorCodeEnum.MQ_TYPE_NOT_SUPPORTED.getMessage(), type));
+    public TubeClusterRequest() {
+        this.setType(ClusterType.CLS_TUBE);
     }
 
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/AbstractClusterOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/AbstractClusterOperator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.cluster;
+
+import org.apache.inlong.manager.common.enums.GlobalConstants;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.dao.entity.InlongClusterEntity;
+import org.apache.inlong.manager.dao.mapper.InlongClusterEntityMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+/**
+ * Default operator of inlong cluster.
+ */
+public abstract class AbstractClusterOperator implements InlongClusterOperator {
+
+    @Autowired
+    protected InlongClusterEntityMapper clusterMapper;
+
+    @Override
+    @Transactional(rollbackFor = Throwable.class)
+    public Integer saveOpt(InlongClusterRequest request, String operator) {
+        InlongClusterEntity entity = CommonBeanUtils.copyProperties(request, InlongClusterEntity::new);
+        // set the ext params
+        this.setTargetEntity(request, entity);
+
+        entity.setCreator(operator);
+        entity.setCreateTime(new Date());
+        entity.setIsDeleted(GlobalConstants.UN_DELETED);
+        clusterMapper.insert(entity);
+
+        return entity.getId();
+    }
+
+    /**
+     * Set the parameters of the target entity.
+     *
+     * @param request inlong cluster request
+     * @param targetEntity entity which will set the new parameters
+     */
+    protected abstract void setTargetEntity(InlongClusterRequest request, InlongClusterEntity targetEntity);
+
+    @Override
+    @Transactional(rollbackFor = Throwable.class, isolation = Isolation.REPEATABLE_READ)
+    public void updateOpt(InlongClusterRequest request, String operator) {
+        InlongClusterEntity entity = CommonBeanUtils.copyProperties(request, InlongClusterEntity::new);
+        // set the ext params
+        this.setTargetEntity(request, entity);
+        entity.setModifier(operator);
+        entity.setModifyTime(new Date());
+        clusterMapper.updateByIdSelective(entity);
+    }
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/DataProxyClusterOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/DataProxyClusterOperator.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.cluster;
+
+import org.apache.inlong.manager.common.enums.ClusterType;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
+import org.apache.inlong.manager.common.pojo.cluster.dataproxy.DataProxyClusterInfo;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.dao.entity.InlongClusterEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * DataProxy cluster operator.
+ */
+@Service
+public class DataProxyClusterOperator extends AbstractClusterOperator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataProxyClusterOperator.class);
+
+    @Override
+    public Boolean accept(String clusterType) {
+        return getClusterType().equals(clusterType);
+    }
+
+    @Override
+    public String getClusterType() {
+        return ClusterType.CLS_DATA_PROXY;
+    }
+
+    @Override
+    protected void setTargetEntity(InlongClusterRequest request, InlongClusterEntity targetEntity) {
+        LOGGER.info("do nothing for data proxy cluster in set target entity");
+    }
+
+    @Override
+    public InlongClusterInfo getFromEntity(InlongClusterEntity entity) {
+        if (entity == null) {
+            throw new BusinessException(ErrorCodeEnum.CLUSTER_NOT_FOUND);
+        }
+        return CommonBeanUtils.copyProperties(entity, DataProxyClusterInfo::new);
+    }
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterOperator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.cluster;
+
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
+import org.apache.inlong.manager.dao.entity.InlongClusterEntity;
+
+/**
+ * Interface of the inlong cluster operator.
+ */
+public interface InlongClusterOperator {
+
+    /**
+     * Determines whether the current instance matches the specified type.
+     */
+    Boolean accept(String clusterType);
+
+    /**
+     * Get the cluster type.
+     *
+     * @return cluster type string
+     */
+    String getClusterType();
+
+    /**
+     * Save the inlong cluster info.
+     *
+     * @param request request of the cluster
+     * @param operator name of the operator
+     * @return cluster id after saving
+     */
+    Integer saveOpt(InlongClusterRequest request, String operator);
+
+    /**
+     * Get the cluster info from the given entity.
+     *
+     * @param entity get field value from the entity
+     * @return cluster info after encapsulating
+     */
+    InlongClusterInfo getFromEntity(InlongClusterEntity entity);
+
+    /**
+     * Update the inlong cluster info.
+     *
+     * @param request request of update
+     * @param operator name of operator
+     */
+    void updateOpt(InlongClusterRequest request, String operator);
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterOperatorFactory.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterOperatorFactory.java
@@ -15,35 +15,33 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.common.enums;
+package org.apache.inlong.manager.service.cluster;
 
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
- * Enum of cluster type.
+ * Factory for {@link InlongClusterOperator}.
  */
-public enum ClusterType {
+@Service
+public class InlongClusterOperatorFactory {
 
-    TUBE,
-    PULSAR,
-    DATA_PROXY,
-
-    ;
-
-    public static final String CLS_TUBE = "TUBE";
-    public static final String CLS_PULSAR = "PULSAR";
-    public static final String CLS_DATA_PROXY = "DATA_PROXY";
+    @Autowired
+    private List<InlongClusterOperator> clusterOperatorList;
 
     /**
-     * Get the SinkType enum via the given sinkType string
+     * Get a cluster operator instance via the given type
      */
-    public static ClusterType forType(String type) {
-        for (ClusterType clsType : values()) {
-            if (clsType.name().equals(type)) {
-                return clsType;
-            }
-        }
-        throw new BusinessException(String.format(ErrorCodeEnum.MQ_TYPE_NOT_SUPPORTED.getMessage(), type));
+    public InlongClusterOperator getInstance(String type) {
+        return clusterOperatorList.stream()
+                .filter(inst -> inst.accept(type))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(
+                        String.format(ErrorCodeEnum.CLUSTER_TYPE_NOT_SUPPORTED.getMessage(), type)));
     }
 
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
@@ -15,15 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.service.core;
+package org.apache.inlong.manager.service.cluster;
 
 import com.github.pagehelper.PageInfo;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyConfig;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeRequest;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeResponse;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
 import org.apache.inlong.manager.common.pojo.cluster.InlongClusterPageRequest;
 import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
-import org.apache.inlong.manager.common.pojo.cluster.InlongClusterResponse;
 import org.apache.inlong.manager.common.pojo.dataproxy.DataProxyNodeInfo;
 
 import java.util.List;
@@ -48,7 +48,7 @@ public interface InlongClusterService {
      * @param id cluster id
      * @return cluster info
      */
-    InlongClusterResponse get(Integer id);
+    InlongClusterInfo get(Integer id);
 
     /**
      * Paging query clusters according to conditions.
@@ -56,15 +56,7 @@ public interface InlongClusterService {
      * @param request page request conditions
      * @return cluster list
      */
-    PageInfo<InlongClusterResponse> list(InlongClusterPageRequest request);
-
-    /**
-     * Query ip list by cluster type
-     *
-     * @param type cluster type
-     * @return cluster node ip list
-     */
-    List<String> listNodeIpByType(String type);
+    PageInfo<InlongClusterInfo> list(InlongClusterPageRequest request);
 
     /**
      * Update cluster information
@@ -108,6 +100,14 @@ public interface InlongClusterService {
      * @return cluster node list
      */
     PageInfo<ClusterNodeResponse> listNode(InlongClusterPageRequest request);
+
+    /**
+     * Query node IP list by cluster type
+     *
+     * @param type cluster type
+     * @return cluster node ip list
+     */
+    List<String> listNodeIpByType(String type);
 
     /**
      * Update cluster node.

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -132,7 +132,14 @@ public class InlongClusterServiceImpl implements InlongClusterService {
     public PageInfo<InlongClusterInfo> list(InlongClusterPageRequest request) {
         PageHelper.startPage(request.getPageNum(), request.getPageSize());
         Page<InlongClusterEntity> entityPage = (Page<InlongClusterEntity>) clusterMapper.selectByCondition(request);
-        List<InlongClusterInfo> list = CommonBeanUtils.copyListProperties(entityPage, InlongClusterInfo::new);
+
+        List<InlongClusterInfo> list = new ArrayList<>(entityPage.getResult().size());
+        for (InlongClusterEntity entity : entityPage) {
+            InlongClusterOperator instance = clusterOperatorFactory.getInstance(entity.getType());
+            InlongClusterInfo clusterInfo = instance.getFromEntity(entity);
+            list.add(clusterInfo);
+        }
+
         PageInfo<InlongClusterInfo> page = new PageInfo<>(list);
         page.setTotal(list.size());
         LOGGER.debug("success to list inlong cluster by {}", request);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/PulsarClusterOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/PulsarClusterOperator.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.cluster;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.enums.ClusterType;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
+import org.apache.inlong.manager.common.pojo.cluster.pulsar.PulsarClusterDTO;
+import org.apache.inlong.manager.common.pojo.cluster.pulsar.PulsarClusterInfo;
+import org.apache.inlong.manager.common.pojo.cluster.pulsar.PulsarClusterRequest;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.dao.entity.InlongClusterEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Pulsar cluster operator.
+ */
+@Service
+public class PulsarClusterOperator extends AbstractClusterOperator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PulsarClusterOperator.class);
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public Boolean accept(String clusterType) {
+        return getClusterType().equals(clusterType);
+    }
+
+    @Override
+    public String getClusterType() {
+        return ClusterType.CLS_PULSAR;
+    }
+
+    @Override
+    public InlongClusterInfo getFromEntity(InlongClusterEntity entity) {
+        if (entity == null) {
+            throw new BusinessException(ErrorCodeEnum.CLUSTER_NOT_FOUND);
+        }
+
+        PulsarClusterInfo pulsarInfo = new PulsarClusterInfo();
+        CommonBeanUtils.copyProperties(entity, pulsarInfo);
+        if (StringUtils.isNotBlank(entity.getExtParams())) {
+            PulsarClusterDTO dto = PulsarClusterDTO.getFromJson(entity.getExtParams());
+            CommonBeanUtils.copyProperties(dto, pulsarInfo);
+        }
+
+        LOGGER.info("success to get pulsar cluster info from entity");
+        return pulsarInfo;
+    }
+
+    @Override
+    protected void setTargetEntity(InlongClusterRequest request, InlongClusterEntity targetEntity) {
+        PulsarClusterRequest pulsarRequest = (PulsarClusterRequest) request;
+        CommonBeanUtils.copyProperties(pulsarRequest, targetEntity, true);
+        try {
+            PulsarClusterDTO dto = PulsarClusterDTO.getFromRequest(pulsarRequest);
+            targetEntity.setExtParams(objectMapper.writeValueAsString(dto));
+            LOGGER.info("success to set entity for pulsar cluster");
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCodeEnum.SOURCE_INFO_INCORRECT.getMessage());
+        }
+    }
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/TubeClusterOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/TubeClusterOperator.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.cluster;
+
+import org.apache.inlong.manager.common.enums.ClusterType;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
+import org.apache.inlong.manager.common.pojo.cluster.tube.TubeClusterInfo;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.dao.entity.InlongClusterEntity;
+import org.apache.inlong.manager.service.group.InlongNoneMqOperator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Tube cluster operator.
+ */
+@Service
+public class TubeClusterOperator extends AbstractClusterOperator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InlongNoneMqOperator.class);
+
+    @Override
+    public Boolean accept(String clusterType) {
+        return getClusterType().equals(clusterType);
+    }
+
+    @Override
+    public String getClusterType() {
+        return ClusterType.CLS_TUBE;
+    }
+
+    @Override
+    protected void setTargetEntity(InlongClusterRequest request, InlongClusterEntity targetEntity) {
+        LOGGER.info("do nothing for tube cluster in set target entity");
+    }
+
+    @Override
+    public InlongClusterInfo getFromEntity(InlongClusterEntity entity) {
+        if (entity == null) {
+            throw new BusinessException(ErrorCodeEnum.CLUSTER_NOT_FOUND);
+        }
+        return CommonBeanUtils.copyProperties(entity, TubeClusterInfo::new);
+    }
+
+}

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/ConsumptionServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/ConsumptionServiceTest.java
@@ -22,6 +22,7 @@ import org.apache.inlong.manager.common.pojo.consumption.ConsumptionInfo;
 import org.apache.inlong.manager.common.pojo.consumption.ConsumptionPulsarInfo;
 import org.apache.inlong.manager.service.ServiceBaseTest;
 import org.apache.inlong.manager.service.core.ConsumptionService;
+import org.apache.inlong.manager.service.group.InlongGroupServiceTest;
 import org.junit.Assert;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/InlongClusterServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/InlongClusterServiceTest.java
@@ -18,15 +18,18 @@
 package org.apache.inlong.manager.service.core.impl;
 
 import com.github.pagehelper.PageInfo;
+import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeRequest;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeResponse;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
 import org.apache.inlong.manager.common.pojo.cluster.InlongClusterPageRequest;
 import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
-import org.apache.inlong.manager.common.pojo.cluster.InlongClusterResponse;
+import org.apache.inlong.manager.common.pojo.cluster.dataproxy.DataProxyClusterRequest;
+import org.apache.inlong.manager.common.pojo.cluster.pulsar.PulsarClusterRequest;
 import org.apache.inlong.manager.common.pojo.dataproxy.DataProxyNodeInfo;
 import org.apache.inlong.manager.common.settings.InlongGroupSettings;
 import org.apache.inlong.manager.service.ServiceBaseTest;
-import org.apache.inlong.manager.service.core.InlongClusterService;
+import org.apache.inlong.manager.service.cluster.InlongClusterService;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -101,13 +104,26 @@ public class InlongClusterServiceTest extends ServiceBaseTest {
     }
 
     /**
-     * save cluster info.
+     * Save Pulsar cluster
      */
-    public Integer saveCluster(String clusterTag, String clusterName, String type, String extTag) {
-        InlongClusterRequest request = new InlongClusterRequest();
+    public Integer savePulsarCluster(String clusterTag, String clusterName, String extTag) {
+        PulsarClusterRequest request = new PulsarClusterRequest();
         request.setClusterTag(clusterTag);
         request.setName(clusterName);
-        request.setType(type);
+        request.setType(ClusterType.CLS_PULSAR);
+        request.setExtTag(extTag);
+        request.setInCharges(GLOBAL_OPERATOR);
+        return clusterService.save(request, GLOBAL_OPERATOR);
+    }
+
+    /**
+     * Save data proxy cluster
+     */
+    public Integer saveDataProxyCluster(String clusterTag, String clusterName, String extTag) {
+        DataProxyClusterRequest request = new DataProxyClusterRequest();
+        request.setClusterTag(clusterTag);
+        request.setName(clusterName);
+        request.setType(ClusterType.CLS_DATA_PROXY);
         request.setExtTag(extTag);
         request.setInCharges(GLOBAL_OPERATOR);
         return clusterService.save(request, GLOBAL_OPERATOR);
@@ -116,7 +132,7 @@ public class InlongClusterServiceTest extends ServiceBaseTest {
     /**
      * get cluster list info.
      */
-    public PageInfo<InlongClusterResponse> listCluster(String type, String clusterTag) {
+    public PageInfo<InlongClusterInfo> listCluster(String type, String clusterTag) {
         InlongClusterPageRequest request = new InlongClusterPageRequest();
         request.setType(type);
         request.setClusterTag(clusterTag);
@@ -191,7 +207,6 @@ public class InlongClusterServiceTest extends ServiceBaseTest {
      */
     @Test
     public void testClusterSaveAndDelete() {
-        String type = "PULSAR";
         String clusterTag = "default_cluster";
         String extTag = "ext_1";
         String ip = "127.0.0.1";
@@ -205,11 +220,11 @@ public class InlongClusterServiceTest extends ServiceBaseTest {
         Integer portUpdate = 8083;
 
         // save cluster
-        Integer id = this.saveCluster(clusterTag, CLUSTER_NAME, type, extTag);
+        Integer id = this.savePulsarCluster(clusterTag, CLUSTER_NAME, extTag);
         Assert.assertNotNull(id);
 
         // list cluster
-        PageInfo<InlongClusterResponse> listCluster = this.listCluster(type, clusterTag);
+        PageInfo<InlongClusterInfo> listCluster = this.listCluster(ClusterType.CLS_PULSAR, clusterTag);
         Assert.assertEquals(listCluster.getTotal(), 1);
 
         // update cluster
@@ -218,11 +233,11 @@ public class InlongClusterServiceTest extends ServiceBaseTest {
 
         // save cluster node
         Integer parentId = id;
-        Integer nodeId = this.saveClusterNode(parentId, type, ip, port);
+        Integer nodeId = this.saveClusterNode(parentId, ClusterType.CLS_PULSAR, ip, port);
         Assert.assertNotNull(nodeId);
 
         // list cluster node
-        PageInfo<ClusterNodeResponse> listNode = this.listNode(type, ip);
+        PageInfo<ClusterNodeResponse> listNode = this.listNode(ClusterType.CLS_PULSAR, ip);
         Assert.assertEquals(listNode.getTotal(), 1);
 
         // update cluster node
@@ -245,7 +260,7 @@ public class InlongClusterServiceTest extends ServiceBaseTest {
         Integer port1 = 46800;
         Integer port2 = 46801;
 
-        Integer id = this.saveCluster(CLUSTER_TAG, CLUSTER_NAME, InlongGroupSettings.CLUSTER_DATA_PROXY, extTag);
+        Integer id = this.saveDataProxyCluster(CLUSTER_TAG, CLUSTER_NAME, extTag);
         Assert.assertNotNull(id);
 
         // save cluster node

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/InlongStreamServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/InlongStreamServiceTest.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.service.core.impl;
 import org.apache.inlong.manager.common.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.common.pojo.stream.InlongStreamRequest;
 import org.apache.inlong.manager.service.core.InlongStreamService;
+import org.apache.inlong.manager.service.group.InlongGroupServiceTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/group/InlongGroupServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/group/InlongGroupServiceTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.service.core.impl;
+package org.apache.inlong.manager.service.group;
 
 import org.apache.inlong.manager.common.enums.GroupStatus;
 import org.apache.inlong.manager.common.enums.MQType;
@@ -24,7 +24,6 @@ import org.apache.inlong.manager.common.pojo.group.InlongGroupInfo;
 import org.apache.inlong.manager.common.pojo.group.pulsar.InlongPulsarInfo;
 import org.apache.inlong.manager.dao.entity.InlongGroupExtEntity;
 import org.apache.inlong.manager.dao.mapper.InlongGroupExtEntityMapper;
-import org.apache.inlong.manager.service.group.InlongGroupService;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -36,7 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Inlong group service test
+ * Test for {@link InlongGroupService}
  */
 @TestComponent
 public class InlongGroupServiceTest {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -27,10 +27,10 @@ import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeRequest;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeResponse;
 import org.apache.inlong.manager.common.pojo.cluster.InlongClusterPageRequest;
 import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
-import org.apache.inlong.manager.common.pojo.cluster.InlongClusterResponse;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
 import org.apache.inlong.manager.common.pojo.user.UserRoleCode;
 import org.apache.inlong.manager.common.util.LoginUserUtils;
-import org.apache.inlong.manager.service.core.InlongClusterService;
+import org.apache.inlong.manager.service.cluster.InlongClusterService;
 import org.apache.inlong.manager.service.core.operationlog.OperationLog;
 import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,13 +66,13 @@ public class InlongClusterController {
     @GetMapping(value = "/get/{id}")
     @ApiOperation(value = "Get cluster by id")
     @ApiImplicitParam(name = "id", value = "Cluster ID", dataTypeClass = Integer.class, required = true)
-    public Response<InlongClusterResponse> get(@PathVariable Integer id) {
+    public Response<InlongClusterInfo> get(@PathVariable Integer id) {
         return Response.success(clusterService.get(id));
     }
 
     @PostMapping(value = "/list")
     @ApiOperation(value = "List clusters")
-    public Response<PageInfo<InlongClusterResponse>> list(@RequestBody InlongClusterPageRequest request) {
+    public Response<PageInfo<InlongClusterInfo>> list(@RequestBody InlongClusterPageRequest request) {
         return Response.success(clusterService.list(request));
     }
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/AgentController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/AgentController.java
@@ -24,7 +24,7 @@ import org.apache.inlong.common.pojo.agent.TaskResult;
 import org.apache.inlong.common.pojo.agent.TaskSnapshotRequest;
 import org.apache.inlong.manager.common.beans.Response;
 import org.apache.inlong.manager.service.core.AgentService;
-import org.apache.inlong.manager.service.core.InlongClusterService;
+import org.apache.inlong.manager.service.cluster.InlongClusterService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/DataProxyController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/DataProxyController.java
@@ -25,7 +25,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyConfig;
 import org.apache.inlong.manager.common.beans.Response;
 import org.apache.inlong.manager.common.pojo.dataproxy.DataProxyNodeInfo;
-import org.apache.inlong.manager.service.core.InlongClusterService;
+import org.apache.inlong.manager.service.cluster.InlongClusterService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenClusterController.java
@@ -25,8 +25,8 @@ import org.apache.inlong.manager.common.beans.Response;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.pojo.cluster.InlongClusterPageRequest;
 import org.apache.inlong.manager.common.pojo.cluster.InlongClusterRequest;
-import org.apache.inlong.manager.common.pojo.cluster.InlongClusterResponse;
-import org.apache.inlong.manager.service.core.InlongClusterService;
+import org.apache.inlong.manager.common.pojo.cluster.InlongClusterInfo;
+import org.apache.inlong.manager.service.cluster.InlongClusterService;
 import org.apache.inlong.manager.service.core.operationlog.OperationLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -58,13 +58,13 @@ public class OpenClusterController {
     @GetMapping(value = "/get/{id}")
     @ApiOperation(value = "Get cluster by id")
     @ApiImplicitParam(name = "id", value = "common cluster ID", dataTypeClass = Integer.class, required = true)
-    public Response<InlongClusterResponse> get(@PathVariable Integer id) {
+    public Response<InlongClusterInfo> get(@PathVariable Integer id) {
         return Response.success(clusterService.get(id));
     }
 
     @PostMapping(value = "/list")
     @ApiOperation(value = "Get clusters by paginating")
-    public Response<PageInfo<InlongClusterResponse>> list(@RequestBody InlongClusterPageRequest request) {
+    public Response<PageInfo<InlongClusterInfo>> list(@RequestBody InlongClusterPageRequest request) {
         return Response.success(clusterService.list(request));
     }
 


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #4541 

### Motivation

Support save extension params for inlong cluster.

### Modifications

Support saves, gets, and updates the extension params for inlong clusters through the factory design pattern.

For example, pulsar admin URL and tenant are extension params, they are not in the inlong_cluster table, this PR supports saving them into the ext_params.

### Verifying this change

- [X] This change is already covered by existing tests, such as:

  `org.apache.inlong.manager.service.cluster.InlongClusterServiceTest`

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
