### PR TITLE
[INLONG-4653][CI] Add concurrency support on GitHub Actions

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -56,6 +56,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -53,7 +53,7 @@ on:
       - '!**.md'
 
 concurrency:
-  group: ${{ github.workflow || build }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -56,7 +56,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
-
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -52,6 +52,10 @@ on:
       - 'inlong-tubemq/**'
       - '!**.md'
 
+concurrency:
+  group: ${{ github.workflow || build }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci_chart_test.yml
+++ b/.github/workflows/ci_chart_test.yml
@@ -40,7 +40,6 @@ env:
   CT_CONFIG_PATH: '.github/ct.yml'
   KIND_CONFIG_PATH: '.github/kind.yml'
 
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/ci_chart_test.yml
+++ b/.github/workflows/ci_chart_test.yml
@@ -40,6 +40,10 @@ env:
   CT_CONFIG_PATH: '.github/ct.yml'
   KIND_CONFIG_PATH: '.github/kind.yml'
 
+concurrency:
+  group: ${{ github.workflow || chart-test }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   chart-test:
     name: Lint and test charts

--- a/.github/workflows/ci_chart_test.yml
+++ b/.github/workflows/ci_chart_test.yml
@@ -40,6 +40,7 @@ env:
   CT_CONFIG_PATH: '.github/ct.yml'
   KIND_CONFIG_PATH: '.github/kind.yml'
 
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/ci_chart_test.yml
+++ b/.github/workflows/ci_chart_test.yml
@@ -41,7 +41,7 @@ env:
   KIND_CONFIG_PATH: '.github/kind.yml'
 
 concurrency:
-  group: ${{ github.workflow || chart-test }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci_check_license.yml
+++ b/.github/workflows/ci_check_license.yml
@@ -20,7 +20,7 @@ name: InLong Check License Header
 on: [ push, pull_request ]
 
 concurrency:
-  group: ${{ github.workflow || check-license-header }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci_check_license.yml
+++ b/.github/workflows/ci_check_license.yml
@@ -19,6 +19,10 @@ name: InLong Check License Header
 
 on: [ push, pull_request ]
 
+concurrency:
+  group: ${{ github.workflow || check-license-header }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-license:
     name: Check license header

--- a/.github/workflows/ci_check_license.yml
+++ b/.github/workflows/ci_check_license.yml
@@ -23,6 +23,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
+
 jobs:
   check-license:
     name: Check license header

--- a/.github/workflows/ci_check_license.yml
+++ b/.github/workflows/ci_check_license.yml
@@ -23,7 +23,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
-
 jobs:
   check-license:
     name: Check license header

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -41,7 +41,7 @@ on:
       - '!**.md'
 
 concurrency:
-  group: ${{ github.workflow || docker }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -44,6 +44,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
+
 jobs:
   docker:
     name: Docker build and push

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -40,6 +40,10 @@ on:
       - 'inlong-tubemq/tubemq-docker/**'
       - '!**.md'
 
+concurrency:
+  group: ${{ github.workflow || docker }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     name: Docker build and push

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -77,6 +77,13 @@ jobs:
         env:
           CI: false
 
+      # Check if only the workflow file is changed.
+      - name: Check workflow diff
+        id: check-workflow-diff
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: .github/workflows/ci_docker.yml
+
       # If the changes are being pushed to the master branch or a branch like 'release-1.0.0', this step will output true.
       - name: Match branch
         id: match-branch
@@ -90,7 +97,10 @@ jobs:
           fi
 
       - name: Push Docker images to Docker Hub
-        if: ${{ success() && steps.match-branch.outputs.match == 'true' }}
+        if: |
+          success()
+          && steps.check-workflow-diff.outputs.changed_only == 'no'
+          && steps.match-branch.outputs.match == 'true'
         working-directory: docker
         run: bash +x publish.sh
         env:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -44,7 +44,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
-
 jobs:
   docker:
     name: Docker build and push

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -56,7 +56,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
-
 jobs:
   unit-test:
     name: Unit Test

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -53,7 +53,7 @@ on:
       - '!**.md'
 
 concurrency:
-  group: ${{ github.workflow || ut }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -52,6 +52,10 @@ on:
       - 'inlong-tubemq/**'
       - '!**.md'
 
+concurrency:
+  group: ${{ github.workflow || ut }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   unit-test:
     name: Unit Test

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -56,6 +56,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
+
 jobs:
   unit-test:
     name: Unit Test


### PR DESCRIPTION
Fixes #4653

### Motivation

Add concurrency support on GitHub Actions

### Modifications

Add concurrency support on GitHub Actions.
See https://docs.github.com/en/actions/using-jobs/using-concurrency for more information.
