### PR TITLE
[INLONG-4591][Sort] Set the default hive version and alter the log version from log4j to log4j2 in the sort core module

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/HiveLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/HiveLoadNode.java
@@ -99,7 +99,7 @@ public class HiveLoadNode extends LoadNode implements Serializable {
         this.database = Preconditions.checkNotNull(database, "database of hive is null");
         this.tableName = Preconditions.checkNotNull(tableName, "table of hive is null");
         this.hiveConfDir = hiveConfDir;
-        this.hiveVersion = hiveVersion;
+        this.hiveVersion = null == hiveVersion ? "3.1.2" : hiveVersion;
         this.catalogName = catalogName;
         this.hadoopConfDir = hadoopConfDir;
         this.partitionFields = partitionFields;

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/HiveLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/HiveLoadNode.java
@@ -52,6 +52,7 @@ public class HiveLoadNode extends LoadNode implements Serializable {
     private static final String timestampPattern = "partition.time-extractor.timestamp-pattern";
     private static final String delay = "sink.partition-commit.delay";
     private static final String policyKind = "sink.partition-commit.policy.kind";
+    private static final String HIVE_VERSION = "3.1.2";
 
     @JsonProperty("tableName")
     @Nonnull
@@ -99,7 +100,7 @@ public class HiveLoadNode extends LoadNode implements Serializable {
         this.database = Preconditions.checkNotNull(database, "database of hive is null");
         this.tableName = Preconditions.checkNotNull(tableName, "table of hive is null");
         this.hiveConfDir = hiveConfDir;
-        this.hiveVersion = null == hiveVersion ? "3.1.2" : hiveVersion;
+        this.hiveVersion = null == hiveVersion ? HIVE_VERSION : hiveVersion;
         this.catalogName = catalogName;
         this.hadoopConfDir = hadoopConfDir;
         this.partitionFields = partitionFields;

--- a/inlong-sort/sort-core/src/main/resources/log4j2.properties
+++ b/inlong-sort/sort-core/src/main/resources/log4j2.properties
@@ -16,13 +16,18 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-log4j.rootLogger=INFO, logger
-# logger is set to be a ConsoleAppender.
-log4j.appender.logger=org.apache.log4j.ConsoleAppender
-log4j.appender.logger.target=System.err
-log4j.appender.logger.layout=org.apache.log4j.PatternLayout
-log4j.appender.logger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+rootLogger=INFO, logger
+
+appender.out.type=Console
+appender.out.name=logger
+appender.out.layout.type=PatternLayout
+appender.out.layout.pattern=%-4r [%t] %-5p %c %x - %m%n
+
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
-log4j.logger.org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, logger
+logger.flinknetty=ERROR, logger
+logger.flinknetty.name=org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+logger.flinknetty.additivity=false
 # Resource leak detector only works with logging enabled at error level
-log4j.logger.org.apache.flink.shaded.netty4.io.netty.util.ResourceLeakDetector=ERROR, logger
+logger.leakdetector=ERROR, logger
+logger.leakdetector.name=org.apache.flink.shaded.netty4.io.netty.util.ResourceLeakDetector
+logger.leakdetector.additivity=false


### PR DESCRIPTION
An error occurs when the user omits an incoming version, data sink hive.
Alter log version module of sort core.


- Fixes #4591 

### Motivation

Test error.

### Modifications

Set default version 3.1.2.
Change log version  from log4j to log4j2.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
