### PR TITLE
[INLONG-4613][Release] Change the tag of Docker images to 1.2.0-incubating

### DIFF
--- a/conf/inlong.conf
+++ b/conf/inlong.conf
@@ -35,7 +35,7 @@ tube_manager_url=127.0.0.1:8080
 
 ############## Dashboard Configuration ##############
 # dashboard docker image
-dashboard_docker_image=inlong/dashboard:latest
+dashboard_docker_image=inlong/dashboard:1.2.0-incubating
 # dashboard service port
 dashboard_mapping_port=80
 

--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     command: bin/pulsar standalone
 
   manager:
-    image: inlong/manager
+    image: inlong/manager:1.2.0-incubating
     container_name: manager
     depends_on:
       mysql:
@@ -57,7 +57,7 @@ services:
       - ZK_URL=tubemq-server:2181
 
   webisite:
-    image: inlong/dashboard
+    image: inlong/dashboard:1.2.0-incubating
     container_name: dashboard
     depends_on:
       - manager
@@ -67,7 +67,7 @@ services:
       - MANAGER_API_ADDRESS=manager:8083
 
   dataproxy:
-    image: inlong/dataproxy:latest
+    image: inlong/dataproxy:1.2.0-incubating
     container_name: dataproxy
     depends_on:
       - manager
@@ -79,7 +79,7 @@ services:
       - AUDIT_PROXY_URL=audit:10081
 
   agent:
-    image: inlong/agent:latest
+    image: inlong/agent:1.2.0-incubating
     container_name: agent
     depends_on:
       - manager
@@ -96,7 +96,7 @@ services:
       - ./collect-data:/data/collect-data
 
   audit:
-    image: inlong/audit:latest
+    image: inlong/audit:1.2.0-incubating
     container_name: audit
     depends_on:
       mysql:

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -52,15 +52,15 @@ set -x
 set -e
 
 # tag all images
-docker tag inlong/manager:latest     ${docker_registry_org}/manager:latest
-docker tag inlong/agent:latest           ${docker_registry_org}/agent:latest
-docker tag inlong/dataproxy:latest       ${docker_registry_org}/dataproxy:latest
-docker tag inlong/tubemq-manager:latest  ${docker_registry_org}/tubemq-manager:latest
-docker tag inlong/tubemq-all:latest      ${docker_registry_org}/tubemq-all:latest
-docker tag inlong/tubemq-build:latest    ${docker_registry_org}/tubemq-build:latest
-docker tag inlong/dashboard:latest         ${docker_registry_org}/dashboard:latest
-docker tag inlong/tubemq-cpp:latest      ${docker_registry_org}/tubemq-cpp:latest
-docker tag inlong/audit:latest      ${docker_registry_org}/audit:latest
+docker tag inlong/manager:1.2.0-incubating     ${docker_registry_org}/manager:1.2.0-incubating
+docker tag inlong/agent:1.2.0-incubating           ${docker_registry_org}/agent:1.2.0-incubating
+docker tag inlong/dataproxy:1.2.0-incubating       ${docker_registry_org}/dataproxy:1.2.0-incubating
+docker tag inlong/tubemq-manager:1.2.0-incubating  ${docker_registry_org}/tubemq-manager:1.2.0-incubating
+docker tag inlong/tubemq-all:1.2.0-incubating      ${docker_registry_org}/tubemq-all:1.2.0-incubating
+docker tag inlong/tubemq-build:1.2.0-incubating    ${docker_registry_org}/tubemq-build:1.2.0-incubating
+docker tag inlong/dashboard:1.2.0-incubating         ${docker_registry_org}/dashboard:1.2.0-incubating
+docker tag inlong/tubemq-cpp:1.2.0-incubating      ${docker_registry_org}/tubemq-cpp:1.2.0-incubating
+docker tag inlong/audit:1.2.0-incubating      ${docker_registry_org}/audit:1.2.0-incubating
 
 docker tag inlong/manager:$MVN_VERSION     ${docker_registry_org}/manager:$MVN_VERSION
 docker tag inlong/agent:$MVN_VERSION           ${docker_registry_org}/agent:$MVN_VERSION
@@ -73,15 +73,15 @@ docker tag inlong/tubemq-cpp:$MVN_VERSION      ${docker_registry_org}/tubemq-cpp
 docker tag inlong/audit:$MVN_VERSION      ${docker_registry_org}/audit:$MVN_VERSION
 
 # Push all images and tags
-docker push inlong/manager:latest
-docker push inlong/agent:latest
-docker push inlong/dataproxy:latest
-docker push inlong/tubemq-manager:latest
-docker push inlong/tubemq-all:latest
-docker push inlong/tubemq-build:latest
-docker push inlong/dashboard:latest
-docker push inlong/tubemq-cpp:latest
-docker push inlong/audit:latest
+docker push inlong/manager:1.2.0-incubating
+docker push inlong/agent:1.2.0-incubating
+docker push inlong/dataproxy:1.2.0-incubating
+docker push inlong/tubemq-manager:1.2.0-incubating
+docker push inlong/tubemq-all:1.2.0-incubating
+docker push inlong/tubemq-build:1.2.0-incubating
+docker push inlong/dashboard:1.2.0-incubating
+docker push inlong/tubemq-cpp:1.2.0-incubating
+docker push inlong/audit:1.2.0-incubating
 
 docker push inlong/manager:$MVN_VERSION
 docker push inlong/agent:$MVN_VERSION

--- a/inlong-agent/agent-docker/README.md
+++ b/inlong-agent/agent-docker/README.md
@@ -3,7 +3,7 @@ InLong Agent is available for development and experience.
 
 ##### Pull Image
 ```
-docker pull inlong/agent:latest
+docker pull inlong/agent:1.2.0-incubating
 ```
 
 ##### Start Container

--- a/inlong-audit/audit-docker/README.md
+++ b/inlong-audit/audit-docker/README.md
@@ -3,7 +3,7 @@ InLong Audit is available for development and experience.
 
 ##### Pull Image
 ```
-docker pull inlong/audit:latest
+docker pull inlong/audit:1.2.0-incubating
 ```
 
 ##### Start Container

--- a/inlong-dataproxy/dataproxy-docker/README.md
+++ b/inlong-dataproxy/dataproxy-docker/README.md
@@ -3,7 +3,7 @@ InLong DataProxy is available for development and experience.
 
 ##### Pull Image
 ```
-docker pull inlong/dataproxy:latest
+docker pull inlong/dataproxy:1.2.0-incubating
 ```
 
 ##### Start Container

--- a/inlong-manager/manager-docker/README.md
+++ b/inlong-manager/manager-docker/README.md
@@ -5,7 +5,7 @@ InLong Manager is available for development and experience.
 ### Pull Image
 
 ```
-docker pull inlong/manager:latest
+docker pull inlong/manager:1.2.0-incubating
 ```
 
 ### Start Container
@@ -16,5 +16,5 @@ docker run -d --name manager -p 8083:8083 \
 -e JDBC_URL=127.0.0.1:3306 \
 -e USERNAME=root \
 -e PASSWORD=inlong \
-inlong/manager:latest
+inlong/manager:1.2.0-incubating
 ```

--- a/inlong-tubemq/tubemq-docker/tubemq-all/README.md
+++ b/inlong-tubemq/tubemq-docker/tubemq-all/README.md
@@ -3,12 +3,12 @@ TubeMQ standalone is available for development and experience.
 
 ##### Pull Image
 ```
-docker pull inlong/tubemq-all:latest
+docker pull inlong/tubemq-all:1.2.0-incubating
 ```
 
 ##### Start Standalone Container
 ```
-docker run -p 8080:8080 -p 8715:8715 -p 8123:8123 -p 2181:2181 --name tubemq -d inlong/tubemq-all:latest
+docker run -p 8080:8080 -p 8715:8715 -p 8123:8123 -p 2181:2181 --name tubemq -d inlong/tubemq-all:1.2.0-incubating
 ```
 this command will start zookeeper/master/broker service in one container.
 #### Add Topic

--- a/inlong-tubemq/tubemq-docker/tubemq-manager/README.md
+++ b/inlong-tubemq/tubemq-docker/tubemq-manager/README.md
@@ -3,7 +3,7 @@ TubeMQ manager is available for development and experience.
 
 ##### Pull Image
 ```
-docker pull inlong/tubemq-manager:latest
+docker pull inlong/tubemq-manager:1.2.0-incubating
 ```
 
 ##### Start Container


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #4613

### Motivation

Change the tag of Docker images to 1.2.0-incubating.

### Modifications

Change the tag of Docker images to 1.2.0-incubating.

### Verifying this change

- [X] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)
