### PR TITLE
[INLONG-4674][Manager] Refactor the client by using the Retrofit framework

### DIFF
--- a/inlong-manager/manager-client/pom.xml
+++ b/inlong-manager/manager-client/pom.xml
@@ -51,8 +51,8 @@
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
@@ -219,7 +219,7 @@ public class InnerInlongManagerClient {
      * Create information of stream.
      */
     public Integer createStreamInfo(InlongStreamInfo streamInfo) {
-        Response<Integer> response = executeHttpCall(inlongStreamApi.createStreamInfo(streamInfo));
+        Response<Integer> response = executeHttpCall(inlongStreamApi.createStream(streamInfo));
         assertRespSuccess(response);
         return response.getData();
     }
@@ -236,7 +236,7 @@ public class InnerInlongManagerClient {
     }
 
     public Pair<Boolean, String> updateStreamInfo(InlongStreamInfo streamInfo) {
-        Response<Boolean> resp = executeHttpCall(inlongStreamApi.updateStreamInfo(streamInfo));
+        Response<Boolean> resp = executeHttpCall(inlongStreamApi.updateStream(streamInfo));
 
         if (resp.getData() != null) {
             return Pair.of(resp.getData(), resp.getErrMsg());
@@ -249,7 +249,7 @@ public class InnerInlongManagerClient {
      * Get inlong stream by the given groupId and streamId.
      */
     public InlongStreamInfo getStreamInfo(String groupId, String streamId) {
-        Response<InlongStreamInfo> response = executeHttpCall(inlongStreamApi.getStreamInfo(groupId, streamId));
+        Response<InlongStreamInfo> response = executeHttpCall(inlongStreamApi.getStream(groupId, streamId));
 
         if (response.isSuccess()) {
             return response.getData();
@@ -268,7 +268,7 @@ public class InnerInlongManagerClient {
         InlongStreamPageRequest pageRequest = new InlongStreamPageRequest();
         pageRequest.setInlongGroupId(inlongGroupId);
 
-        Response<PageInfo<FullStreamResponse>> response = executeHttpCall(inlongStreamApi.listStreamInfo(pageRequest));
+        Response<PageInfo<FullStreamResponse>> response = executeHttpCall(inlongStreamApi.listStream(pageRequest));
         assertRespSuccess(response);
         return response.getData().getList();
     }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
@@ -74,6 +74,9 @@ public class InnerInlongManagerClient {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    protected final String host;
+    protected final int port;
+
     private final InlongStreamApi inlongStreamApi;
     private final InlongGroupApi inlongGroupApi;
     private final StreamSourceApi streamSourceApi;
@@ -82,6 +85,9 @@ public class InnerInlongManagerClient {
     private final WorkflowApi workflowApi;
 
     public InnerInlongManagerClient(ClientConfiguration configuration) {
+        this.host = configuration.getBindHost();
+        this.port = configuration.getBindPort();
+
         Authentication authentication = configuration.getAuthentication();
         AssertUtils.notNull(authentication, "Inlong should be authenticated");
         AssertUtils.isTrue(authentication instanceof DefaultAuthentication,
@@ -98,7 +104,7 @@ public class InnerInlongManagerClient {
                 .build();
 
         Retrofit retrofit = new Retrofit.Builder()
-                .baseUrl("http://" + configuration.getServiceUrl() + "/api/inlong/manager/")
+                .baseUrl("http://" + host + ":" + port + "/api/inlong/manager/")
                 .addConverterFactory(JacksonConverterFactory.create(JsonUtils.OBJECT_MAPPER))
                 .client(okHttpClient)
                 .build();

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/AuthInterceptor.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/AuthInterceptor.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.service;
+
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * AuthInterceptor
+ * Before okhttp call a request, uniformly encapsulate the relevant parameters of authentication
+ */
+public class AuthInterceptor implements Interceptor {
+
+    private final String username;
+    private final String password;
+
+    public AuthInterceptor(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request oldRequest = chain.request();
+        HttpUrl.Builder builder = oldRequest.url()
+                .newBuilder()
+                .addEncodedQueryParameter("username", username)
+                .addEncodedQueryParameter("password", password);
+
+        Request newRequest = oldRequest.newBuilder()
+                .method(oldRequest.method(), oldRequest.body())
+                .url(builder.build())
+                .build();
+
+        return chain.proceed(newRequest);
+    }
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongGroupApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongGroupApi.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.service;
+
+import com.github.pagehelper.PageInfo;
+import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.pojo.group.InlongGroupInfo;
+import org.apache.inlong.manager.common.pojo.group.InlongGroupListResponse;
+import org.apache.inlong.manager.common.pojo.group.InlongGroupPageRequest;
+import org.apache.inlong.manager.common.pojo.group.InlongGroupRequest;
+import org.apache.inlong.manager.common.pojo.workflow.WorkflowResult;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+public interface InlongGroupApi {
+
+    @GET("group/exist/{id}")
+    Call<Response<Boolean>> isGroupExists(@Path("id") String id);
+
+    @GET("group/get/{id}")
+    Call<Response<InlongGroupInfo>> getGroupInfo(@Path("id") String id);
+
+    @POST("group/list")
+    Call<Response<PageInfo<InlongGroupListResponse>>> listGroups(@Body InlongGroupPageRequest request);
+
+    @POST("group/save")
+    Call<Response<String>> createGroup(@Body InlongGroupRequest request);
+
+    @POST("group/update")
+    Call<Response<String>> updateGroup(@Body InlongGroupRequest request);
+
+    @POST("group/startProcess/{id}")
+    Call<Response<WorkflowResult>> initInlongGroup(@Path("id") String id);
+
+    @POST("group/suspendProcessAsync/{id}")
+    Call<Response<String>> suspendProcessAsync(@Path("id") String id);
+
+    @POST("group/suspendProcess/{id}")
+    Call<Response<String>> suspendProcess(@Path("id") String id);
+
+    @POST("group/restartProcessAsync/{id}")
+    Call<Response<String>> restartProcessAsync(@Path("id") String id);
+
+    @POST("group/restartProcess/{id}")
+    Call<Response<String>> restartProcess(@Path("id") String id);
+
+    @DELETE("group/deleteAsync/{id}")
+    Call<Response<String>> deleteGroupAsync(@Path("id") String id);
+
+    @DELETE("group/delete/{id}")
+    Call<Response<Boolean>> deleteGroup(@Path("id") String id);
+
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongStreamApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongStreamApi.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.service;
+
+import com.github.pagehelper.PageInfo;
+import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.pojo.stream.FullStreamResponse;
+import org.apache.inlong.manager.common.pojo.stream.InlongStreamConfigLogListResponse;
+import org.apache.inlong.manager.common.pojo.stream.InlongStreamInfo;
+import org.apache.inlong.manager.common.pojo.stream.InlongStreamPageRequest;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+public interface InlongStreamApi {
+
+    @POST("stream/save")
+    Call<Response<Integer>> createStreamInfo(@Body InlongStreamInfo streamInfo);
+
+    @GET("stream/exist/{groupId}/{streamId}")
+    Call<Response<Boolean>> isStreamExists(@Path("groupId") String groupId, @Path("streamId") String streamId);
+
+    @POST("stream/update")
+    Call<Response<Boolean>> updateStreamInfo(@Body InlongStreamInfo streamInfo);
+
+    @GET("stream/get")
+    Call<Response<InlongStreamInfo>> getStreamInfo(@Query("inlongGroupId") String groupId,
+            @Query("inlongStreamId") String streamId);
+
+    @POST("stream/listAll")
+    Call<Response<PageInfo<FullStreamResponse>>> listStreamInfo(@Body InlongStreamPageRequest request);
+
+    @GET("stream/config/log/list")
+    Call<Response<PageInfo<InlongStreamConfigLogListResponse>>> getStreamLogs(@Query("inlongGroupId") String groupId,
+            @Query("inlongStreamId") String streamId);
+
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongStreamApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongStreamApi.java
@@ -33,13 +33,13 @@ import retrofit2.http.Query;
 public interface InlongStreamApi {
 
     @POST("stream/save")
-    Call<Response<Integer>> createStreamInfo(@Body InlongStreamInfo streamInfo);
+    Call<Response<Integer>> createStreamInfo(@Body InlongStreamInfo stream);
 
     @GET("stream/exist/{groupId}/{streamId}")
     Call<Response<Boolean>> isStreamExists(@Path("groupId") String groupId, @Path("streamId") String streamId);
 
     @POST("stream/update")
-    Call<Response<Boolean>> updateStreamInfo(@Body InlongStreamInfo streamInfo);
+    Call<Response<Boolean>> updateStreamInfo(@Body InlongStreamInfo stream);
 
     @GET("stream/get")
     Call<Response<InlongStreamInfo>> getStreamInfo(@Query("inlongGroupId") String groupId,

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongStreamApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongStreamApi.java
@@ -33,20 +33,20 @@ import retrofit2.http.Query;
 public interface InlongStreamApi {
 
     @POST("stream/save")
-    Call<Response<Integer>> createStreamInfo(@Body InlongStreamInfo stream);
+    Call<Response<Integer>> createStream(@Body InlongStreamInfo stream);
 
     @GET("stream/exist/{groupId}/{streamId}")
     Call<Response<Boolean>> isStreamExists(@Path("groupId") String groupId, @Path("streamId") String streamId);
 
     @POST("stream/update")
-    Call<Response<Boolean>> updateStreamInfo(@Body InlongStreamInfo stream);
+    Call<Response<Boolean>> updateStream(@Body InlongStreamInfo stream);
 
     @GET("stream/get")
-    Call<Response<InlongStreamInfo>> getStreamInfo(@Query("inlongGroupId") String groupId,
+    Call<Response<InlongStreamInfo>> getStream(@Query("inlongGroupId") String groupId,
             @Query("inlongStreamId") String streamId);
 
     @POST("stream/listAll")
-    Call<Response<PageInfo<FullStreamResponse>>> listStreamInfo(@Body InlongStreamPageRequest request);
+    Call<Response<PageInfo<FullStreamResponse>>> listStream(@Body InlongStreamPageRequest request);
 
     @GET("stream/config/log/list")
     Call<Response<PageInfo<InlongStreamConfigLogListResponse>>> getStreamLogs(@Query("inlongGroupId") String groupId,

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamSinkApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamSinkApi.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.service;
+
+import com.github.pagehelper.PageInfo;
+import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.pojo.sink.SinkListResponse;
+import org.apache.inlong.manager.common.pojo.sink.SinkRequest;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+public interface StreamSinkApi {
+
+    @POST("sink/save")
+    Call<Response<Integer>> createSink(@Body SinkRequest request);
+
+    @POST("sink/update")
+    Call<Response<Boolean>> updateSink(@Body SinkRequest request);
+
+    @DELETE("sink/delete/{id}")
+    Call<Response<Boolean>> deleteSink(@Path("id") Integer id);
+
+    @GET("sink/list")
+    Call<Response<PageInfo<SinkListResponse>>> listSinks(@Query("inlongGroupId") String groupId,
+            @Query("inlongStreamId") String streamId, @Query("sinkType") String sinkType);
+
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamSourceApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamSourceApi.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.service;
+
+import com.github.pagehelper.PageInfo;
+import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.pojo.source.SourceListResponse;
+import org.apache.inlong.manager.common.pojo.source.SourceRequest;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+public interface StreamSourceApi {
+
+    @POST("source/save")
+    Call<Response<Integer>> createSource(@Body SourceRequest request);
+
+    @POST("source/update")
+    Call<Response<Boolean>> updateSource(@Body SourceRequest request);
+
+    @GET("source/list")
+    Call<Response<PageInfo<SourceListResponse>>> listSources(@Query("inlongGroupId") String groupId,
+            @Query("inlongGroupId") String streamId, @Query("sourceType") String sourceType);
+
+    @DELETE("source/delete/{id}")
+    Call<Response<Boolean>> deleteSource(@Path("id") Integer sourceId);
+
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamSourceApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamSourceApi.java
@@ -39,7 +39,7 @@ public interface StreamSourceApi {
 
     @GET("source/list")
     Call<Response<PageInfo<SourceListResponse>>> listSources(@Query("inlongGroupId") String groupId,
-            @Query("inlongGroupId") String streamId, @Query("sourceType") String sourceType);
+            @Query("inlongStreamId") String streamId, @Query("sourceType") String sourceType);
 
     @DELETE("source/delete/{id}")
     Call<Response<Boolean>> deleteSource(@Path("id") Integer sourceId);

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamTransformApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamTransformApi.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.service;
+
+import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.pojo.transform.TransformRequest;
+import org.apache.inlong.manager.common.pojo.transform.TransformResponse;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+import java.util.List;
+
+public interface StreamTransformApi {
+
+    @POST("transform/save")
+    Call<Response<Integer>> createTransform(@Body TransformRequest request);
+
+    @GET("transform/list")
+    Call<Response<List<TransformResponse>>> listTransform(@Path("inlongGroupId") String groupId,
+            @Path("inlongStreamId") String streamId);
+
+    @POST("transform/update")
+    Call<Response<Boolean>> updateTransform(@Body TransformRequest request);
+
+    @DELETE("transform/delete")
+    Call<Response<Boolean>> deleteTransform(@Path("inlongGroupId") String groupId,
+            @Path("inlongStreamId") String streamId, @Path("transformName") String transformName);
+
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/WorkflowApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/WorkflowApi.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.service;
+
+import com.github.pagehelper.PageInfo;
+import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.pojo.workflow.EventLogView;
+import org.apache.inlong.manager.common.pojo.workflow.WorkflowResult;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.Headers;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+import java.util.Map;
+
+public interface WorkflowApi {
+
+    @Headers("Content-Type: application/json")
+    @POST("workflow/approve/{taskId}")
+    Call<Response<WorkflowResult>> startInlongGroup(@Path("taskId") Integer taskId, @Body Map<String, Object> request);
+
+    @GET("workflow/event/list")
+    Call<Response<PageInfo<EventLogView>>> getInlongGroupError(@Query("inlongGroupId") String groupId,
+            @Query("status") Integer status);
+
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/util/JsonUtils.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/util/JsonUtils.java
@@ -46,7 +46,7 @@ import java.util.Set;
 public class JsonUtils {
 
     public static final String PROJECT_PACKAGE = "org.apache.inlong.manager.common.pojo";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     static {
         OBJECT_MAPPER.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);

--- a/licenses/inlong-manager/LICENSE
+++ b/licenses/inlong-manager/LICENSE
@@ -671,6 +671,8 @@ The text of each license is the standard Apache 2.0 license.
   io.netty:netty-tcnative-classes:2.0.46.Final - Netty/TomcatNative [OpenSSL - Classes] (https://github.com/netty/netty-tcnative/tree/netty-tcnative-parent-2.0.46.Final), (Apache 2.0)
   com.nimbusds:nimbus-jose-jwt:7.9 - Nimbus JOSE+JWT (https://bitbucket.org/connect2id/nimbus-jose-jwt), (The Apache Software License, Version 2.0)
   org.objenesis:objenesis:3.2 - Objenesis (http://objenesis.org/objenesis), (Apache License, Version 2.0)
+  com.squareup.retrofit2:converter-jackson:2.9.0 - Retrofit (https://github.com/square/retrofit) (Apache License, Version 2.0)
+  com.squareup.retrofit2:retrofit:2.9.0 - Retrofit (https://github.com/square/retrofit) (Apache License, Version 2.0)
   com.squareup.okhttp:okhttp:2.7.5 - OkHttp (https://github.com/square/okhttp/tree/parent-2.7.5/okhttp), (Apache 2.0)
   com.squareup.okhttp3:okhttp:3.14.9 - OkHttp (https://github.com/square/okhttp/tree/parent-3.14.9/okhttp), (Apache 2.0)
   com.squareup.okio:okio:1.17.2 - Okio (https://github.com/square/okio/tree/okio-parent-1.17.2/okio), (Apache 2.0)

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
         <httpcore.version>4.4.14</httpcore.version>
         <httpclient.version>4.5.13</httpclient.version>
         <okhttp.version>3.14.9</okhttp.version>
+        <retrofit.version>2.9.0</retrofit.version>
 
         <spring.boot.version>2.6.6</spring.boot.version>
         <spring.version>5.3.20</spring.version>
@@ -816,7 +817,11 @@
                 <artifactId>okhttp</artifactId>
                 <version>${okhttp.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>com.squareup.retrofit2</groupId>
+                <artifactId>converter-jackson</artifactId>
+                <version>${retrofit.version}</version>
+            </dependency>
             <!-- elastic search -->
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>


### PR DESCRIPTION

### Prepare a Pull Request

- Fixes #4674 

### Motivation

The previous implementation of the client is not particularly good
1. The authentication information of the user's login is spliced ​​in the path each time
2. Param and PathVariable are manually spliced ​​together, and the scalability is not good
3. All the request methods for connecting to the web are all in one class
4. The previous execution of the http request package is not concise enough

### Modifications

1. The processing of authentication information is placed in the interceptor, and then if the authentication information is replaced by a header, it only needs to be modified here
2. The method of client requesting web controller is divided according to business, corresponding to the web aspect, which is convenient for maintenance and search
3. Use declarative annotations to simplify development and maintenance

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is already covered by existing tests, such as:
  - Kafka2HiveExample
  - InnerInlongManagerClientTest

