### PR TITLE
[INLONG-4650][Sort] Sort lightweight iceberg hive classpath notfound

### DIFF
--- a/inlong-sort/sort-connectors/iceberg/pom.xml
+++ b/inlong-sort/sort-connectors/iceberg/pom.xml
@@ -35,10 +35,31 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-flink-1.13</artifactId>
+            <artifactId>iceberg-flink-runtime-1.13</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.calcite.avatica</groupId>
+                    <artifactId>avatica</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
-
 
     <build>
         <plugins>
@@ -53,48 +74,12 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <relocations>
-                                <relocation>
-                                    <pattern>org.apache.avro</pattern>
-                                    <shadedPattern>org.apache.iceberg.shaded.org.apache.avro</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.parquet</pattern>
-                                    <shadedPattern>org.apache.iceberg.shaded.org.apache.parquet</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>org.apache.iceberg.shaded.com.google</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.fasterxml</pattern>
-                                    <shadedPattern>org.apache.iceberg.shaded.com.fasterxml</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.github.benmanes</pattern>
-                                    <shadedPattern>org.apache.iceberg.shaded.com.github.benmanes</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.checkerframework</pattern>
-                                    <shadedPattern>org.apache.iceberg.shaded.org.checkerframework</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>shaded.parquet</pattern>
-                                    <shadedPattern>org.apache.iceberg.shaded.org.apache.parquet.shaded</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.orc</pattern>
-                                    <shadedPattern>org.apache.iceberg.shaded.org.apache.orc</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>io.airlift</pattern>
-                                    <shadedPattern>org.apache.iceberg.shaded.io.airlift</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.threeten.extra</pattern>
-                                    <shadedPattern>org.apache.iceberg.shaded.org.threeten.extra</shadedPattern>
-                                </relocation>
-                            </relocations>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.iceberg:*</include>
+                                    <include>org.apache.hive:hive-exec</include>
+                                </includes>
+                            </artifactSet>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1011,6 +1011,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.apache.iceberg</groupId>
+                <artifactId>iceberg-flink-runtime-1.13</artifactId>
+                <version>${iceberg.flink.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.flink</groupId>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

Sort lightweight iceberg hive classpath notfound

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/incubator-inlong/issues) number)*

- Fixes #4650 

### Motivation

fix bug: Sort lightweight iceberg hive classpath notfound
