### PR TITLE
[INLONG-4594][Audit] Make Elasticsearch authentication configurable

### DIFF
--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/config/ElasticsearchConfig.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/config/ElasticsearchConfig.java
@@ -92,9 +92,9 @@ public class ElasticsearchConfig {
         // support es cluster with multi hosts
         List<HttpHost> hosts = new ArrayList<>();
         String[] hostArrays = host.split(",");
-        for (String h : hostArrays) {
-            if (StringUtils.isNotEmpty(h)) {
-                hosts.add(new HttpHost(h.trim(), port, "http"));
+        for (String host : hostArrays) {
+            if (StringUtils.isNotEmpty(host)) {
+                hosts.add(new HttpHost(host.trim(), port, "http"));
             }
         }
 

--- a/inlong-audit/conf/application.properties
+++ b/inlong-audit/conf/application.properties
@@ -66,6 +66,7 @@ audit.tube.consumer.group.name=inlong-audit-consumer
 # es config
 elasticsearch.host=127.0.0.1
 elasticsearch.port=9200
+elasticsearch.authEnable=false
 elasticsearch.username=elastic
 elasticsearch.password=inlong
 elasticsearch.shardsNum=5


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-4594][Audit] Make Elasticsearch authentication configurable

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/incubator-inlong/issues) number)*

- Fixes #4594 

### Modifications

- make Elasticsearch authentication configurable
- support es cluster with multi hosts


### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
