### PR TITLE
[INLONG-4624][Sort] Package pulsar and hive connectors to same file

### DIFF
--- a/inlong-distribution/src/main/assemblies/release.xml
+++ b/inlong-distribution/src/main/assemblies/release.xml
@@ -73,7 +73,7 @@
         <!--basic connector-->
         <fileSet>
             <directory>../inlong-sort/sort-connectors/pulsar/target</directory>
-            <outputDirectory>sort-plugin/connectors</outputDirectory>
+            <outputDirectory>sort-plugin</outputDirectory>
             <includes>
                 <include>sort-connector-pulsar-${project.version}.jar</include>
             </includes>
@@ -81,7 +81,7 @@
         </fileSet>
         <fileSet>
             <directory>../inlong-sort/sort-connectors/hive/target</directory>
-            <outputDirectory>sort-plugin/connectors</outputDirectory>
+            <outputDirectory>sort-plugin</outputDirectory>
             <includes>
                 <include>sort-connector-hive-${project.version}.jar</include>
             </includes>


### PR DESCRIPTION
Improve the packaging operation.


- Fixes #4624 

### Motivation

![企业微信截图_16548578847330](https://user-images.githubusercontent.com/17596132/173059453-52587f88-ad12-4a6e-919b-438e1d953d1c.png)


### Modifications

![image](https://user-images.githubusercontent.com/17596132/173059523-72bcdb07-7aa5-4d0c-94c9-a8ebe7282a6a.png)


### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
