### PR TITLE
[INLONG-4665][Sort] The primary key must be _id in mongoDB CDC Connector

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/ExtractNodeUtils.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/ExtractNodeUtils.java
@@ -385,7 +385,6 @@ public class ExtractNodeUtils {
                 fieldInfos,
                 null,
                 properties,
-                source.getPrimaryKey(),
                 source.getCollection(),
                 source.getHosts(),
                 source.getUsername(),

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
@@ -31,6 +31,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInc
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.inlong.sort.formats.common.StringFormatInfo;
 import org.apache.inlong.sort.protocol.FieldInfo;
 import org.apache.inlong.sort.protocol.node.ExtractNode;
 import org.apache.inlong.sort.protocol.transformation.WatermarkField;
@@ -71,6 +72,8 @@ public class MongoExtractNode extends ExtractNode implements Serializable {
             @JsonProperty("password") String password,
             @JsonProperty("database") String database) {
         super(id, name, fields, waterMarkField, properties);
+        fields.add(new FieldInfo("_id", new StringFormatInfo()));
+        this.setFields(fields);
         this.collection = Preconditions.checkNotNull(collection, "collection is null");
         this.hosts = Preconditions.checkNotNull(hostname, "hostname is null");
         this.username = Preconditions.checkNotNull(username, "username is null");

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
@@ -80,9 +80,9 @@ public class MongoExtractNode extends ExtractNode implements Serializable {
             @JsonProperty("password") String password,
             @JsonProperty("database") String database) {
         super(id, name, fields, waterMarkField, properties);
-        if (fields.stream().noneMatch(m -> m.getName().equals("_id"))) {
+        if (fields.stream().noneMatch(m -> m.getName().equals(ID))) {
             List<FieldInfo> allFields = new ArrayList<>(fields);
-            allFields.add(new FieldInfo("_id", new StringFormatInfo()));
+            allFields.add(new FieldInfo(ID, new StringFormatInfo()));
             this.setFields(allFields);
         }
         this.collection = Preconditions.checkNotNull(collection, "collection is null");

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
@@ -74,9 +74,11 @@ public class MongoExtractNode extends ExtractNode implements Serializable {
             @JsonProperty("password") String password,
             @JsonProperty("database") String database) {
         super(id, name, fields, waterMarkField, properties);
-        List<FieldInfo> allFields = new ArrayList<>(fields);
-        allFields.add(new FieldInfo("_id", new StringFormatInfo()));
-        this.setFields(allFields);
+        if (fields.stream().noneMatch(m -> m.getName().equals("_id"))) {
+            List<FieldInfo> allFields = new ArrayList<>(fields);
+            allFields.add(new FieldInfo("_id", new StringFormatInfo()));
+            this.setFields(allFields);
+        }
         this.collection = Preconditions.checkNotNull(collection, "collection is null");
         this.hosts = Preconditions.checkNotNull(hostname, "hostname is null");
         this.username = Preconditions.checkNotNull(username, "username is null");

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
@@ -47,6 +47,13 @@ public class MongoExtractNode extends ExtractNode implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * the primary key must be "_id"
+     *
+     * @see <a href="https://ververica.github.io/flink-cdc-connectors/release-2.1/content/connectors/mongodb-cdc.html#">MongoDB CDC Connector</a>
+     */
+    private static final String ID = "_id";
+
     @JsonInclude(Include.NON_NULL)
     @JsonProperty("primaryKey")
     private String primaryKey;
@@ -83,8 +90,7 @@ public class MongoExtractNode extends ExtractNode implements Serializable {
         this.username = Preconditions.checkNotNull(username, "username is null");
         this.password = Preconditions.checkNotNull(password, "password is null");
         this.database = Preconditions.checkNotNull(database, "database is null");
-        // the primaryKey must be "_id"
-        this.primaryKey = "_id";
+        this.primaryKey = ID;
     }
 
     @Override

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
@@ -20,6 +20,8 @@ package org.apache.inlong.sort.protocol.node.extract;
 
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -72,8 +74,9 @@ public class MongoExtractNode extends ExtractNode implements Serializable {
             @JsonProperty("password") String password,
             @JsonProperty("database") String database) {
         super(id, name, fields, waterMarkField, properties);
-        fields.add(new FieldInfo("_id", new StringFormatInfo()));
-        this.setFields(fields);
+        List<FieldInfo> allFields = new ArrayList<>(fields);
+        allFields.add(new FieldInfo("_id", new StringFormatInfo()));
+        this.setFields(allFields);
         this.collection = Preconditions.checkNotNull(collection, "collection is null");
         this.hosts = Preconditions.checkNotNull(hostname, "hostname is null");
         this.username = Preconditions.checkNotNull(username, "username is null");

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
@@ -61,23 +61,23 @@ public class MongoExtractNode extends ExtractNode implements Serializable {
 
     @JsonCreator
     public MongoExtractNode(@JsonProperty("id") String id,
-        @JsonProperty("name") String name,
-        @JsonProperty("fields") List<FieldInfo> fields,
-        @Nullable @JsonProperty("watermarkField") WatermarkField waterMarkField,
-        @JsonProperty("properties") Map<String, String> properties,
-        @JsonProperty("primaryKey") String primaryKey,
-        @JsonProperty("collection") @Nonnull String collection,
-        @JsonProperty("hostname") String hostname,
-        @JsonProperty("username") String username,
-        @JsonProperty("password") String password,
-        @JsonProperty("database") String database) {
+            @JsonProperty("name") String name,
+            @JsonProperty("fields") List<FieldInfo> fields,
+            @Nullable @JsonProperty("watermarkField") WatermarkField waterMarkField,
+            @JsonProperty("properties") Map<String, String> properties,
+            @JsonProperty("collection") @Nonnull String collection,
+            @JsonProperty("hostname") String hostname,
+            @JsonProperty("username") String username,
+            @JsonProperty("password") String password,
+            @JsonProperty("database") String database) {
         super(id, name, fields, waterMarkField, properties);
         this.collection = Preconditions.checkNotNull(collection, "collection is null");
         this.hosts = Preconditions.checkNotNull(hostname, "hostname is null");
         this.username = Preconditions.checkNotNull(username, "username is null");
         this.password = Preconditions.checkNotNull(password, "password is null");
         this.database = Preconditions.checkNotNull(database, "database is null");
-        this.primaryKey = primaryKey;
+        // the primaryKey must be "_id"
+        this.primaryKey = "_id";
     }
 
     @Override

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNode.java
@@ -21,7 +21,6 @@ package org.apache.inlong.sort.protocol.node.extract;
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/MongoExtractNodeTest.java
@@ -35,7 +35,7 @@ public class MongoExtractNodeTest extends SerializeBaseTest<MongoExtractNode>  {
             new FieldInfo("age", new IntFormatInfo()));
         return new MongoExtractNode(
             "1", "test", fields,  null, null,
-            "id", "test", "localhost", "inlong", "password", "test"
+                "test", "localhost", "inlong", "password", "test"
         );
     }
 

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MongoExtractFlinkSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MongoExtractFlinkSqlParseTest.java
@@ -52,9 +52,8 @@ public class MongoExtractFlinkSqlParseTest extends AbstractTestBase {
                 new FieldInfo("name", new StringFormatInfo()),
                 new FieldInfo("_id", new StringFormatInfo()));
         return new MongoExtractNode("1", "mysql_input", fields,
-                null, null, "_id",
-                "test", "localhost:27017", "root", "inlong",
-                "test");
+                null, null, "test", "localhost:27017",
+                "root", "inlong", "test");
     }
 
     private KafkaLoadNode buildAllMigrateKafkaNode() {

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MongoExtractFlinkSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MongoExtractFlinkSqlParseTest.java
@@ -48,9 +48,7 @@ import java.util.stream.Collectors;
 public class MongoExtractFlinkSqlParseTest extends AbstractTestBase {
 
     private MongoExtractNode buildMongoNode() {
-        List<FieldInfo> fields = Arrays.asList(
-                new FieldInfo("name", new StringFormatInfo()),
-                new FieldInfo("_id", new StringFormatInfo()));
+        List<FieldInfo> fields = Arrays.asList(new FieldInfo("name", new StringFormatInfo()));
         return new MongoExtractNode("1", "mysql_input", fields,
                 null, null, "test", "localhost:27017",
                 "root", "inlong", "test");


### PR DESCRIPTION
- Fixes #4665 

### Motivation

The primary key must be _id in MongoDB CDC Connector

### Modifications

modify the MongoExtractNode constructor

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)
